### PR TITLE
lib/expression: use literal fallback in ak_obj_attr

### DIFF
--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -174,9 +174,7 @@ class BaseEvaluator:
         return fallback value."""
         attrs = getattr(obj, "attributes", {})
         value = get_path_from_dict(attrs, attr_key)
-        if value is None and fallback:
-            return getattr(obj, fallback)
-        return value
+        return fallback if value is None else value
 
     def expr_event_create(self, action: str, **kwargs):
         """Create event with supplied data and try to extract as much relevant data

--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -174,7 +174,7 @@ class BaseEvaluator:
         return fallback value."""
         attrs = getattr(obj, "attributes", {})
         value = get_path_from_dict(attrs, attr_key)
-        if value is None and fallback:
+        if value is None and fallback is not None:
             return getattr(obj, fallback, fallback)
         return value
 

--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -174,7 +174,9 @@ class BaseEvaluator:
         return fallback value."""
         attrs = getattr(obj, "attributes", {})
         value = get_path_from_dict(attrs, attr_key)
-        return fallback if value is None else value
+        if value is None and fallback:
+            return getattr(obj, fallback, fallback)
+        return value
 
     def expr_event_create(self, action: str, **kwargs):
         """Create event with supplied data and try to extract as much relevant data

--- a/authentik/lib/tests/test_evaluator.py
+++ b/authentik/lib/tests/test_evaluator.py
@@ -39,6 +39,16 @@ class TestEvaluator(TestCase):
         """Test expr_is_group_member"""
         self.assertFalse(BaseEvaluator.expr_is_group_member(create_test_admin_user(), name="test"))
 
+    def test_expr_obj_attr(self):
+        """Test expr_obj_attr"""
+        user = create_test_user()
+        user.attributes = {"locale": "en-US"}
+
+        self.assertEqual(BaseEvaluator.expr_obj_attr(user, "locale", "en-GB"), "en-US")
+        self.assertEqual(BaseEvaluator.expr_obj_attr(user, "missing", "en-GB"), "en-GB")
+        self.assertEqual(BaseEvaluator.expr_obj_attr(user, "missing", ""), "")
+        self.assertIsNone(BaseEvaluator.expr_obj_attr(user, "missing"))
+
     def test_expr_event_create(self):
         """Test expr_event_create"""
         evaluator = BaseEvaluator(generate_id())

--- a/authentik/lib/tests/test_evaluator.py
+++ b/authentik/lib/tests/test_evaluator.py
@@ -45,6 +45,7 @@ class TestEvaluator(TestCase):
         user.attributes = {"locale": "en-US"}
 
         self.assertEqual(BaseEvaluator.expr_obj_attr(user, "locale", "en-GB"), "en-US")
+        self.assertEqual(BaseEvaluator.expr_obj_attr(user, "missing", "username"), user.username)
         self.assertEqual(BaseEvaluator.expr_obj_attr(user, "missing", "en-GB"), "en-GB")
         self.assertEqual(BaseEvaluator.expr_obj_attr(user, "missing", ""), "")
         self.assertIsNone(BaseEvaluator.expr_obj_attr(user, "missing"))


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?
Changes `ak_obj_attr` so its fallback argument is returned as a literal value when the requested attribute is missing.

### Why is this change needed?
The fallback was incorrectly treated as an attribute name on the object. This made literal fallback values ambiguous and could return an unrelated object attribute instead of the supplied fallback.

### How was this tested?
- Added focused regression coverage for existing attributes, literal fallbacks, empty-string fallbacks, and `None`.
- Ran `make test authentik/lib/tests/test_evaluator.py`.
- `git diff --check` passed.

### Linked issues
closes #25381
<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [X] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
