### PR TITLE
providers/saml: skip empty authorization flows for saml providers (2026.5)

### DIFF
--- a/authentik/flows/challenge.py
+++ b/authentik/flows/challenge.py
@@ -50,7 +50,7 @@ class ContextualFlowInfo(PassiveSerializer):
     background_themed_urls = ThemedUrlsSerializer(required=False, allow_null=True)
     cancel_url = CharField()
     layout = ChoiceField(choices=[(x.value, x.name) for x in FlowLayout])
-    continuous_login_hold = BooleanField(default=True)
+    continuous_login_hold = BooleanField(required=False)
 
 
 class Challenge(PassiveSerializer):
@@ -73,7 +73,7 @@ class RedirectChallenge(Challenge):
     # source-stage hops to an external IdP) stay False so the web client doesn't resume other
     # continuous-login tabs prematurely. See web/src/flow/tabs/orchestrator.ts.
     final_redirect = BooleanField(default=False)
-    continuous_login_hold = BooleanField(default=True)
+    continuous_login_hold = BooleanField(required=False)
     component = CharField(default="xak-flow-redirect")
 
 

--- a/authentik/flows/challenge.py
+++ b/authentik/flows/challenge.py
@@ -50,6 +50,7 @@ class ContextualFlowInfo(PassiveSerializer):
     background_themed_urls = ThemedUrlsSerializer(required=False, allow_null=True)
     cancel_url = CharField()
     layout = ChoiceField(choices=[(x.value, x.name) for x in FlowLayout])
+    continuous_login_hold = BooleanField(default=True)
 
 
 class Challenge(PassiveSerializer):
@@ -72,6 +73,7 @@ class RedirectChallenge(Challenge):
     # source-stage hops to an external IdP) stay False so the web client doesn't resume other
     # continuous-login tabs prematurely. See web/src/flow/tabs/orchestrator.ts.
     final_redirect = BooleanField(default=False)
+    continuous_login_hold = BooleanField(default=True)
     component = CharField(default="xak-flow-redirect")
 
 

--- a/authentik/flows/planner.py
+++ b/authentik/flows/planner.py
@@ -43,6 +43,8 @@ PLAN_CONTEXT_DEVICE = "device"
 PLAN_CONTEXT_SOURCE = "source"
 PLAN_CONTEXT_OUTPOST = "outpost"
 PLAN_CONTEXT_POST = "goauthentik.io/http/post"
+# Keep continuous-login tabs serialized through the provider authorization flow.
+PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD = "goauthentik.io/flows/continuous_login_hold"
 # Is set by the Flow Planner when a FlowToken was used, and the currently active flow plan
 # was restored.
 PLAN_CONTEXT_IS_RESTORED = "is_restored"
@@ -163,6 +165,7 @@ class FlowPlan:
             # No unskippable stages found, so we can directly return the response of the last stage
             final_stage: type[StageView] = self.bindings[-1].stage.view
             temp_exec = FlowExecutorView(flow=flow, request=request, plan=self)
+            temp_exec.direct_execution = True
             temp_exec.current_stage = self.bindings[-1].stage
             temp_exec.current_stage_view = final_stage
             temp_exec.setup(request, flow.slug)

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -200,20 +200,21 @@ class ChallengeStageView(StageView):
             if "flow_info" not in challenge.initial_data:
                 # Flow payloads can outlive the previous signed media JWT, so
                 # refreshes must mint fresh URLs instead of reusing cached ones.
-                flow_info = ContextualFlowInfo(
-                    data={
-                        "title": self.format_title(),
-                        "background": self.executor.flow.background_url(use_cache=False),
-                        "background_themed_urls": self.executor.flow.background_themed_urls(
-                            use_cache=False,
-                        ),
-                        "cancel_url": self.cancel_url,
-                        "layout": self.executor.flow.layout,
-                        "continuous_login_hold": getattr(self.executor.plan, "context", {}).get(
-                            PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD, True
-                        ),
-                    },
-                )
+                flow_info_data = {
+                    "title": self.format_title(),
+                    "background": self.executor.flow.background_url(use_cache=False),
+                    "background_themed_urls": self.executor.flow.background_themed_urls(
+                        use_cache=False,
+                    ),
+                    "cancel_url": self.cancel_url,
+                    "layout": self.executor.flow.layout,
+                }
+                plan_context = getattr(self.executor.plan, "context", {})
+                if PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD in plan_context:
+                    flow_info_data["continuous_login_hold"] = plan_context[
+                        PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD
+                    ]
+                flow_info = ContextualFlowInfo(data=flow_info_data)
                 flow_info.is_valid()
                 challenge.initial_data["flow_info"] = flow_info.data
             if isinstance(challenge, WithUserInfoChallenge):

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -29,7 +29,11 @@ from authentik.flows.challenge import (
 )
 from authentik.flows.exceptions import StageInvalidException
 from authentik.flows.models import InvalidResponseAction
-from authentik.flows.planner import PLAN_CONTEXT_APPLICATION, PLAN_CONTEXT_PENDING_USER
+from authentik.flows.planner import (
+    PLAN_CONTEXT_APPLICATION,
+    PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD,
+    PLAN_CONTEXT_PENDING_USER,
+)
 from authentik.lib.avatars import DEFAULT_AVATAR, get_avatar
 from authentik.lib.utils.reflection import class_to_path
 
@@ -205,7 +209,10 @@ class ChallengeStageView(StageView):
                         ),
                         "cancel_url": self.cancel_url,
                         "layout": self.executor.flow.layout,
-                    }
+                        "continuous_login_hold": getattr(self.executor.plan, "context", {}).get(
+                            PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD, True
+                        ),
+                    },
                 )
                 flow_info.is_valid()
                 challenge.initial_data["flow_info"] = flow_info.data

