### PR TITLE
Renew certificates in outposts

### DIFF
--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 type Config struct {
 	LogLevel string `yaml:"log_level" env:"AUTHENTIK_LOG_LEVEL, overwrite"`
 
@@ -12,10 +14,11 @@ type Config struct {
 	// Outpost specific config
 	// These are only relevant for proxy/ldap outposts, and cannot be set via YAML
 	// They are loaded via this config loader to support file:// schemas
-	AuthentikHost        string `env:"AUTHENTIK_HOST"`
-	AuthentikHostBrowser string `env:"AUTHENTIK_HOST_BROWSER"`
-	AuthentikToken       string `env:"AUTHENTIK_TOKEN"`
-	AuthentikInsecure    bool   `env:"AUTHENTIK_INSECURE"`
+	AuthentikHost                string        `env:"AUTHENTIK_HOST"`
+	AuthentikHostBrowser         string        `env:"AUTHENTIK_HOST_BROWSER"`
+	AuthentikToken               string        `env:"AUTHENTIK_TOKEN"`
+	AuthentikInsecure            bool          `env:"AUTHENTIK_INSECURE"`
+	AuthentikCertificateCacheTTL time.Duration `env:"AUTHENTIK_CERT_CACHE_TTL"`
 }
 
 type ListenConfig struct {

--- a/internal/outpost/ak/crypto.go
+++ b/internal/outpost/ak/crypto.go
@@ -5,40 +5,59 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"time"
 
 	log "github.com/sirupsen/logrus"
+	"goauthentik.io/internal/config"
+
 	api "goauthentik.io/packages/client-go"
 )
+
+type CertCacheEntry struct {
+	certificate *tls.Certificate
+	fingerprint string
+	refreshAt   time.Time
+}
 
 type CryptoStore struct {
 	api *api.CryptoAPIService
 
 	log *log.Entry
 
-	fingerprints map[string]string
-	certificates map[string]*tls.Certificate
+	certificates map[string]CertCacheEntry
+
+	cacheTTL time.Duration
 }
 
 func NewCryptoStore(cryptoApi *api.CryptoAPIService) *CryptoStore {
+	certificateCacheTTL := config.Get().AuthentikCertificateCacheTTL
+
+	if certificateCacheTTL == 0 {
+		certificateCacheTTL = 24 * time.Hour
+	}
+
 	return &CryptoStore{
 		api:          cryptoApi,
 		log:          log.WithField("logger", "authentik.outpost.cryptostore"),
-		fingerprints: make(map[string]string),
-		certificates: make(map[string]*tls.Certificate),
+		certificates: make(map[string]CertCacheEntry),
+		cacheTTL:     certificateCacheTTL,
 	}
 }
 
 func (cs *CryptoStore) AddKeypair(uuid string) error {
 	// Check if the cached fingerprint matches the certificate,
 	// if not, we re-fetch it
-	if sfp, ok := cs.fingerprints[uuid]; ok {
+	if sfp, ok := cs.certificates[uuid]; ok {
 		fp := cs.getFingerprint(uuid)
-		if sfp == fp {
+		if sfp.fingerprint == fp {
 			return nil
 		}
 	}
 	// reset fingerprint to force update
-	cs.fingerprints[uuid] = ""
+	if cert, ok := cs.certificates[uuid]; ok {
+		cert.fingerprint = ""
+	}
+
 	err := cs.Fetch(uuid)
 	if err != nil {
 		return err
@@ -57,8 +76,9 @@ func (cs *CryptoStore) getFingerprint(uuid string) string {
 
 func (cs *CryptoStore) Fetch(uuid string) error {
 	cfp := cs.getFingerprint(uuid)
-	if cfp == cs.fingerprints[uuid] {
+	if cert, ok := cs.certificates[uuid]; ok && cfp == cert.fingerprint {
 		cs.log.WithField("uuid", uuid).Debug("Fingerprint hasn't changed, not fetching cert")
+		cert.refreshAt = time.Now().Add(cs.cacheTTL)
 		return nil
 	}
 	cs.log.WithField("uuid", uuid).Info("Fetching certificate and private key")
@@ -90,19 +110,24 @@ func (cs *CryptoStore) Fetch(uuid string) error {
 			Leaf:        x509cert,
 		}
 	}
-	cs.certificates[uuid] = &tcert
-	cs.fingerprints[uuid] = cfp
+
+	cs.certificates[uuid] = CertCacheEntry{
+		certificate: &tcert,
+		fingerprint: cfp,
+		refreshAt:   time.Now().Add(cs.cacheTTL),
+	}
+
 	return nil
 }
 
 func (cs *CryptoStore) Get(uuid string) *tls.Certificate {
 	c, ok := cs.certificates[uuid]
-	if ok {
-		return c
+	if ok && c.refreshAt.After(time.Now()) {
+		return c.certificate
 	}
 	err := cs.Fetch(uuid)
 	if err != nil {
 		cs.log.WithError(err).Warning("failed to fetch certificate")
 	}
-	return cs.certificates[uuid]
+	return cs.certificates[uuid].certificate
 }


### PR DESCRIPTION
## Details

The outposts have to expire the certificates in the cache and fetch updated information. Otherwise, they continue to serve expired certificates even when the server already has newer ones.


### What does this PR change?

Add a TTL for certificate data and fetch new certificates after configured time.

### Why is this change needed?

Not updating certificates leads to incidents because of expired certificates.
Manually restarting the outposts is not reasonable since ACME certificates are short-lived and should auto-update.

### How was this tested?
Manual testing.

### Linked issues

Closes https://github.com/goauthentik/authentik/issues/25437

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
