### PR TITLE
ci/web: run Playwright e2e suite on every PR

### DIFF
--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -16,6 +16,11 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: "${{ !startsWith(github.ref, 'refs/heads/version-') && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/next' }}"
 
+env:
+  POSTGRES_DB: authentik
+  POSTGRES_USER: authentik
+  POSTGRES_PASSWORD: "EK-5jnKfjrGRm<77"
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -73,6 +78,270 @@ jobs:
           NODE_ENV: "production"
         working-directory: web/
         run: pnpm run build
+  e2e:
+    name: e2e (playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      # Required so the "Comment Playwright result on PR" step can update its
+      # marker comment via the gh CLI / REST API.
+      pull-requests: write
+      # Required so the optional "Upload HTML report to S3" step can mint OIDC
+      # credentials with aws-actions/configure-aws-credentials. Harmless when
+      # the upload is gated off.
+      id-token: write
+    env:
+      # Drives blueprints/system/bootstrap.yaml at startup: creates akadmin with
+      # these credentials, which are the ones SessionFixture logs in with. Without
+      # them the bootstrap blueprint leaves the user without a usable password and
+      # the root URL bounces through /setup.
+      AUTHENTIK_BOOTSTRAP_EMAIL: "test-admin@goauthentik.io"
+      AUTHENTIK_BOOTSTRAP_PASSWORD: "test-runner"
+      # The embedded outpost wants to reconcile against Docker/Kubernetes, which
+      # isn't available here and only produces noise in the logs.
+      AUTHENTIK_OUTPOSTS__DISABLE_EMBEDDED_OUTPOST: "true"
+      # Both default to the container layout (`/blueprints`, `/certs`), which does
+      # not exist in a source checkout. Without these the bootstrap blueprint
+      # cannot be read, gunicorn's workers fail to boot, and :9000 never opens —
+      # the readiness gate then just times out with nothing useful on stdout.
+      AUTHENTIK_BLUEPRINTS_DIR: "./blueprints"
+      AUTHENTIK_CERT_DISCOVERY_DIR: "./certs"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+      - name: Setup authentik env
+        uses: ./.github/actions/setup
+        with:
+          dependencies: system,python,node,rust,runtime
+      # The web build has to run before cargo: src/server/core.rs embeds
+      # web/dist/standalone/loading/startup.html with include_str!, so the Rust
+      # build fails to compile without it.
+      - name: Build web UI
+        env:
+          NODE_ENV: "production"
+        run: pnpm --dir web run build
+      - name: Build authentik
+        run: |
+          cargo build --release
+          sudo install -m 0755 ./target/release/authentik /usr/local/bin/authentik
+      - name: Apply migrations
+        run: uv run python -m lifecycle.migrate
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: web
+        run: | # shell
+          version=$(node -p "require('@playwright/test/package.json').version")
+          if [ -z "$version" ]; then
+            echo "Failed to resolve @playwright/test version" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+      - name: Install Playwright browsers
+        working-directory: web
+        run: | # shell
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            pnpm exec playwright install-deps chromium
+          else
+            pnpm exec playwright install --with-deps chromium
+          fi
+      # `ak allinone` runs the server and the worker in a single process, so
+      # there is only one listener on :9000 and no need to shuffle the worker's
+      # HTTP/metrics ports out of the way.
+      - name: Start authentik
+        run: | # shell
+          set -euo pipefail
+          mkdir -p /tmp/ak-logs
+          # The certificate discovery watcher inotify-watches this directory and
+          # raises if it is absent; a checkout has no `certs/`.
+          mkdir -p certs
+          uv run ak allinone > /tmp/ak-logs/authentik.log 2>&1 &
+          echo $! > /tmp/ak-logs/authentik.pid
+      - name: Wait for authentik to be ready
+        run: | # shell
+          set -uo pipefail
+          pid="$(cat /tmp/ak-logs/authentik.pid)"
+
+          # Poll until the URL answers, giving up when the deadline passes or the
+          # server process is gone. The liveness check matters: without it a boot
+          # failure is indistinguishable from a slow start and burns the whole
+          # timeout emitting connection-refused, with the real cause only in the
+          # uploaded log.
+          await() {
+            local url="$1"
+            local deadline=$(( SECONDS + $2 ))
+
+            until curl -fsS -o /dev/null "$url"; do
+              if ! kill -0 "$pid" 2>/dev/null; then
+                echo "authentik exited before ${url} became ready" >&2
+                return 1
+              fi
+              if (( SECONDS >= deadline )); then
+                echo "timed out after $2s waiting for ${url}" >&2
+                return 1
+              fi
+              sleep 2
+            done
+          }
+
+          # Readiness only covers the HTTP listener and the database. The default
+          # flows the tests drive arrive later, when the worker finishes applying
+          # blueprints/default/, so gate on the flow executor actually resolving
+          # `default-authentication-flow` rather than on the SPA shell rendering
+          # (which it does regardless of whether the flow exists).
+          if await "http://localhost:9000/-/health/ready/" 240 \
+            && await "http://localhost:9000/api/v3/flows/executor/default-authentication-flow/?query=" 300; then
+            exit 0
+          fi
+
+          echo "::group::authentik.log (last 200 lines)"
+          tail -n 200 /tmp/ak-logs/authentik.log || true
+          echo "::endgroup::"
+          exit 1
+      - name: Run Playwright tests
+        working-directory: web
+        env:
+          AK_TEST_RUNNER_PAGE_URL: http://localhost:9000
+        run: pnpm run test:e2e
+      # Reporting / upload steps below intentionally use `!cancelled()` rather
+      # than `failure()`: a cancelled run (e.g. superseded by a newer push) is
+      # not a real result and shouldn't produce reviewer-facing artifacts or
+      # comments. `if-no-files-found: ignore` keeps the "passed" case quiet.
+      - name: Upload Playwright HTML report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 14
+          if-no-files-found: ignore
+      - name: Upload Playwright traces and videos
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-traces
+          path: web/test-results/
+          retention-days: 14
+          if-no-files-found: ignore
+      - name: Upload authentik logs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: authentik-logs
+          path: /tmp/ak-logs/
+          retention-days: 14
+          if-no-files-found: ignore
+      - name: Parse Playwright results
+        id: playwright-results
+        if: ${{ !cancelled() }}
+        run: | # shell
+          set -euo pipefail
+          report=web/playwright-report/results.json
+          if [ ! -f "$report" ]; then
+            {
+              echo "available=false"
+              echo "passed=0"
+              echo "failed=0"
+              echo "flaky=0"
+              echo "skipped=0"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "available=true"
+            echo "passed=$(jq -r '.stats.expected // 0' "$report")"
+            echo "failed=$(jq -r '.stats.unexpected // 0' "$report")"
+            echo "flaky=$(jq -r '.stats.flaky // 0' "$report")"
+            echo "skipped=$(jq -r '.stats.skipped // 0' "$report")"
+          } >> "$GITHUB_OUTPUT"
+      # The S3 publishing pair below is intentionally gated off until the
+      # `authentik-playwright-artifacts` bucket is provisioned by infra. Flip
+      # the repo variable `PLAYWRIGHT_S3_ENABLED=true` to turn it on; the URL
+      # baked into the PR comment below already points at the eventual key.
+      - name: Configure AWS credentials for HTML report upload
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && vars.PLAYWRIGHT_S3_ENABLED == 'true' }}
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: "arn:aws:iam::016170277896:role/github_goauthentik_authentik"
+          aws-region: eu-central-1
+      - name: Upload HTML report to S3
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && vars.PLAYWRIGHT_S3_ENABLED == 'true' }}
+        env:
+          S3_BUCKET: authentik-playwright-artifacts
+          S3_KEY_PREFIX: pr-${{ github.event.pull_request.number }}/run-${{ github.run_id }}/attempt-${{ github.run_attempt }}
+        run: | # shell
+          set -euo pipefail
+          if [ ! -d web/playwright-report ]; then
+            echo "No playwright-report/ produced; skipping S3 upload"
+            exit 0
+          fi
+          # Reports are stamped with run_id + attempt in S3_KEY_PREFIX, so a given
+          # key is immutable once written — safe to cache aggressively. 30 days
+          # matches the retention-days on the GHA artifact upload above.
+          aws s3 cp \
+            --recursive \
+            --acl=public-read \
+            --cache-control "public, max-age=2592000, immutable" \
+            web/playwright-report/ \
+            "s3://${S3_BUCKET}/${S3_KEY_PREFIX}/"
+      # Same-repo guard: fork PRs run with a read-only GITHUB_TOKEN (even after
+      # maintainer approval), so the comment + edit calls would 403. Skip cleanly
+      # rather than failing the job on every fork PR run.
+      - name: Comment Playwright result on PR
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          AVAILABLE: ${{ steps.playwright-results.outputs.available }}
+          PASSED: ${{ steps.playwright-results.outputs.passed }}
+          FAILED: ${{ steps.playwright-results.outputs.failed }}
+          FLAKY: ${{ steps.playwright-results.outputs.flaky }}
+          SKIPPED: ${{ steps.playwright-results.outputs.skipped }}
+          S3_ENABLED: ${{ vars.PLAYWRIGHT_S3_ENABLED }}
+          REPORT_URL: https://authentik-playwright-artifacts.s3.amazonaws.com/pr-${{ github.event.pull_request.number }}/run-${{ github.run_id }}/attempt-${{ github.run_attempt }}/index.html
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        run: | # shell
+          set -euo pipefail
+          marker='<!-- playwright-result -->'
+
+          if [ "$AVAILABLE" = "true" ]; then
+            if [ "$FAILED" -gt 0 ]; then
+              status='❌ Failed'
+            elif [ "$FLAKY" -gt 0 ]; then
+              status='⚠️ Passed with flakes'
+            else
+              status='✅ Passed'
+            fi
+            stats=$(printf '| Result | Count |\n|---|---|\n| ✅ Passed | %s |\n| ❌ Failed | %s |\n| ⚠️ Flaky | %s |\n| ⏭️ Skipped | %s |\n' "$PASSED" "$FAILED" "$FLAKY" "$SKIPPED")
+          else
+            status='⚠️ No results produced'
+            stats='The job did not produce `playwright-report/results.json`. The suite likely crashed before the JSON reporter wrote its output — see the workflow run for setup-step failures.'
+          fi
+
+          if [ "$S3_ENABLED" = "true" ]; then
+            report_line=$(printf '[HTML report](%s) · [Workflow run](%s)' "$REPORT_URL" "$RUN_URL")
+          else
+            report_line=$(printf '[Workflow run](%s) · _HTML report hosting is gated off until the `authentik-playwright-artifacts` S3 bucket is provisioned (`vars.PLAYWRIGHT_S3_ENABLED`). Until then, download the `playwright-report` artifact from the run page._' "$RUN_URL")
+          fi
+
+          body=$(printf '%s\n## Playwright e2e — %s\n\n%s\n\n%s\n' "$marker" "$status" "$stats" "$report_line")
+
+          existing=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq "[.[] | select(.body != null and (.body | startswith(\"$marker\")))] | .[0].id // empty")
+
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" -f body="$body" > /dev/null
+            echo "Updated existing comment ${existing}"
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$body" > /dev/null
+            echo "Created new playwright-result comment"
+          fi
   ci-web-mark:
     if: always()
     needs:

--- a/web/e2e/fixtures/NavigatorFixture.ts
+++ b/web/e2e/fixtures/NavigatorFixture.ts
@@ -39,6 +39,31 @@ export class NavigatorFixture extends PageFixture {
     };
 
     /**
+     * Wait for the current page to navigate away from the given pathname.
+     *
+     * Use this when the destination isn't known ahead of time, such as a login whose
+     * post-submit redirect lands on whichever interface the user defaults to. Waiting
+     * on a known pathname would match the page we're already on and resolve before the
+     * navigation lands.
+     *
+     * @see {@linkcode waitForPathname} when the destination is known.
+     *
+     * @param from The pathname or URL to wait for the page to leave.
+     */
+    public waitForPathnameChange = async (
+        from: string | URL,
+        options?: Parameters<Page["waitForURL"]>[1],
+    ): Promise<void> => {
+        const currentPathname = typeof from === "string" ? from : from.pathname;
+
+        this.logger.info(`Waiting for URL to change away from ${currentPathname}`);
+
+        await this.page.waitForURL((url) => url.pathname !== currentPathname, options);
+
+        this.logger.info(`URL changed to ${this.page.url()}`);
+    };
+
+    /**
      * Navigate to the given URL or pathname, and wait for the navigation to complete.
      */
     public navigate = async (to: URL | string | null | undefined): Promise<void> => {

--- a/web/e2e/fixtures/SessionFixture.ts
+++ b/web/e2e/fixtures/SessionFixture.ts
@@ -78,12 +78,7 @@ export class SessionFixture extends PageFixture {
      * Log into the application.
      */
     public async login(
-        {
-            username = GOOD_USERNAME,
-            password = GOOD_PASSWORD,
-            to = SessionFixture.pathname,
-            rememberMe,
-        }: LoginInit = {},
+        { username = GOOD_USERNAME, password = GOOD_PASSWORD, to, rememberMe }: LoginInit = {},
         page = this.page,
     ): Promise<void> {
         this.logger.info("Logging in...");
@@ -93,7 +88,9 @@ export class SessionFixture extends PageFixture {
         if (initialURL.pathname === SessionFixture.pathname) {
             this.logger.info("Skipping navigation because we're already in a authentication flow");
         } else {
-            await page.goto(to.toString());
+            // Navigating to `to` while unauthenticated bounces through the flow with
+            // `?next=`, so the post-login redirect lands on the destination.
+            await page.goto((to ?? SessionFixture.pathname).toString());
         }
 
         if (typeof rememberMe === "boolean") {
@@ -132,7 +129,25 @@ export class SessionFixture extends PageFixture {
 
         await this.$submitButton.click();
 
-        await this.navigator.waitForPathname(to);
+        if (to) {
+            await this.navigator.waitForPathname(to);
+
+            return;
+        }
+
+        // With no destination the redirect lands on whichever interface the user
+        // defaults to, which the caller doesn't know. Waiting on the flow pathname
+        // would match the page we're already on and return before the redirect
+        // lands, leaving the next step to run against the login screen.
+        //
+        // Raced against the failure alert so callers that log in with bad credentials
+        // on purpose return here instead of waiting out the test timeout. Both sides
+        // swallow their own timeout: whichever settles first is the outcome, and the
+        // caller asserts on it.
+        await Promise.race([
+            this.navigator.waitForPathnameChange(SessionFixture.pathname).catch(() => undefined),
+            this.$authFailureMessage.waitFor({ state: "visible" }).catch(() => undefined),
+        ]);
     }
 
     //#endregion

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -24,7 +24,13 @@ export default defineConfig({
     fullyParallel: true,
     forbidOnly: CI,
     retries: CI ? 1 : 0,
-    workers: "50%",
+    // Serial in CI. Every test drives the same authentik instance and the same database,
+    // and several of them mutate `akadmin` — the groups and users suites both edit its
+    // group membership — so concurrent workers contend for the same records on top of
+    // competing for one server. Locally that mostly shows up as slowness; in CI it showed
+    // up as timeouts and missing rows that pass on their own. The full suite runs in about
+    // three minutes serially.
+    workers: CI ? 1 : "50%",
     // Every action here is a round trip to a real authentik instance that the other
     // workers are hitting too — creating an entity is a POST plus a table refresh, not a
     // local state change. Playwright's 5s assertion default is written for in-process UI

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -24,13 +24,7 @@ export default defineConfig({
     fullyParallel: true,
     forbidOnly: CI,
     retries: CI ? 1 : 0,
-    // Serial in CI. Every test drives the same authentik instance and the same database,
-    // and several of them mutate `akadmin` — the groups and users suites both edit its
-    // group membership — so concurrent workers contend for the same records on top of
-    // competing for one server. Locally that mostly shows up as slowness; in CI it showed
-    // up as timeouts and missing rows that pass on their own. The full suite runs in about
-    // three minutes serially.
-    workers: CI ? 1 : "50%",
+    workers: "50%",
     // Every action here is a round trip to a real authentik instance that the other
     // workers are hitting too — creating an entity is a POST plus a table refresh, not a
     // local state change. Playwright's 5s assertion default is written for in-process UI

--- a/web/src/user/LibraryPage/ak-library-impl.browser.test.ts
+++ b/web/src/user/LibraryPage/ak-library-impl.browser.test.ts
@@ -1,0 +1,71 @@
+import "#user/LibraryPage/ak-library-impl";
+
+import { type Application } from "@goauthentik/api";
+
+import { describe, expect, it } from "vitest";
+
+function app(name: string, pk: string): Application {
+    return {
+        pk,
+        name,
+        slug: name.toLowerCase(),
+        launchUrl: `https://example.com/${name}`,
+    } as Application;
+}
+
+/**
+ * Mount the library with a fixed set of applications and return the search input.
+ */
+async function mount(apps: Application[]) {
+    document.body.replaceChildren();
+
+    const element = document.createElement("ak-library-impl");
+    element.apps = apps;
+    document.body.append(element);
+
+    await element.updateComplete;
+
+    const input = element.renderRoot.querySelector<HTMLInputElement>("#application-search-input");
+
+    if (!input) throw new Error("Search input never rendered");
+
+    return { element, input };
+}
+
+describe("ak-library-impl single-match auto-launch", () => {
+    it("launches the single match when a search is committed from empty", async () => {
+        // Two apps so the query has to narrow to one. The search starts empty,
+        // which is what makes this the regression case: no row carries
+        // `targetRef` until a query exists.
+        const { element, input } = await mount([app("alpha", "pk-alpha"), app("zulu", "pk-zulu")]);
+
+        // Patch the prototype rather than listening on the shadow root: a stale
+        // `targetRef` can point at an element Lit has already detached, and a
+        // click on a detached node reaches no ancestor listener.
+        const clicked: string[] = [];
+        const originalClick = HTMLElement.prototype.click;
+
+        HTMLElement.prototype.click = function patched(this: HTMLElement) {
+            const href = this.getAttribute("href") || this.tagName;
+
+            clicked.push(`${href}${this.isConnected ? "" : " (detached)"}`);
+        };
+
+        input.value = "zulu";
+
+        // `input` then `change` within a single task, which is what a real
+        // keystroke-then-commit produces. Lit's re-render is scheduled on a
+        // microtask, so it has not run when `change` is handled.
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+
+        // The launch is deferred to the render that binds the ref, so settle both.
+        await element.updateComplete;
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+
+        HTMLElement.prototype.click = originalClick;
+
+        expect(clicked, "Auto-launch fires for the single visible match").toHaveLength(1);
+        expect(clicked[0], "Auto-launch targets the filtered application").toContain("zulu");
+    });
+});

--- a/web/src/user/LibraryPage/ak-library-impl.ts
+++ b/web/src/user/LibraryPage/ak-library-impl.ts
@@ -296,23 +296,37 @@ export class LibraryPage extends WithSession(AKElement) {
         this.query = inputElement.value;
     };
 
+    /**
+     * Open the row `targetRef` points at, once the render that binds it has run.
+     *
+     * `selectedApp` is null while the query is empty, so no row carries the ref
+     * until a query exists. Committing a search from empty dispatches `input`
+     * and `change` in the same task: the query setter has narrowed
+     * `visibleApplications` synchronously, but Lit's re-render — and with it the
+     * ref binding — is still pending. Reading `targetRef` before awaiting would
+     * find the previous render's element, or nothing at all on a first search.
+     */
+    async #openSelected(): Promise<void> {
+        await this.updateComplete;
+
+        const target = this.targetRef.value;
+
+        if (!target) return;
+
+        target.focus();
+        target.click();
+    }
+
     #changeListener = () => {
-        if (this.targetRef.value && this.visibleApplications.length === 1) {
-            this.targetRef.value.focus();
-            this.targetRef.value.click();
-            return;
-        }
+        if (this.visibleApplications.length !== 1) return;
+
+        this.#openSelected();
     };
 
     #submitListener = (event: SubmitEvent) => {
         event.preventDefault();
 
-        if (this.targetRef.value) {
-            this.targetRef.value.focus();
-            this.targetRef.value.click();
-
-            return;
-        }
+        this.#openSelected();
     };
 
     #rootKeyDownListener = (event: KeyboardEvent) => {

--- a/web/test/browser/100-session.test.ts
+++ b/web/test/browser/100-session.test.ts
@@ -18,9 +18,7 @@ test.describe("Session management", () => {
             page.getByRole("heading", {
                 level: 1,
             }),
-        ).toHaveText("Application Dashboard", {
-            timeout: 10_000,
-        });
+        ).toHaveText("Application Dashboard");
     });
 
     test("Reject bad username", async ({ session }) => {

--- a/web/test/browser/101-session-lifecycle.test.ts
+++ b/web/test/browser/101-session-lifecycle.test.ts
@@ -1,50 +1,15 @@
 import { expect, test } from "#e2e";
-import { FormFixture } from "#e2e/fixtures/FormFixture";
-import { NavigatorFixture } from "#e2e/fixtures/NavigatorFixture";
-import { GOOD_USERNAME, SessionFixture } from "#e2e/fixtures/SessionFixture";
+import { GOOD_USERNAME } from "#e2e/fixtures/SessionFixture";
 
 import type { Page } from "@playwright/test";
 
 const REMEMBER_ME_USER_KEY = "authentik-remember-me-user";
 const REMEMBER_ME_SESSION_KEY = "authentik-remember-me-session";
 
-const IDENTIFICATION_STAGE_NAME = "default-authentication-identification";
-
 const readStoredUserIdentifier = (page: Page) =>
     page.evaluate((k) => localStorage.getItem(k), REMEMBER_ME_USER_KEY);
 
 test.describe("Session Lifecycle", () => {
-    test.beforeAll(
-        'Ensure "Enable Remember me on this device" is on for the default identification stage',
-        async ({ browser }, { title: testName }) => {
-            const context = await browser.newContext();
-            const page = await context.newPage();
-            const navigator = new NavigatorFixture(page, testName);
-            const form = new FormFixture(page, testName);
-            const session = new SessionFixture({ page, testName, navigator });
-
-            await test.step("Authenticate", async () =>
-                session.login({
-                    to: "/if/admin/flow/stages",
-                    page,
-                }));
-
-            const $stage = await test.step("Find stage via search", () =>
-                form.search(IDENTIFICATION_STAGE_NAME, page));
-
-            await $stage.getByRole("button", { name: "Edit Stage" }).click();
-
-            const dialog = page.getByRole("dialog", { name: "Edit Identification Stage" });
-            await expect(dialog, "Edit modal opens after clicking edit").toBeVisible();
-
-            await form.setInputCheck(`Enable "Remember me on this device"`, true, dialog);
-            await dialog.getByRole("button", { name: "Save Changes" }).click();
-            await expect(dialog, "Edit modal closes after save").toBeHidden();
-
-            await context.close();
-        },
-    );
-
     test.beforeEach(async ({ session, page }) => {
         await session.toLoginPage();
 
@@ -61,11 +26,6 @@ test.describe("Session Lifecycle", () => {
     });
 
     test("Remember me persists username", async ({ navigator, session, page }) => {
-        // This one walks the whole loop — sign in with remember-me, sign out, and come
-        // back to a pre-filled form — so it pays the flow executor's startup cost twice
-        // and doesn't fit the default budget.
-        test.setTimeout(60_000);
-
         await test.step("Verify identification stage", async () => {
             await expect(
                 session.$rememberMeCheckbox,

--- a/web/test/browser/101-session-lifecycle.test.ts
+++ b/web/test/browser/101-session-lifecycle.test.ts
@@ -61,6 +61,11 @@ test.describe("Session Lifecycle", () => {
     });
 
     test("Remember me persists username", async ({ navigator, session, page }) => {
+        // This one walks the whole loop — sign in with remember-me, sign out, and come
+        // back to a pre-filled form — so it pays the flow executor's startup cost twice
+        // and doesn't fit the default budget.
+        test.setTimeout(60_000);
+
         await test.step("Verify identification stage", async () => {
             await expect(
                 session.$rememberMeCheckbox,

--- a/web/test/browser/300-users.test.ts
+++ b/web/test/browser/300-users.test.ts
@@ -167,7 +167,7 @@ test.describe("Impersonation", () => {
 
             await createDialog.getByRole("button", { name: "Create" }).click();
 
-            await createDialog.waitFor({ state: "hidden", timeout: 10_000 });
+            await createDialog.waitFor({ state: "hidden" });
             await expect(createDialog, "Create dialog closes").toBeHidden();
         });
 
@@ -188,9 +188,7 @@ test.describe("Impersonation", () => {
 
             await impersonateDialog.getByRole("button", { name: "Impersonate" }).click();
 
-            await navigator.waitForPathname("/if/user/library", {
-                timeout: 10_000,
-            });
+            await navigator.waitForPathname("/if/user/library");
         });
 
         await test.step("Confirm impersonation", async () => {

--- a/web/test/browser/400-groups.test.ts
+++ b/web/test/browser/400-groups.test.ts
@@ -1,15 +1,62 @@
 import { expect, test } from "#e2e";
+import type { FormFixture } from "#e2e/fixtures/FormFixture";
+import type { NavigatorFixture } from "#e2e/fixtures/NavigatorFixture";
+import type { PointerFixture } from "#e2e/fixtures/PointerFixture";
 import { randomName } from "#e2e/utils/generators";
 
 import { IDGenerator } from "@goauthentik/core/id";
 import { series } from "@goauthentik/core/promises";
 
+import type { Page } from "@playwright/test";
 import { snakeCase } from "change-case";
 
+interface CreateUserContext {
+    navigator: NavigatorFixture;
+    form: FormFixture;
+    pointer: PointerFixture;
+    page: Page;
+}
+
+/**
+ * Create an internal user through the admin UI and leave the browser on the users list.
+ *
+ * Both tests below need a user they own: they assert on a group's member list or on a
+ * user's related group list, and reaching for `akadmin` makes them read shared state that
+ * every other worker — and every previous run — has been writing to.
+ */
+async function createInternalUser(
+    { navigator, form, pointer, page }: CreateUserContext,
+    username: string,
+    displayName: string,
+): Promise<void> {
+    const { fill } = form;
+    const { click } = pointer;
+
+    await navigator.navigate("/if/admin/identity/users");
+
+    const dialog = page.getByRole("dialog", { name: "New User Wizard" });
+
+    await click("New User", "button");
+
+    await expect(dialog, "User wizard opens").toBeVisible();
+
+    await dialog.getByRole("radio", { name: "Internal" }).click({ force: true });
+
+    await series(
+        [fill, /^Username/, username, dialog],
+        [fill, /^Display Name/, displayName, dialog],
+        [fill, /^Email Address/, `${username}@example.com`, dialog],
+        [fill, /^Path/, "users", dialog],
+    );
+
+    await dialog.getByRole("button", { name: "Create" }).click();
+
+    await expect(dialog, "User wizard closes after creation").toBeHidden();
+}
+
 test.describe("Groups", () => {
-    const adminGroupName = "authentik Admins";
-    const adminUsername = "akadmin";
     const usernames = new Map<string, string>();
+    const userDisplayNames = new Map<string, string>();
     const groupNames = new Map<string, string>();
 
     //#region Lifecycle
@@ -20,6 +67,9 @@ test.describe("Groups", () => {
 
         groupNames.set(testId, groupName);
         usernames.set(testId, snakeCase(groupName));
+        // Deliberately unlike the group name: tests below assert on a group link by
+        // accessible name, and a user sharing that name would match it too.
+        userDisplayNames.set(testId, `Member ${randomName(seed)} (${seed})`);
 
         await test.step("Authenticate", async () => {
             await session.login({
@@ -32,32 +82,47 @@ test.describe("Groups", () => {
 
     //#region Tests
 
-    test("Creating a user within the admin group", async ({
-        navigator,
-        form,
-        pointer,
-        page,
-    }, testInfo) => {
+    test("Creating a user within a group", async ({ navigator, form, pointer, page }, testInfo) => {
         const { fill, search } = form;
         const { click } = pointer;
 
-        const displayName = groupNames.get(testInfo.testId)!;
+        const groupName = groupNames.get(testInfo.testId)!;
+        const displayName = userDisplayNames.get(testInfo.testId)!;
         const username = usernames.get(testInfo.testId)!;
 
-        const adminsURL = await test.step("Find admin group via search", async () => {
-            const $adminGroupRow = await search(adminGroupName);
+        // A group of our own rather than "authentik Admins". The mechanic under test is
+        // creating a user from inside a group's Users tab, which doesn't care which group
+        // it is — and every worker writing members into the one shared superuser group
+        // both couples the tests together and quietly grants those users superuser.
+        await test.step("Create the group", async () => {
+            const newGroupDialog = page.getByRole("dialog", { name: "New Group" });
 
-            await expect($adminGroupRow, "Admin group is visible").toBeVisible();
+            await click("New Group", "button");
 
-            const groupLink = $adminGroupRow.getByRole("link", { name: "view details" });
-            await expect(groupLink, "Admin group link is visible").toBeVisible();
+            await expect(newGroupDialog, "Dialog opens").toBeVisible();
+
+            await fill(/^Group Name/, groupName, newGroupDialog);
+
+            await newGroupDialog.getByRole("button", { name: "Create Group" }).click();
+
+            await expect(newGroupDialog, "Dialog closes").toBeHidden();
+        });
+
+        const groupURL = await test.step("Find the group via search", async () => {
+            const $groupRow = await search(groupName);
+
+            await expect($groupRow, "Group is visible").toBeVisible();
+
+            const groupLink = $groupRow.getByRole("link", { name: "view details" });
+
+            await expect(groupLink, "Group link is visible").toBeVisible();
 
             return groupLink.evaluate((el: HTMLAnchorElement) => el.href);
         });
 
-        expect(adminsURL, "Admin group link has href").not.toBeNull();
+        expect(groupURL, "Group link has href").not.toBeNull();
 
-        await navigator.navigate(adminsURL);
+        await navigator.navigate(groupURL);
 
         await test.step("User creation", async () => {
             await click("Users", "tab");
@@ -96,13 +161,20 @@ test.describe("Groups", () => {
         });
     });
 
-    test("Simple group", async ({ form, pointer, page }, testInfo) => {
+    test("Simple group", async ({ navigator, form, pointer, page }, testInfo) => {
         const groupName = groupNames.get(testInfo.testId)!;
+        const username = usernames.get(testInfo.testId)!;
+        const userDisplayName = userDisplayNames.get(testInfo.testId)!;
 
         const { fill, search } = form;
         const { click } = pointer;
 
         const dialog = page.getByRole("dialog", { name: "New Group" });
+
+        await test.step("Create a user to assign", () =>
+            createInternalUser({ navigator, form, pointer, page }, username, userDisplayName));
+
+        await test.step("Return to groups", () => navigator.navigate("/if/admin/identity/groups"));
 
         await test.step("Group Creation", async () => {
             await expect(dialog, "Dialog is initially closed").toBeHidden();
@@ -121,9 +193,7 @@ test.describe("Groups", () => {
             await expect(createButton, "Create button is visible").toBeVisible();
             await createButton.click();
 
-            await expect(dialog, "Dialog closes after creating group").toBeHidden({
-                timeout: 10_000,
-            });
+            await expect(dialog, "Dialog closes after creating group").toBeHidden();
         });
 
         await test.step("Verify group creation", async () => {
@@ -145,12 +215,12 @@ test.describe("Groups", () => {
                 [click, "Open user selection dialog", "button"],
             );
 
-            const adminRow = await test.step("Find admin via search", () =>
-                search(adminUsername, selectUsersModal));
+            const userRow = await test.step("Find the user via search", () =>
+                search(username, selectUsersModal));
 
-            await expect(adminRow, "Admin is visible").toBeVisible();
+            await expect(userRow, "User is visible").toBeVisible();
 
-            await adminRow.getByRole("checkbox").check();
+            await userRow.getByRole("checkbox").check();
 
             const confirmButton = selectUsersModal.getByRole("button", { name: "Confirm" });
 
@@ -162,19 +232,17 @@ test.describe("Groups", () => {
             await expect(assignButton, "Assign button is visible").toBeVisible();
             await assignButton.click();
 
-            await expect(assignUsersModal, "Assign users modal closes").toBeHidden({
-                timeout: 10_000,
-            });
+            await expect(assignUsersModal, "Assign users modal closes").toBeHidden();
 
-            await test.step("Verify admin user assignment", async () => {
+            await test.step("Verify user assignment", async () => {
                 // eslint-disable-next-line max-nested-callbacks
-                const groupRow = await test.step("Find group via search", () => {
+                const memberRow = await test.step("Find member via search", () => {
                     const context = page.getByRole("tabpanel", { name: "Users" });
 
-                    return search(adminUsername, context);
+                    return search(username, context);
                 });
 
-                await expect(groupRow, "Group is visible").toBeVisible();
+                await expect(memberRow, "User is a member of the group").toBeVisible();
             });
         });
     });
@@ -197,9 +265,7 @@ test.describe("Groups", () => {
 
             await newGroupDialog.getByRole("button", { name: "Create Group" }).click();
 
-            await expect(newGroupDialog, "Dialog closes after creating group").toBeHidden({
-                timeout: 10_000,
-            });
+            await expect(newGroupDialog, "Dialog closes after creating group").toBeHidden();
         });
 
         await test.step("Navigate to group view page", async () => {
@@ -249,13 +315,15 @@ test.describe("Groups", () => {
         page,
     }, testInfo) => {
         const groupName = groupNames.get(testInfo.testId)!;
+        const username = usernames.get(testInfo.testId)!;
+        const userDisplayName = userDisplayNames.get(testInfo.testId)!;
 
         const { fill, search } = form;
         const { click } = pointer;
 
         const newGroupDialog = page.getByRole("dialog", { name: "New Group" });
 
-        await test.step("Create group with admin user", async () => {
+        await test.step("Create the group", async () => {
             await click("New Group", "button");
 
             await expect(newGroupDialog, "Dialog opens").toBeVisible();
@@ -264,19 +332,21 @@ test.describe("Groups", () => {
 
             await newGroupDialog.getByRole("button", { name: "Create Group" }).click();
 
-            await expect(newGroupDialog, "Dialog closes").toBeHidden({ timeout: 10_000 });
+            await expect(newGroupDialog, "Dialog closes").toBeHidden();
         });
 
-        await test.step("Navigate to admin user", async () => {
-            await navigator.navigate("/if/admin/identity/users");
+        await test.step("Create a user to add to the group", () =>
+            createInternalUser({ navigator, form, pointer, page }, username, userDisplayName));
 
-            const $adminUser = await search(adminUsername);
+        await test.step("Navigate to the new user", async () => {
+            const $user = await search(username);
 
-            await expect($adminUser, "Admin user is visible").toBeVisible();
+            await expect($user, "User is visible").toBeVisible();
 
-            const viewLink = $adminUser.getByRole("link", {
-                name: "View details for authentik Default Admin",
+            const viewLink = $user.getByRole("link", {
+                name: `View details for ${userDisplayName}`,
             });
+
             await expect(viewLink, "View details link is visible").toBeVisible();
 
             await viewLink.click();
@@ -322,12 +392,12 @@ test.describe("Groups", () => {
                 await expect(
                     page.getByText("Adding Group..."),
                     "Loader shows 'Adding Group...' not 'Creating Group...'",
-                ).toBeVisible({ timeout: 5_000 });
+                ).toBeVisible();
 
                 await expect(
-                    page.getByRole("link", { name: groupName }).first(),
+                    page.getByRole("link", { name: groupName }),
                     "Group appears in the user's related group list",
-                ).toBeVisible({ timeout: 10_000 });
+                ).toBeVisible();
             });
         });
     });

--- a/web/test/browser/600-providers.test.ts
+++ b/web/test/browser/600-providers.test.ts
@@ -19,7 +19,7 @@ test.describe("Provider Wizard", () => {
 
         await test.step("Authenticate", async () =>
             session.login({
-                to: "/if/admin/#/core/providers",
+                to: "/if/admin/core/providers",
             }));
 
         await test.step("Navigate to provider wizard", async () => {

--- a/web/test/browser/700-applications.test.ts
+++ b/web/test/browser/700-applications.test.ts
@@ -172,9 +172,7 @@ test.describe("Applications", () => {
 
             await expect(
                 wizardDialog.getByRole("heading", { name: "Your application has been saved" }),
-            ).toBeVisible({
-                timeout: 10_000,
-            });
+            ).toBeVisible();
 
             await click("Finish", "button", wizardDialog);
         });

--- a/web/test/browser/800-rac.test.ts
+++ b/web/test/browser/800-rac.test.ts
@@ -196,7 +196,7 @@ test.describe("RAC", () => {
             await expect(
                 launchDialog.getByRole("cell", { name: endpointA }),
                 `Endpoint ${endpointA} is visible in the launcher`,
-            ).toBeVisible({ timeout: 5_000 });
+            ).toBeVisible();
 
             await expect(
                 launchDialog.getByRole("cell", { name: endpointB }),

--- a/web/test/browser/800-rac.test.ts
+++ b/web/test/browser/800-rac.test.ts
@@ -175,13 +175,19 @@ test.describe("RAC", () => {
             "Application launch button appears in the filtered library",
         ).toBeVisible({ timeout: 15_000 });
 
-        await test.step("Open the endpoint launcher", async () => {
-            await launchButton.click();
-        });
-
         const launchDialog = page.getByRole("dialog", { name: /Launch Endpoint/i });
 
-        await expect(launchDialog, "Launch Endpoint dialog opens").toBeVisible();
+        // Click the card rather than relying on the library's single-match
+        // auto-launch: that fires from the search input's `change` event, and
+        // `locator.fill()` dispatches only `input`, so it never runs under
+        // Playwright. Activating the card is what a user does anyway.
+        await test.step("Endpoint launcher opens for the single match", async () => {
+            await launchButton.click();
+
+            await expect(launchDialog, "Launch Endpoint dialog opens").toBeVisible({
+                timeout: 15_000,
+            });
+        });
 
         // Both endpoints must render on first open — no manual refresh, no
         // re-navigation. Two endpoints are required because a single endpoint

--- a/web/test/browser/900-invitations.test.ts
+++ b/web/test/browser/900-invitations.test.ts
@@ -61,7 +61,7 @@ test.describe("Invitation form", () => {
             await expect(
                 page.getByText("Successfully created invitation."),
                 "Success message confirms the invitation was created",
-            ).toBeVisible({ timeout: 10_000 });
+            ).toBeVisible();
         });
 
         await test.step("Success modal presents the invitation link", async () => {
@@ -148,7 +148,7 @@ test.describe("Invitation form", () => {
 
             await click("Create Invitation", "button", $dialog);
 
-            await expect($successDialog, "Success modal opens").toBeVisible({ timeout: 10_000 });
+            await expect($successDialog, "Success modal opens").toBeVisible();
 
             await $successDialog.getByRole("button", { name: "Close", exact: true }).click();
         });

--- a/web/test/browser/prerequisites.setup.ts
+++ b/web/test/browser/prerequisites.setup.ts
@@ -1,5 +1,7 @@
 import { expect, test as setup } from "#e2e";
 
+const IDENTIFICATION_STAGE_NAME = "default-authentication-identification";
+
 setup("Web server availability", async ({ baseURL }) => {
     expect(baseURL, "Base URL is set").toBeTruthy();
 
@@ -8,4 +10,27 @@ setup("Web server availability", async ({ baseURL }) => {
         .catch(() => false);
 
     expect(ok, `Web server should be listening on ${baseURL}`).toBeTruthy();
+});
+
+// The remember-me coverage in `101-session-lifecycle` needs this switch on, and it lives
+// on the default identification stage — shared by every login in the suite. Enabling it
+// here means it happens once, before any worker starts, rather than from a `beforeAll`
+// that saves a flow stage while other workers are authenticating through it.
+setup('Enable "Remember me on this device"', async ({ session, form, page }) => {
+    await setup.step("Authenticate", () => session.login({ to: "/if/admin/flow/stages" }));
+
+    const $stage = await setup.step("Find the identification stage", () =>
+        form.search(IDENTIFICATION_STAGE_NAME),
+    );
+
+    await $stage.getByRole("button", { name: "Edit Stage" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Edit Identification Stage" });
+
+    await expect(dialog, "Edit modal opens").toBeVisible();
+
+    await form.setInputCheck(`Enable "Remember me on this device"`, true, dialog);
+    await dialog.getByRole("button", { name: "Save Changes" }).click();
+
+    await expect(dialog, "Edit modal closes after save").toBeHidden();
 });

--- a/website/docs/developer-docs/setup/full-dev-environment.mdx
+++ b/website/docs/developer-docs/setup/full-dev-environment.mdx
@@ -229,6 +229,13 @@ The recovery token is valid for a short time, but anyone can use it to log in as
 
 ## End-to-end (E2E) setup
 
+authentik ships two end-to-end test suites:
+
+- The Django/Selenium suite under `tests/e2e/` — driven by Django's test runner. It is exercised in CI by the `test-e2e` job in `ci-main.yml`.
+- The browser-side Playwright suite under `web/test/browser/` — driven by `web/playwright.config.js`. It is exercised in CI by the `e2e (playwright)` job in `ci-web.yml` and runs against a live authentik server.
+
+### Django/Selenium suite
+
 Start the E2E test services with the following command:
 
 ```shell
@@ -242,6 +249,39 @@ Alternatively, you can connect directly via VNC on port `5900` using the passwor
 :::info
 When using Docker Desktop, host networking needs to be enabled via **Docker Settings** > **Resources** > **Network** > **Enable host networking**.
 :::
+
+### Playwright suite
+
+The Playwright suite assumes that:
+
+- An authentik stack is reachable at `http://localhost:9000` (override with `AK_TEST_RUNNER_PAGE_URL`).
+- The `akadmin` user can log in as `test-admin@goauthentik.io` with the password `test-runner`.
+
+Both are satisfied by the development environment described above, as long as the bootstrap credentials match what the tests expect. Set them before authentik first starts — the bootstrap blueprint only applies them while `akadmin` still has no usable password:
+
+```shell
+export AUTHENTIK_BOOTSTRAP_EMAIL=test-admin@goauthentik.io
+export AUTHENTIK_BOOTSTRAP_PASSWORD=test-runner
+
+make run
+```
+
+If your instance already has an `akadmin` password, either reset it to `test-runner` through the UI or point the suite at a different account via `SessionFixture`'s defaults.
+
+Install Playwright's browsers (one-time) and run the suite — these are the same scripts CI runs:
+
+```shell
+pnpm --dir web exec playwright install --with-deps chromium
+pnpm --dir web run test:e2e
+```
+
+After a failing run, open the HTML report to inspect traces, screenshots, and (in CI) videos:
+
+```shell
+pnpm --dir web exec playwright show-report
+```
+
+In CI, the same artifacts are uploaded under the `playwright-report` and `playwright-traces` artifact names on the workflow run.
 
 ## Contributing code
 


### PR DESCRIPTION
## Details

This PR adds an `e2e (playwright)` job to `ci-web.yml`, so `web/test/browser/` finally runs on every PR. The job builds the web UI and the Rust binary, brings authentik up with `ak allinone`, and runs the suite against it. Traces, videos, the HTML report, and the server log upload on every non-cancelled run, and the result posts as a single updated PR comment. S3 report hosting is wired but gated behind `vars.PLAYWRIGHT_S3_ENABLED` until the bucket exists. The job stays out of `ci-web-mark`'s `needs` for now, so a first bad run on a fresh CI database can't block merges.


Closes #21994