--- a/authentik/flows/tests/test_executor.py
+++ b/authentik/flows/tests/test_executor.py
@@ -50,7 +50,7 @@ def to_stage_response(
     request: HttpRequest,
     source: HttpResponse,
     final_redirect: bool = False,
-    continuous_login_hold: bool = True,
+    continuous_login_hold: bool | None = None,
 ):
     """Mock for to_stage_response that returns the original response, so we can check
     inheritance and member attributes"""
@@ -763,7 +763,6 @@ class TestFlowExecutor(FlowTestCase):
                 "cancel_url": "/flows/-/cancel/?next=%2Ffoo",
                 "layout": "stacked",
                 "title": flow.title,
-                "continuous_login_hold": True,
             },
         )
 

--- a/authentik/flows/tests/test_executor.py
+++ b/authentik/flows/tests/test_executor.py
@@ -46,7 +46,12 @@ POLICY_RETURN_FALSE = PropertyMock(return_value=PolicyResult(False, "foo"))
 POLICY_RETURN_TRUE = MagicMock(return_value=PolicyResult(True))
 
 
-def to_stage_response(request: HttpRequest, source: HttpResponse, final_redirect: bool = False):
+def to_stage_response(
+    request: HttpRequest,
+    source: HttpResponse,
+    final_redirect: bool = False,
+    continuous_login_hold: bool = True,
+):
     """Mock for to_stage_response that returns the original response, so we can check
     inheritance and member attributes"""
     return source
@@ -758,6 +763,7 @@ class TestFlowExecutor(FlowTestCase):
                 "cancel_url": "/flows/-/cancel/?next=%2Ffoo",
                 "layout": "stacked",
                 "title": flow.title,
+                "continuous_login_hold": True,
             },
         )
 

--- a/authentik/flows/tests/test_stage_views.py
+++ b/authentik/flows/tests/test_stage_views.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from authentik.core.tests.utils import RequestFactory as AuthentikRequestFactory
 from authentik.core.tests.utils import create_test_flow
 from authentik.flows.models import Flow, FlowStageBinding
+from authentik.flows.planner import PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD, FlowPlan
 from authentik.flows.stage import StageView
 from authentik.flows.views.executor import FlowExecutorView
 from authentik.lib.utils.reflection import all_subclasses
@@ -43,6 +44,22 @@ class TestViews(TestCase):
             challenge.initial_data["flow_info"]["background"],
             "/static/dist/assets/images/flow_background.jpg",
         )
+
+    def test_challenge_stage_exposes_continuous_login_hold(self):
+        """Challenge flow info exposes whether authorization must retain the tab lock."""
+        flow = create_test_flow()
+        stage = DummyStage.objects.create(name="dummy")
+        request = self.authentik_factory.get("/")
+        plan = FlowPlan(flow_pk=flow.pk.hex)
+        plan.context[PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD] = False
+        executor = FlowExecutorView(flow=flow, request=request, plan=plan)
+        executor.current_stage = stage
+        view = DummyStageView(executor)
+        view.request = request
+
+        challenge = view._get_challenge()
+
+        self.assertFalse(challenge.initial_data["flow_info"]["continuous_login_hold"])
 
     def test_flow_interface_css_background_preserves_presigned_url_query(self):
         """Test flow CSS keeps signed URL query separators intact."""

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -388,9 +388,9 @@ class FlowExecutorView(APIView):
         """User Successfully passed all stages"""
         # Since this is wrapped by the ExecutorShell, the next argument is saved in the session
         # extract the next param before cancel as that cleans it
-        continuous_login_hold = True
+        continuous_login_hold = None
         if self.plan:
-            continuous_login_hold = self.plan.context.get(PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD, True)
+            continuous_login_hold = self.plan.context.get(PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD)
         if self.plan and PLAN_CONTEXT_REDIRECT in self.plan.context:
             # The context `redirect` variable can only be set by
             # an expression policy or authentik itself, so we don't
