### PR TITLE
outpost/proxy: avoid breaking header parsing in non-compliant backends

### DIFF
--- a/src/outpost/proxy/upstream.rs
+++ b/src/outpost/proxy/upstream.rs
@@ -28,13 +28,13 @@ pub(super) fn build_client(insecure: bool) -> Result<UpstreamClient> {
         builder.with_native_roots()?
     }
     .https_or_http()
-    .enable_http1()
-    .enable_http2()
+    .enable_all_versions()
     .build();
     // Forward the request's own `Host` upstream instead of deriving it from the
     // (internal) upstream URI authority. The proxy sets `Host` explicitly.
     Ok(Client::builder(TokioExecutor::new())
         .set_host(false)
+        .http1_title_case_headers(true)
         .build(connector))
 }
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

### Why is this change needed?

### How was this tested?

### Linked issues

closes #25410

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [ ] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
