### PR TITLE
website/docs: use new compose.yml file name

### DIFF
--- a/website/docs/install-config/automated-install.mdx
+++ b/website/docs/install-config/automated-install.mdx
@@ -44,7 +44,7 @@ Password hashes contain `$` characters which Docker Compose interprets as variab
 AUTHENTIK_BOOTSTRAP_PASSWORD_HASH='pbkdf2_sha256$1000000$xKKFuYtJEE27km09BD49x2$4+Z6j3utmouPF5mik0Z21L2P0og5IlmMmIJ46Tj3zCM='
 ```
 
-**In `docker-compose.yml`** (inline environment), escape each `$` with `$$`:
+**In `compose.yml`** (inline environment), escape each `$` with `$$`:
 
 ```yaml
 services:

--- a/website/docs/install-config/first-steps/index.mdx
+++ b/website/docs/install-config/first-steps/index.mdx
@@ -206,7 +206,7 @@ Review the following information to learn more about the basics of setting up au
 
 ### Modify the Docker Compose file
 
-Especially when you are just starting out with authentik, we recommend that you use the default `docker-compose.yml` file that comes with the download, instead of trying to write the file from scratch. After you have successfully installed, configured, and accessed authentik, you can edit the file to do more advanced configurations, as documented in the [Configuration section](../../install-config/configuration/configuration.mdx).
+Especially when you are just starting out with authentik, we recommend that you use the default `compose.yml` file that comes with the download, instead of trying to write the file from scratch. After you have successfully installed, configured, and accessed authentik, you can edit the file to do more advanced configurations, as documented in the [Configuration section](../../install-config/configuration/configuration.mdx).
 
 ### Reverse proxy
 

--- a/website/docs/install-config/install/docker-compose.mdx
+++ b/website/docs/install-config/install/docker-compose.mdx
@@ -106,7 +106,7 @@ For more information, refer to our [Email configuration](../email.mdx) documenta
 All internal operations use UTC. Times displayed in the UI are automatically localized for the user. Do not update or mount `/etc/timezone` or `/etc/localtime` in the authentik containers; it will cause problems with OAuth and SAML authentication, as seen this [GitHub issue](https://github.com/goauthentik/authentik/issues/3005).
 :::
 
-After you have downloaded the `docker-compose.yml` file, generated a password and a secret key, and optionally configured your global email, run these commands to retrieve and install the current version of authentik:
+After you have downloaded the `compose.yml` file, generated a password and a secret key, and optionally configured your global email, run these commands to retrieve and install the current version of authentik:
 
 ```shell
 docker compose pull


### PR DESCRIPTION
The file is now `compose.yml` rather than `docker-compose.yml` as of commit 646a0d3692bb09c6f265800d0e431b3920209702

<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?
In some of the documentation, there was still spots where it referenced `docker-compose.yml`.  This PR changes that to reflect the new `compose.yml` file rename.

### Why is this change needed?
To reflect the new changes and to not confuse users while they're reading the documentation.

### How was this tested?
Built docs & viewed them locally on my machine
```
make docs
cd website/build
python3 -m http.server 5173
```

### Linked issues
N/A

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [X] The documentation has been updated and formatted (`make docs`)
-   [X] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