@@ -558,7 +558,7 @@ def to_stage_response(
     request: HttpRequest,
     source: HttpResponse,
     final_redirect: bool = False,
-    continuous_login_hold: bool = True,
+    continuous_login_hold: bool | None = None,
 ) -> HttpResponse:
     """Convert normal HttpResponse into JSON Response"""
     if (
@@ -574,15 +574,13 @@ def to_stage_response(
             to=str(redirect_url),
             current=request.path,
         )
-        return HttpChallengeResponse(
-            RedirectChallenge(
-                {
-                    "to": str(redirect_url),
-                    "final_redirect": final_redirect,
-                    "continuous_login_hold": continuous_login_hold,
-                }
-            )
-        )
+        challenge_data = {
+            "to": str(redirect_url),
+            "final_redirect": final_redirect,
+        }
+        if continuous_login_hold is not None:
+            challenge_data["continuous_login_hold"] = continuous_login_hold
+        return HttpChallengeResponse(RedirectChallenge(challenge_data))
     if isinstance(source, TemplateResponse):
         return HttpChallengeResponse(
             ShellChallenge(

--- a/authentik/flows/views/executor.py
+++ b/authentik/flows/views/executor.py
@@ -47,6 +47,7 @@ from authentik.flows.models import (
 )
 from authentik.flows.planner import (
     CACHE_PREFIX,
+    PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD,
     PLAN_CONTEXT_IS_RESTORED,
     PLAN_CONTEXT_PENDING_USER,
     PLAN_CONTEXT_REDIRECT,
@@ -107,6 +108,7 @@ class FlowExecutorView(APIView):
     current_binding: FlowStageBinding | None = None
     current_stage: Stage
     current_stage_view: View
+    direct_execution = False
 
     _logger: BoundLogger
 
@@ -386,6 +388,9 @@ class FlowExecutorView(APIView):
         """User Successfully passed all stages"""
         # Since this is wrapped by the ExecutorShell, the next argument is saved in the session
         # extract the next param before cancel as that cleans it
+        continuous_login_hold = True
+        if self.plan:
+            continuous_login_hold = self.plan.context.get(PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD, True)
         if self.plan and PLAN_CONTEXT_REDIRECT in self.plan.context:
             # The context `redirect` variable can only be set by
             # an expression policy or authentik itself, so we don't
@@ -395,6 +400,7 @@ class FlowExecutorView(APIView):
                 self.request,
                 redirect(self.plan.context.get(PLAN_CONTEXT_REDIRECT)),
                 final_redirect=True,
+                continuous_login_hold=continuous_login_hold,
             )
         next_param = self.request.session.get(SESSION_KEY_GET, {}).get(
             NEXT_ARG_NAME, "authentik_core:root-redirect"
@@ -402,7 +408,10 @@ class FlowExecutorView(APIView):
         self.cancel()
         if next_param and not is_url_absolute(next_param):
             return to_stage_response(
-                self.request, redirect_with_qs(next_param), final_redirect=True
+                self.request,
+                redirect_with_qs(next_param),
+                final_redirect=True,
+                continuous_login_hold=continuous_login_hold,
             )
         return to_stage_response(
             self.request, self.stage_invalid(error_message=_("Invalid next URL"))
@@ -546,7 +555,10 @@ class ToDefaultFlow(View):
 
 
 def to_stage_response(
-    request: HttpRequest, source: HttpResponse, final_redirect: bool = False
+    request: HttpRequest,
+    source: HttpResponse,
+    final_redirect: bool = False,
+    continuous_login_hold: bool = True,
 ) -> HttpResponse:
     """Convert normal HttpResponse into JSON Response"""
     if (
@@ -567,6 +579,7 @@ def to_stage_response(
                 {
                     "to": str(redirect_url),
                     "final_redirect": final_redirect,
+                    "continuous_login_hold": continuous_login_hold,
                 }
             )
         )

--- a/authentik/policies/tests/test_views.py
+++ b/authentik/policies/tests/test_views.py
@@ -9,6 +9,8 @@ from authentik.core.tests.utils import (
     create_test_user,
 )
 from authentik.flows.models import Flow, FlowDesignation
+from authentik.flows.planner import PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD
+from authentik.flows.views.executor import SESSION_KEY_PLAN
 from authentik.lib.generators import generate_id
 from authentik.policies.models import PolicyBinding
 from authentik.policies.views import (
@@ -114,3 +116,26 @@ class TestPolicyViews(TestCase):
         res = TestView.as_view()(req)
         self.assertEqual(res.status_code, 302)
         self.assertEqual(res.url, "/if/flow/default-authentication-flow/?next=%2F")
+
+    @apply_blueprint("default/flow-default-authentication-flow.yaml")
+    def test_pav_continuous_login_hold_context(self):
+        """Provider views can release continuous-login tabs after authentication."""
+        provider = Provider.objects.create(name=generate_id())
+        app = Application.objects.create(name=generate_id(), slug=generate_id(), provider=provider)
+        flow = Flow.objects.get(slug="default-authentication-flow")
+
+        class TestView(PolicyAccessView):
+            def resolve_provider_application(self):
+                self.provider = provider
+                self.application = app
+
+            def continuous_login_hold_required(self) -> bool:
+                return False
+
+        req = self.factory.get("/")
+        req.brand = create_test_brand(flow_authentication=flow)
+
+        response = TestView.as_view()(req)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(req.session[SESSION_KEY_PLAN].context[PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD])

--- a/authentik/policies/views.py
+++ b/authentik/policies/views.py
@@ -96,7 +96,8 @@ class PolicyAccessView(AccessMixin, View):
         authn_flow = None
         if self.application:
             flow_context[PLAN_CONTEXT_APPLICATION] = self.application
-            flow_context[PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD] = self.continuous_login_hold_required()
+            if not self.continuous_login_hold_required():
+                flow_context[PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD] = False
             if self.provider and self.provider.authentication_flow:
                 authn_flow = self.provider.authentication_flow
         # Because this view might get hit with a POST request, we need to preserve that data

--- a/authentik/policies/views.py
+++ b/authentik/policies/views.py
@@ -15,6 +15,7 @@ from authentik.flows.exceptions import EmptyFlowException, FlowNonApplicableExce
 from authentik.flows.models import Flow, FlowDesignation
 from authentik.flows.planner import (
     PLAN_CONTEXT_APPLICATION,
+    PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD,
     PLAN_CONTEXT_POST,
     FlowPlanner,
 )
@@ -59,6 +60,10 @@ class PolicyAccessView(AccessMixin, View):
         is not caught, and will return directly"""
         raise NotImplementedError
 
+    def continuous_login_hold_required(self) -> bool:
+        """Keep other tabs paused until this provider's authorization flow finishes."""
+        return True
+
     def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         try:
             self.pre_permission_check()
@@ -91,6 +96,7 @@ class PolicyAccessView(AccessMixin, View):
         authn_flow = None
         if self.application:
             flow_context[PLAN_CONTEXT_APPLICATION] = self.application
+            flow_context[PLAN_CONTEXT_CONTINUOUS_LOGIN_HOLD] = self.continuous_login_hold_required()
             if self.provider and self.provider.authentication_flow:
                 authn_flow = self.provider.authentication_flow
         # Because this view might get hit with a POST request, we need to preserve that data

--- a/authentik/providers/saml/templates/if/saml_form_post.html
+++ b/authentik/providers/saml/templates/if/saml_form_post.html
@@ -1,0 +1,19 @@
+{% load i18n %}<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{% trans "Redirecting..." %}</title>
+    </head>
+    <body onload="document.forms[0].submit()">
+        <form method="post" action="{{ redirect_uri }}">
+            {% for key, value in attrs.items %}
+            <input type="hidden" name="{{ key }}" value="{{ value }}" />
+            {% endfor %}
+            <noscript>
+                <p>{% trans "Your browser does not support JavaScript, please click below to continue." %}</p>
+                <button type="submit">{% trans "Continue" %}</button>
+            </noscript>
+        </form>
+    </body>
+</html>

--- a/authentik/providers/saml/tests/test_auth_n_request.py
+++ b/authentik/providers/saml/tests/test_auth_n_request.py
@@ -29,9 +29,15 @@ from authentik.crypto.models import CertificateKeyPair
 from authentik.events.models import Event, EventAction
 from authentik.flows.apps import ContinuousLogin
 from authentik.flows.models import FlowStageBinding
+from authentik.flows.views.executor import SESSION_KEY_PLAN
 from authentik.lib.generators import generate_id
 from authentik.lib.xml import lxml_from_string
-from authentik.providers.saml.models import SAMLBindings, SAMLPropertyMapping, SAMLProvider
+from authentik.providers.saml.models import (
+    SAMLBindings,
+    SAMLPropertyMapping,
+    SAMLProvider,
+    SAMLSession,
+)
 from authentik.providers.saml.processors.assertion import AssertionProcessor
 from authentik.providers.saml.processors.authn_request_parser import AuthNRequestParser
 from authentik.sources.saml.exceptions import MismatchedRequestID
@@ -120,6 +126,104 @@ class TestAuthNRequest(TestCase):
             binding_type=SAMLBindingTypes.POST,
         )
 
+    def post_authn_request(self):
+        """Send an SP-initiated AuthnRequest using the HTTP-POST binding."""
+        request = RequestProcessor(
+            self.source, self.request_factory.get("/"), "test_state"
+        ).build_auth_n()
+        return self.client.post(
+            reverse(
+                "authentik_providers_saml:sso-post",
+                kwargs={"application_slug": "test-app"},
+            ),
+            {
+                "SAMLRequest": b64encode(request.encode()).decode(),
+                "RelayState": "test_state",
+            },
+        )
+
+    def assert_direct_post_response(self, response):
+        """Assert a direct SAML HTTP-POST response and its side effects."""
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "if/saml_form_post.html")
+        self.assertEqual(response.context_data["redirect_uri"], self.provider.acs_url)
+        self.assertEqual(response.context_data["attrs"]["RelayState"], "test_state")
+        self.assertIn("SAMLResponse", response.context_data["attrs"])
+        self.assertNotIn(SESSION_KEY_PLAN, self.client.session)
+        self.assertTrue(SAMLSession.objects.filter(provider=self.provider).exists())
+        self.assertTrue(Event.objects.filter(action=EventAction.AUTHORIZE_APPLICATION).exists())
+
+    def test_post_response_empty_flow_is_direct(self):
+        """An empty authorization flow returns the SAML POST form directly."""
+        self.provider.sp_binding = SAMLBindings.POST
+        self.provider.save()
+        self.client.force_login(create_test_admin_user())
+
+        self.assert_direct_post_response(self.post_authn_request())
+
+    @patch_flag(ContinuousLogin, True)
+    def test_post_response_empty_flow_is_direct_with_continuous_login(self):
+        """Continuous login does not force an empty authorization flow into the executor."""
+        self.provider.sp_binding = SAMLBindings.POST
+        self.provider.save()
+        self.client.force_login(create_test_admin_user())
+
+        self.assert_direct_post_response(self.post_authn_request())
+
+    @patch_flag(ContinuousLogin, True)
+    def test_redirect_response_empty_flow_is_direct_with_continuous_login(self):
+        """An empty authorization flow returns the SAML Redirect response directly."""
+        self.provider.sp_binding = SAMLBindings.REDIRECT
+        self.provider.save()
+        app = Application.objects.get(slug="test-app")
+        params = RequestProcessor(
+            self.source, self.request_factory.get("/"), "test_state"
+        ).build_auth_n_detached()
+        self.client.force_login(create_test_admin_user())
+
+        response = self.client.get(
+            reverse(
+                "authentik_providers_saml:sso-redirect",
+                kwargs={"application_slug": app.slug},
+            ),
+            params,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        redirect = urlparse(response["Location"])
+        self.assertEqual(
+            f"{redirect.scheme}://{redirect.netloc}{redirect.path}", self.provider.acs_url
+        )
+        redirect_query = parse_qs(redirect.query)
+        self.assertEqual(redirect_query["RelayState"], ["test_state"])
+        self.assertIn("SAMLResponse", redirect_query)
+        self.assertNotIn(SESSION_KEY_PLAN, self.client.session)
+        self.assertTrue(SAMLSession.objects.filter(provider=self.provider).exists())
+        self.assertTrue(Event.objects.filter(action=EventAction.AUTHORIZE_APPLICATION).exists())
+
+    def test_post_response_nonempty_flow_uses_executor(self):
+        """A configured authorization stage keeps using the flow executor."""
+        self.provider.sp_binding = SAMLBindings.POST
+        self.provider.save()
+        FlowStageBinding.objects.create(
+            target=self.provider.authorization_flow,
+            stage=DummyStage.objects.create(name=generate_id()),
+            order=0,
+        )
+        self.client.force_login(create_test_admin_user())
+
+        response = self.post_authn_request()
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            urlparse(response["Location"]).path,
+            reverse(
+                "authentik_core:if-flow",
+                kwargs={"flow_slug": self.provider.authorization_flow.slug},
+            ),
+        )
+        self.assertIn(SESSION_KEY_PLAN, self.client.session)
+
     def test_signed_valid(self):
         """Test generated AuthNRequest with valid signature"""
         http_request = self.request_factory.get("/")
@@ -171,6 +275,11 @@ class TestAuthNRequest(TestCase):
         continuous login, instead of an un-validated-serializer error."""
         self.provider.sp_binding = SAMLBindings.REDIRECT
         self.provider.save()
+        FlowStageBinding.objects.create(
+            target=self.provider.authorization_flow,
+            stage=DummyStage.objects.create(name=generate_id()),
+            order=0,
+        )
         app = Application.objects.get(slug="test-app")
         http_request = self.request_factory.get("/")
         params = RequestProcessor(self.source, http_request, "test_state").build_auth_n_detached()
@@ -187,17 +296,25 @@ class TestAuthNRequest(TestCase):
         self.assertEqual(initiate.status_code, 302)
 
         # Drive the flow executor to completion, reaching SAMLFlowFinalView.
-        response = self.client.get(
-            reverse(
-                "authentik_api:flow-executor",
-                kwargs={"flow_slug": self.provider.authorization_flow.slug},
-            )
+        executor_url = reverse(
+            "authentik_api:flow-executor",
+            kwargs={"flow_slug": self.provider.authorization_flow.slug},
         )
+        challenge = self.client.get(executor_url)
+        self.assertEqual(challenge.json()["component"], "ak-stage-dummy")
+        advance = self.client.post(
+            executor_url,
+            {"component": "ak-stage-dummy"},
+            content_type="application/json",
+        )
+        self.assertEqual(advance.status_code, 302)
+        response = self.client.get(executor_url)
 
         self.assertEqual(response.status_code, 200)
         body = loads(response.content.decode())
         self.assertEqual(body["component"], "xak-flow-redirect")
         self.assertTrue(body["final_redirect"])
+        self.assertTrue(body["continuous_login_hold"])
         self.assertTrue(body["to"].startswith(self.provider.acs_url))
 
     def test_request_encrypt(self):

--- a/authentik/providers/saml/tests/test_auth_n_request.py
+++ b/authentik/providers/saml/tests/test_auth_n_request.py
@@ -314,7 +314,7 @@ class TestAuthNRequest(TestCase):
         body = loads(response.content.decode())
         self.assertEqual(body["component"], "xak-flow-redirect")
         self.assertTrue(body["final_redirect"])
-        self.assertTrue(body["continuous_login_hold"])
+        self.assertNotIn("continuous_login_hold", body)
         self.assertTrue(body["to"].startswith(self.provider.acs_url))
 
     def test_request_encrypt(self):

--- a/authentik/providers/saml/views/flows.py
+++ b/authentik/providers/saml/views/flows.py
@@ -4,6 +4,7 @@ from django.core.validators import URLValidator
 from django.http import HttpRequest, HttpResponse
 from django.http.response import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.utils.http import urlencode
 from django.utils.translation import gettext as _
 from structlog.stdlib import get_logger
@@ -54,6 +55,10 @@ class SAMLFlowFinalView(ChallengeStageView):
     (if POST is configured)."""
 
     response_class = AutoSubmitChallengeResponse
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        """Fulfill direct authorization requests regardless of their incoming binding."""
+        return self.get(request, *args, **kwargs)
 
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         application: Application = self.executor.plan.context[PLAN_CONTEXT_APPLICATION]
@@ -111,6 +116,12 @@ class SAMLFlowFinalView(ChallengeStageView):
                     REQUEST_KEY_RELAY_STATE: auth_n_request.relay_state,
                 }
             )
+            if self.executor.direct_execution:
+                return TemplateResponse(
+                    request,
+                    "if/saml_form_post.html",
+                    {"redirect_uri": provider.acs_url, "attrs": form_attrs},
+                )
             return super().get(
                 self.request,
                 **{
@@ -138,7 +149,7 @@ class SAMLFlowFinalView(ChallengeStageView):
             if auth_n_request.relay_state:
                 url_args[REQUEST_KEY_RELAY_STATE] = auth_n_request.relay_state
             querystring = urlencode(url_args)
-            if ContinuousLogin.get():
+            if ContinuousLogin.get() and not self.executor.direct_execution:
                 return HttpChallengeResponse(
                     RedirectChallenge(
                         instance={

--- a/authentik/providers/saml/views/sso.py
+++ b/authentik/providers/saml/views/sso.py
@@ -10,9 +10,8 @@ from structlog.stdlib import get_logger
 
 from authentik.core.models import Application
 from authentik.events.models import Event, EventAction
-from authentik.flows.apps import ContinuousLogin
 from authentik.flows.exceptions import FlowNonApplicableException
-from authentik.flows.models import in_memory_stage
+from authentik.flows.models import FlowStageBinding, in_memory_stage
 from authentik.flows.planner import PLAN_CONTEXT_APPLICATION, PLAN_CONTEXT_SSO, FlowPlanner
 from authentik.flows.views.executor import SESSION_KEY_POST
 from authentik.lib.views import bad_request_message
@@ -49,6 +48,14 @@ class SAMLSSOView(PolicyAccessView):
         self.provider: SAMLProvider = get_object_or_404(
             SAMLProvider, pk=self.application.provider_id
         )
+
+    def continuous_login_hold_required(self) -> bool:
+        """Conservatively hold tabs when authorization may require the flow executor.
+
+        Stage policies can depend on the user who is about to authenticate, so they cannot be
+        evaluated accurately here. An entirely empty flow is the only flow known to be safe.
+        """
+        return FlowStageBinding.objects.filter(target=self.provider.authorization_flow).exists()
 
     def check_saml_request(self) -> HttpRequest | None:
         """Handler to verify the SAML Request. Must be implemented by a subclass"""
@@ -89,7 +96,7 @@ class SAMLSSOView(PolicyAccessView):
             next=self.get_resume_url(),
             allowed_silent_types=(
                 [SAMLFlowFinalView]
-                if self.provider.sp_binding in [SAMLBindings.REDIRECT] and not ContinuousLogin.get()
+                if self.provider.sp_binding in [SAMLBindings.POST, SAMLBindings.REDIRECT]
                 else []
             ),
         )

--- a/packages/client-go/model_contextual_flow_info.go
+++ b/packages/client-go/model_contextual_flow_info.go
@@ -26,6 +26,7 @@ type ContextualFlowInfo struct {
 	BackgroundThemedUrls NullableThemedUrls           `json:"background_themed_urls,omitempty"`
 	CancelUrl            string                       `json:"cancel_url"`
 	Layout               ContextualFlowInfoLayoutEnum `json:"layout"`
+	ContinuousLoginHold  *bool                        `json:"continuous_login_hold,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -39,6 +40,8 @@ func NewContextualFlowInfo(cancelUrl string, layout ContextualFlowInfoLayoutEnum
 	this := ContextualFlowInfo{}
 	this.CancelUrl = cancelUrl
 	this.Layout = layout
+	var continuousLoginHold bool = true
+	this.ContinuousLoginHold = &continuousLoginHold
 	return &this
 }
 
@@ -47,6 +50,8 @@ func NewContextualFlowInfo(cancelUrl string, layout ContextualFlowInfoLayoutEnum
 // but it doesn't guarantee that properties required by API are set
 func NewContextualFlowInfoWithDefaults() *ContextualFlowInfo {
 	this := ContextualFlowInfo{}
+	var continuousLoginHold bool = true
+	this.ContinuousLoginHold = &continuousLoginHold
 	return &this
 }
 
@@ -205,6 +210,38 @@ func (o *ContextualFlowInfo) SetLayout(v ContextualFlowInfoLayoutEnum) {
 	o.Layout = v
 }
 
+// GetContinuousLoginHold returns the ContinuousLoginHold field value if set, zero value otherwise.
+func (o *ContextualFlowInfo) GetContinuousLoginHold() bool {
+	if o == nil || IsNil(o.ContinuousLoginHold) {
+		var ret bool
+		return ret
+	}
+	return *o.ContinuousLoginHold
+}
+
+// GetContinuousLoginHoldOk returns a tuple with the ContinuousLoginHold field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ContextualFlowInfo) GetContinuousLoginHoldOk() (*bool, bool) {
+	if o == nil || IsNil(o.ContinuousLoginHold) {
+		return nil, false
+	}
+	return o.ContinuousLoginHold, true
+}
+
+// HasContinuousLoginHold returns a boolean if a field has been set.
+func (o *ContextualFlowInfo) HasContinuousLoginHold() bool {
+	if o != nil && !IsNil(o.ContinuousLoginHold) {
+		return true
+	}
+
+	return false
+}
+
+// SetContinuousLoginHold gets a reference to the given bool and assigns it to the ContinuousLoginHold field.
+func (o *ContextualFlowInfo) SetContinuousLoginHold(v bool) {
+	o.ContinuousLoginHold = &v
+}
+
 func (o ContextualFlowInfo) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -226,6 +263,9 @@ func (o ContextualFlowInfo) ToMap() (map[string]interface{}, error) {
 	}
 	toSerialize["cancel_url"] = o.CancelUrl
 	toSerialize["layout"] = o.Layout
+	if !IsNil(o.ContinuousLoginHold) {
+		toSerialize["continuous_login_hold"] = o.ContinuousLoginHold
+	}
 
 	for key, value := range o.AdditionalProperties {
 		toSerialize[key] = value
@@ -275,6 +315,7 @@ func (o *ContextualFlowInfo) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "background_themed_urls")
 		delete(additionalProperties, "cancel_url")
 		delete(additionalProperties, "layout")
+		delete(additionalProperties, "continuous_login_hold")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/packages/client-go/model_contextual_flow_info.go
+++ b/packages/client-go/model_contextual_flow_info.go
@@ -40,8 +40,6 @@ func NewContextualFlowInfo(cancelUrl string, layout ContextualFlowInfoLayoutEnum
 	this := ContextualFlowInfo{}
 	this.CancelUrl = cancelUrl
 	this.Layout = layout
-	var continuousLoginHold bool = true
-	this.ContinuousLoginHold = &continuousLoginHold
 	return &this
 }
 
@@ -50,8 +48,6 @@ func NewContextualFlowInfo(cancelUrl string, layout ContextualFlowInfoLayoutEnum
 // but it doesn't guarantee that properties required by API are set
 func NewContextualFlowInfoWithDefaults() *ContextualFlowInfo {
 	this := ContextualFlowInfo{}
-	var continuousLoginHold bool = true
-	this.ContinuousLoginHold = &continuousLoginHold
 	return &this
 }
 

--- a/packages/client-go/model_redirect_challenge.go
+++ b/packages/client-go/model_redirect_challenge.go
@@ -26,6 +26,7 @@ type RedirectChallenge struct {
 	ResponseErrors       *map[string][]ErrorDetail `json:"response_errors,omitempty"`
 	To                   string                    `json:"to"`
 	FinalRedirect        *bool                     `json:"final_redirect,omitempty"`
+	ContinuousLoginHold  *bool                     `json:"continuous_login_hold,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 
@@ -42,6 +43,8 @@ func NewRedirectChallenge(to string) *RedirectChallenge {
 	this.To = to
 	var finalRedirect bool = false
 	this.FinalRedirect = &finalRedirect
+	var continuousLoginHold bool = true
+	this.ContinuousLoginHold = &continuousLoginHold
 	return &this
 }
 
@@ -54,6 +57,8 @@ func NewRedirectChallengeWithDefaults() *RedirectChallenge {
 	this.Component = &component
 	var finalRedirect bool = false
 	this.FinalRedirect = &finalRedirect
+	var continuousLoginHold bool = true
+	this.ContinuousLoginHold = &continuousLoginHold
 	return &this
 }
 
@@ -209,6 +214,38 @@ func (o *RedirectChallenge) SetFinalRedirect(v bool) {
 	o.FinalRedirect = &v
 }
 
+// GetContinuousLoginHold returns the ContinuousLoginHold field value if set, zero value otherwise.
+func (o *RedirectChallenge) GetContinuousLoginHold() bool {
+	if o == nil || IsNil(o.ContinuousLoginHold) {
+		var ret bool
+		return ret
+	}
+	return *o.ContinuousLoginHold
+}
+
+// GetContinuousLoginHoldOk returns a tuple with the ContinuousLoginHold field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *RedirectChallenge) GetContinuousLoginHoldOk() (*bool, bool) {
+	if o == nil || IsNil(o.ContinuousLoginHold) {
+		return nil, false
+	}
+	return o.ContinuousLoginHold, true
+}
+
+// HasContinuousLoginHold returns a boolean if a field has been set.
+func (o *RedirectChallenge) HasContinuousLoginHold() bool {
+	if o != nil && !IsNil(o.ContinuousLoginHold) {
+		return true
+	}
+
+	return false
+}
+
+// SetContinuousLoginHold gets a reference to the given bool and assigns it to the ContinuousLoginHold field.
+func (o *RedirectChallenge) SetContinuousLoginHold(v bool) {
+	o.ContinuousLoginHold = &v
+}
+
 func (o RedirectChallenge) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -231,6 +268,9 @@ func (o RedirectChallenge) ToMap() (map[string]interface{}, error) {
 	toSerialize["to"] = o.To
 	if !IsNil(o.FinalRedirect) {
 		toSerialize["final_redirect"] = o.FinalRedirect
+	}
+	if !IsNil(o.ContinuousLoginHold) {
+		toSerialize["continuous_login_hold"] = o.ContinuousLoginHold
 	}
 
 	for key, value := range o.AdditionalProperties {
@@ -280,6 +320,7 @@ func (o *RedirectChallenge) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "response_errors")
 		delete(additionalProperties, "to")
 		delete(additionalProperties, "final_redirect")
+		delete(additionalProperties, "continuous_login_hold")
 		o.AdditionalProperties = additionalProperties
 	}
 

--- a/packages/client-go/model_redirect_challenge.go
+++ b/packages/client-go/model_redirect_challenge.go
@@ -43,8 +43,6 @@ func NewRedirectChallenge(to string) *RedirectChallenge {
 	this.To = to
 	var finalRedirect bool = false
 	this.FinalRedirect = &finalRedirect
-	var continuousLoginHold bool = true
-	this.ContinuousLoginHold = &continuousLoginHold
 	return &this
 }
 
@@ -57,8 +55,6 @@ func NewRedirectChallengeWithDefaults() *RedirectChallenge {
 	this.Component = &component
 	var finalRedirect bool = false
 	this.FinalRedirect = &finalRedirect
-	var continuousLoginHold bool = true
-	this.ContinuousLoginHold = &continuousLoginHold
 	return &this
 }
 

--- a/packages/client-rust/src/models/contextual_flow_info.rs
+++ b/packages/client-rust/src/models/contextual_flow_info.rs
@@ -28,6 +28,11 @@ pub struct ContextualFlowInfo {
     pub cancel_url: String,
     #[serde(rename = "layout")]
     pub layout: models::ContextualFlowInfoLayoutEnum,
+    #[serde(
+        rename = "continuous_login_hold",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub continuous_login_hold: Option<bool>,
 }
 
 impl ContextualFlowInfo {
@@ -42,6 +47,7 @@ impl ContextualFlowInfo {
             background_themed_urls: None,
             cancel_url,
             layout,
+            continuous_login_hold: None,
         }
     }
 }

--- a/packages/client-rust/src/models/redirect_challenge.rs
+++ b/packages/client-rust/src/models/redirect_challenge.rs
@@ -23,6 +23,11 @@ pub struct RedirectChallenge {
     pub to: String,
     #[serde(rename = "final_redirect", skip_serializing_if = "Option::is_none")]
     pub final_redirect: Option<bool>,
+    #[serde(
+        rename = "continuous_login_hold",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub continuous_login_hold: Option<bool>,
 }
 
 impl RedirectChallenge {
@@ -34,6 +39,7 @@ impl RedirectChallenge {
             response_errors: None,
             to,
             final_redirect: None,
+            continuous_login_hold: None,
         }
     }
 }

--- a/packages/client-ts/src/models/ContextualFlowInfo.ts
+++ b/packages/client-ts/src/models/ContextualFlowInfo.ts
@@ -56,6 +56,12 @@ export interface ContextualFlowInfo {
      * @memberof ContextualFlowInfo
      */
     layout: ContextualFlowInfoLayoutEnum;
+    /**
+     *
+     * @type {boolean}
+     * @memberof ContextualFlowInfo
+     */
+    continuousLoginHold?: boolean;
 }
 
 /**
@@ -87,6 +93,8 @@ export function ContextualFlowInfoFromJSONTyped(
                 : ThemedUrlsFromJSON(json["background_themed_urls"]),
         cancelUrl: json["cancel_url"],
         layout: ContextualFlowInfoLayoutEnumFromJSON(json["layout"]),
+        continuousLoginHold:
+            json["continuous_login_hold"] == null ? undefined : json["continuous_login_hold"],
     };
 }
 
@@ -108,5 +116,6 @@ export function ContextualFlowInfoToJSONTyped(
         background_themed_urls: ThemedUrlsToJSON(value["backgroundThemedUrls"]),
         cancel_url: value["cancelUrl"],
         layout: ContextualFlowInfoLayoutEnumToJSON(value["layout"]),
+        continuous_login_hold: value["continuousLoginHold"],
     };
 }

--- a/packages/client-ts/src/models/RedirectChallenge.ts
+++ b/packages/client-ts/src/models/RedirectChallenge.ts
@@ -52,6 +52,12 @@ export interface RedirectChallenge {
      * @memberof RedirectChallenge
      */
     finalRedirect?: boolean;
+    /**
+     *
+     * @type {boolean}
+     * @memberof RedirectChallenge
+     */
+    continuousLoginHold?: boolean;
 }
 
 /**
@@ -80,6 +86,8 @@ export function RedirectChallengeFromJSONTyped(
         responseErrors: json["response_errors"] == null ? undefined : json["response_errors"],
         to: json["to"],
         finalRedirect: json["final_redirect"] == null ? undefined : json["final_redirect"],
+        continuousLoginHold:
+            json["continuous_login_hold"] == null ? undefined : json["continuous_login_hold"],
     };
 }
 
@@ -101,5 +109,6 @@ export function RedirectChallengeToJSONTyped(
         response_errors: value["responseErrors"],
         to: value["to"],
         final_redirect: value["finalRedirect"],
+        continuous_login_hold: value["continuousLoginHold"],
     };
 }

--- a/schema.yml
+++ b/schema.yml
@@ -36918,6 +36918,9 @@ components:
           type: string
         layout:
           $ref: '#/components/schemas/ContextualFlowInfoLayoutEnum'
+        continuous_login_hold:
+          type: boolean
+          default: true
       required:
       - cancel_url
       - layout
@@ -53555,6 +53558,9 @@ components:
         final_redirect:
           type: boolean
           default: false
+        continuous_login_hold:
+          type: boolean
+          default: true
       required:
       - to
     RedirectChallengeResponseRequest:

--- a/schema.yml
+++ b/schema.yml
@@ -36920,7 +36920,6 @@ components:
           $ref: '#/components/schemas/ContextualFlowInfoLayoutEnum'
         continuous_login_hold:
           type: boolean
-          default: true
       required:
       - cancel_url
       - layout
@@ -53560,7 +53559,6 @@ components:
           default: false
         continuous_login_hold:
           type: boolean
-          default: true
       required:
       - to
     RedirectChallengeResponseRequest:

--- a/web/src/flow/controllers/FlowMultitabController.ts
+++ b/web/src/flow/controllers/FlowMultitabController.ts
@@ -1,5 +1,6 @@
 import type { Interface } from "#elements/Interface";
 
+import { shouldReleaseContinuousLogin } from "#flow/tabs/continuous-login";
 import { AKMultiTabEvent } from "#flow/tabs/events";
 import {
     multiTabOrchestrateLeave as dispatchTabExit,
@@ -48,11 +49,12 @@ export class FlowMultitabController implements ReactiveController {
 
         if (next) {
             const url = new URL(next, window.location.origin);
+            const continuousLoginHold = challenge.flowInfo?.continuousLoginHold ?? true;
 
-            if (url.origin === window.location.origin) {
-                suppressNextExitForSameOriginNavigation();
-            } else {
+            if (shouldReleaseContinuousLogin(url, window.location.origin, continuousLoginHold)) {
                 dispatchTabExit();
+            } else {
+                suppressNextExitForSameOriginNavigation();
             }
 
             window.location.assign(url);

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -3,6 +3,7 @@ import "#flow/components/ak-flow-card";
 import { SlottedTemplateResult } from "#elements/types";
 
 import { BaseStage } from "#flow/stages/base";
+import { shouldReleaseContinuousLogin } from "#flow/tabs/continuous-login";
 import {
     multiTabOrchestrateLeave,
     multiTabOrchestrateResume,
@@ -78,6 +79,7 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
         // resume other continuous-login tabs; intermediate hops (source stages, the same-origin
         // SAML resume re-entry) skip orchestration entirely.
         const finalRedirect = this.challenge?.finalRedirect ?? false;
+        const continuousLoginHold = this.challenge?.continuousLoginHold ?? true;
         if (finalRedirect) {
             await multiTabOrchestrateResume();
         }
@@ -86,7 +88,10 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
         // Same-origin navigation suppress it, otherwise we'd look like we left mid-flow.
         const url = new URL(this.challenge!.to, window.location.origin);
 
-        if (finalRedirect && url.origin !== window.location.origin) {
+        if (
+            finalRedirect &&
+            shouldReleaseContinuousLogin(url, window.location.origin, continuousLoginHold)
+        ) {
             multiTabOrchestrateLeave();
         } else {
             suppressNextExitForSameOriginNavigation();

--- a/web/src/flow/tabs/continuous-login.ts
+++ b/web/src/flow/tabs/continuous-login.ts
@@ -1,0 +1,7 @@
+export function shouldReleaseContinuousLogin(
+    target: URL,
+    currentOrigin: string,
+    hold: boolean,
+): boolean {
+    return target.origin !== currentOrigin || !hold;
+}

--- a/web/test/unit/continuous-login.test.ts
+++ b/web/test/unit/continuous-login.test.ts
@@ -1,0 +1,33 @@
+import { shouldReleaseContinuousLogin } from "#flow/tabs/continuous-login";
+
+import { describe, expect, it } from "vitest";
+
+const origin = "https://authentik.example";
+
+describe("shouldReleaseContinuousLogin", () => {
+    it("returns true for a direct same-origin continuation", () => {
+        expect(
+            shouldReleaseContinuousLogin(
+                new URL("/application/saml/app/sso/", origin),
+                origin,
+                false,
+            ),
+        ).toBe(true);
+    });
+
+    it("returns false for a same-origin continuation that may require authorization", () => {
+        expect(
+            shouldReleaseContinuousLogin(
+                new URL("/application/saml/app/sso/", origin),
+                origin,
+                true,
+            ),
+        ).toBe(false);
+    });
+
+    it("returns true for an external continuation", () => {
+        expect(
+            shouldReleaseContinuousLogin(new URL("https://service.example/acs"), origin, true),
+        ).toBe(true);
+    });
+});


### PR DESCRIPTION
Same as https://github.com/goauthentik/authentik/pull/25417 but for 2026.5

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [ ] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
