### PR TITLE
web/source/flows: fix flicker after webauthn

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -39,6 +39,10 @@ test-results
 # nyc test coverage
 .nyc_output
 
+# Vitest browser-mode failure artifacts
+.vitest-attachments
+**/__screenshots__/
+
 # Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -36,12 +36,12 @@ playwright-traces
 test-results
 *.lcov
 
+# Vitest browser mode writes these on a failing test
+.vitest-attachments/
+**/__screenshots__/
+
 # nyc test coverage
 .nyc_output
-
-# Vitest browser-mode failure artifacts
-.vitest-attachments
-**/__screenshots__/
 
 # Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/web/e2e/fixtures/FormFixture.ts
+++ b/web/e2e/fixtures/FormFixture.ts
@@ -68,7 +68,15 @@ export class FormFixture extends PageFixture {
         query: string,
         context: LocatorContext = this.page,
     ): Promise<Locator> => {
-        const searchInput = await this.findTextualInput(/search/i, context);
+        // Scoped to `ak-table-search` rather than the whole page: tables render either a
+        // plain searchbox or a query-language combobox, so the match has to stay
+        // role-based — but pages that mount a wizard (e.g. providers) also carry the
+        // dual-list-select search boxes for scopes, sources, and providers, which an
+        // unscoped match picks up and then fails strict mode on.
+        const searchInput = await this.findTextualInput(
+            /search/i,
+            context.locator("ak-table-search"),
+        );
         // We have to wait for the user to appear in the table,
         // but several UI elements will be rendered asynchronously.
         // We attempt several times to find the user to avoid flakiness.

--- a/web/e2e/fixtures/PasskeyFixture.ts
+++ b/web/e2e/fixtures/PasskeyFixture.ts
@@ -1,0 +1,80 @@
+import { PageFixture, PageFixtureInit } from "#e2e/fixtures/PageFixture";
+
+import { BrowserContext } from "@playwright/test";
+
+export interface PasskeyFixtureInit extends PageFixtureInit {
+    context: BrowserContext;
+}
+
+export interface PasskeyQuery {
+    /**
+     * Relying party id to filter by — for authentik, the host the flow runs on.
+     */
+    rpId?: string;
+    /**
+     * Base64url-encoded credential id to filter by.
+     */
+    id?: string;
+}
+
+/**
+ * Drives Playwright's virtual WebAuthn authenticator.
+ *
+ * A real ceremony needs hardware and a human touching it, neither of which exists in CI.
+ * The virtual authenticator answers `navigator.credentials.create()` and
+ * `navigator.credentials.get()` in-browser with a software keypair, so registration and
+ * login flows run end-to-end against a real authentik instance without either.
+ *
+ * @see {@link https://playwright.dev/docs/api/class-credentials | Playwright Credentials}
+ */
+export class PasskeyFixture extends PageFixture {
+    static fixtureName = "Passkey";
+
+    protected readonly context: BrowserContext;
+
+    #installed = false;
+
+    constructor({ page, testName, context }: PasskeyFixtureInit) {
+        super({ page, testName });
+
+        this.context = context;
+    }
+
+    /**
+     * Install the virtual authenticator into the browser context.
+     *
+     * Must be called **before** navigating to a page that runs a ceremony — the override is
+     * injected at document start, so a page that has already loaded keeps the real
+     * `navigator.credentials`. Calling this more than once is a no-op.
+     */
+    public install = async (): Promise<void> => {
+        if (this.#installed) return;
+
+        this.logger.info("Installing virtual WebAuthn authenticator...");
+
+        await this.context.credentials.install();
+
+        this.#installed = true;
+    };
+
+    /**
+     * Seed a discoverable credential without running a registration ceremony.
+     *
+     * Only useful when the server already knows the credential — for a fresh device, register
+     * through the UI instead so authentik records the device too.
+     */
+    public seed = async (rpId: string): Promise<string> => {
+        await this.install();
+
+        this.logger.info(`Seeding a credential for ${rpId}...`);
+
+        const { id } = await this.context.credentials.create(rpId);
+
+        return id;
+    };
+
+    /**
+     * The credentials the virtual authenticator currently holds.
+     */
+    public credentials = (query?: PasskeyQuery) => this.context.credentials.get(query);
+}

--- a/web/e2e/fixtures/SessionFixture.ts
+++ b/web/e2e/fixtures/SessionFixture.ts
@@ -38,7 +38,10 @@ export class SessionFixture extends PageFixture {
     public $usernameField = this.page.getByLabel("Username");
 
     public $passwordStage = this.page.locator("ak-stage-password");
-    public $passwordField = this.page.getByLabel("Password");
+    // Exact match: the password stage's "Show password" visibility toggle
+    // (ak-flow-password-input) also carries a "…password" accessible name, so a
+    // substring getByLabel("Password") matches two elements.
+    public $passwordField = this.page.getByLabel("Password", { exact: true });
 
     public $rememberMeCheckbox = this.page.getByRole("checkbox", {
         name: "Remember me on this device",
@@ -138,5 +141,21 @@ export class SessionFixture extends PageFixture {
 
     public async toLoginPage(page: Page = this.page) {
         await page.goto(SessionFixture.pathname);
+    }
+
+    /**
+     * Sign the current user out, landing back on the identification stage.
+     *
+     * Sign-out lives behind the user switcher's dropdown toggle rather than as a bare link,
+     * so the menu has to be opened before the item exists in the accessibility tree.
+     */
+    public async signOut(page: Page = this.page): Promise<void> {
+        this.logger.info("Signing out...");
+
+        await page.getByRole("button", { name: "Switch user" }).click();
+
+        await page.getByRole("menuitem", { name: "Sign out current user" }).click();
+
+        await this.$identificationStage.waitFor({ state: "visible" });
     }
 }

--- a/web/e2e/index.ts
+++ b/web/e2e/index.ts
@@ -4,6 +4,7 @@
 
 import { FormFixture } from "#e2e/fixtures/FormFixture";
 import { NavigatorFixture } from "#e2e/fixtures/NavigatorFixture";
+import { PasskeyFixture } from "#e2e/fixtures/PasskeyFixture";
 import { PointerFixture } from "#e2e/fixtures/PointerFixture";
 import { SessionFixture } from "#e2e/fixtures/SessionFixture";
 
@@ -18,6 +19,7 @@ interface E2EFixturesTestScope {
     session: SessionFixture;
     pointer: PointerFixture;
     form: FormFixture;
+    passkey: PasskeyFixture;
 }
 
 interface E2EWorkerScope {
@@ -39,5 +41,9 @@ export const test = base.extend<E2EFixturesTestScope, E2EWorkerScope>({
 
     pointer: async ({ page }, use, { title: testName }) => {
         await use(new PointerFixture({ page, testName }));
+    },
+
+    passkey: async ({ page, context }, use, { title: testName }) => {
+        await use(new PasskeyFixture({ page, testName, context }));
     },
 });

--- a/web/playwright.config.js
+++ b/web/playwright.config.js
@@ -25,6 +25,15 @@ export default defineConfig({
     forbidOnly: CI,
     retries: CI ? 1 : 0,
     workers: "50%",
+    // Every action here is a round trip to a real authentik instance that the other
+    // workers are hitting too — creating an entity is a POST plus a table refresh, not a
+    // local state change. Playwright's 5s assertion default is written for in-process UI
+    // and is optimistic for that, so raise the floor rather than sprinkling per-assertion
+    // timeouts. Individual steps that are slow for a known reason still say so locally.
+    timeout: 60_000,
+    expect: {
+        timeout: 15_000,
+    },
     maxFailures: CI ? 5 : 2,
     reporter: CI
         ? [

--- a/web/src/common/helpers/webauthn.ts
+++ b/web/src/common/helpers/webauthn.ts
@@ -2,6 +2,8 @@ import * as base64js from "base64-js";
 
 import { msg } from "@lit/localize";
 
+// #region WebAuthn helpers
+
 export function b64enc(buf: Uint8Array): string {
     return base64js.fromByteArray(buf).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }
@@ -29,6 +31,25 @@ export function assertWebAuthnSupported(scope = window): void {
 }
 
 /**
+ * Ensures that the given assertion is a {@linkcode https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential | PublicKeyCredential}
+ *
+ * @throws TypeError if the assertion is not a PublicKeyCredential
+ */
+export function ensurePublicKeyCredential(assertion?: Credential | null): PublicKeyCredential {
+    if (!assertion) {
+        throw new TypeError(msg("No assertion was returned by the authenticator"));
+    }
+
+    if (!(assertion instanceof PublicKeyCredential)) {
+        throw new TypeError(msg("The returned assertion was not a PublicKeyCredential"));
+    }
+
+    return assertion;
+}
+
+// #endregion
+
+/**
  * Predicate to determine if a given error originates from a user cancellation or timeout of a WebAuthn authentication ceremony.
  */
 export function isWebAuthnNotAllowedError(error: unknown): error is DOMException {
@@ -47,6 +68,8 @@ export async function isConditionalMediationAvailable(): Promise<boolean> {
     }
     return false;
 }
+
+// #region Transformations
 
 /**
  * Transforms items in the credentialCreateOptions generated on the server
@@ -165,3 +188,5 @@ export function transformAssertionForServer(newAssertion: PublicKeyCredential): 
         },
     };
 }
+
+// #endregion

--- a/web/src/common/purify.browser.test.ts
+++ b/web/src/common/purify.browser.test.ts
@@ -1,0 +1,34 @@
+import { CompiledMarkdownSanitizePolicy } from "#common/purify";
+
+import { describe, expect, it } from "vitest";
+
+const sanitize = (html: string) => String(CompiledMarkdownSanitizePolicy.createHTML(html));
+
+describe("CompiledMarkdownSanitizePolicy", () => {
+    it("keeps the new-tab attributes the anchor pipeline emits", () => {
+        // `rehypeAnchors` pairs `target` with `rel` on every external link.
+        // DOMPurify's default attribute list carries `rel` but not `target`,
+        // so dropping it here silently defeats the build-time transform.
+        const result = sanitize(
+            `<ak-md-a><a href="https://oauth.net/2/" target="_blank" rel="noopener noreferrer">OAuth 2.0</a></ak-md-a>`,
+        );
+
+        expect(result).toContain(`target="_blank"`);
+        expect(result).toContain(`rel="noopener noreferrer"`);
+    });
+
+    it("keeps the custom elements and parts the pipeline emits", () => {
+        const result = sanitize(`<ak-alert level="warning"><p part="body">Careful</p></ak-alert>`);
+
+        expect(result).toContain("ak-alert");
+        expect(result).toContain(`level="warning"`);
+        expect(result).toContain(`part="body"`);
+    });
+
+    it("still strips script handlers spliced in by a replacer", () => {
+        const result = sanitize(`<a href="#x" onclick="alert(1)">x</a><script>alert(2)</script>`);
+
+        expect(result).not.toContain("onclick");
+        expect(result).not.toContain("<script");
+    });
+});

--- a/web/src/common/purify.ts
+++ b/web/src/common/purify.ts
@@ -64,15 +64,20 @@ export const SanitizedTrustPolicy = trustedTypes.createPolicy("authentik-sanitiz
  * DOMPurify's default tag list would strip the custom elements our
  * pipeline emits (`<ak-alert>`, `<ak-md-a>`, `<ak-diagram>`) along with
  * the `part`/`level` attributes they rely on, so those are explicitly
- * allowed. Everything else — script handlers, unknown elements, unsafe
- * URLs injected via a replacer — is still removed.
+ * allowed. `target` is allowed for the same reason: `rehypeAnchors` opens
+ * external and cross-doc links in a new tab, and without it the attribute
+ * is dropped while the paired `rel` survives. Every browser we support
+ * implies `rel="noopener"` for `target="_blank"` regardless, so a replacer
+ * that injects a bare `target` cannot reach the opener. Everything else —
+ * script handlers, unknown elements, unsafe URLs injected via a replacer —
+ * is still removed.
  */
 export const CompiledMarkdownSanitizePolicy = trustedTypes.createPolicy("authentik-markdown", {
     createHTML: (untrustedHTML: string) => {
         return DOMPurify.sanitize(untrustedHTML, {
             RETURN_TRUSTED_TYPE: false,
             ADD_TAGS: ["ak-alert", "ak-md-a", "ak-diagram"],
-            ADD_ATTR: ["part", "level"],
+            ADD_ATTR: ["part", "level", "target"],
         });
     },
 });

--- a/web/src/components/ak-field-errors.ts
+++ b/web/src/components/ak-field-errors.ts
@@ -15,7 +15,7 @@ export type FieldErrorTuple = [fieldName: string, detail: string];
 export type ErrorProp = string | Error | ErrorDetail | ValidationError | FieldErrorTuple;
 
 export interface AKFormErrorsProps {
-    errors?: ErrorProp[];
+    errors?: ErrorProp[] | readonly ErrorProp[] | null;
 }
 
 function renderError(detail: string) {

--- a/web/src/flow/FlowExecutor.browser.test.ts
+++ b/web/src/flow/FlowExecutor.browser.test.ts
@@ -1,0 +1,36 @@
+import { FlowExecutor } from "#flow/FlowExecutor";
+
+import { ChallengeTypes, FlowsApi } from "@goauthentik/api";
+
+import { afterEach, expect, it, vi } from "vitest";
+
+afterEach(() => {
+    document.querySelectorAll("form[data-test-autosubmit]").forEach((form) => form.remove());
+    vi.restoreAllMocks();
+});
+
+it("preserves and disables the current stage during autosubmit navigation", async () => {
+    vi.spyOn(FlowsApi.prototype, "flowsExecutorSolve").mockResolvedValue({
+        component: "ak-stage-autosubmit",
+        url: "https://example.com/sso",
+        attrs: { SAMLResponse: "response" },
+    });
+    const formSubmit = vi
+        .spyOn(HTMLFormElement.prototype, "submit")
+        .mockImplementation(function submit(this: HTMLFormElement) {
+            this.dataset.testAutosubmit = "true";
+        });
+
+    const executor = new FlowExecutor();
+    const currentChallenge = {
+        component: "ak-stage-authenticator-validate",
+    } as ChallengeTypes;
+    executor.flowSlug = "test-flow";
+    executor.challenge = currentChallenge;
+
+    await executor.submit({ component: "ak-stage-authenticator-validate" }, { invisible: true });
+
+    expect(formSubmit).toHaveBeenCalledOnce();
+    expect(executor.challenge).toBe(currentChallenge);
+    expect(executor.inert).toBe(true);
+});

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -30,6 +30,7 @@ import { StageMapping } from "#flow/FlowExecutorStageFactory";
 import { flowMessages } from "#flow/messages";
 import { BaseStage } from "#flow/stages/base";
 import type { FlowChallengeResponseRequestBody, StageHost, SubmitOptions } from "#flow/types";
+import { submitAutosubmitChallenge } from "#flow/utils/autosubmit";
 
 import { ConsoleLogger } from "#logger/browser";
 
@@ -290,6 +291,11 @@ export class FlowExecutor extends WithBrandConfig(Interface) implements StageHos
             })
             .then((challenge) => {
                 window.dispatchEvent(new AKFlowAdvanceEvent());
+                if (challenge.component === "ak-stage-autosubmit") {
+                    submitAutosubmitChallenge(challenge);
+                    this.inert = true;
+                    return true;
+                }
                 this.challenge = challenge;
                 return !this.challenge.responseErrors;
             })

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.browser.test.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.browser.test.ts
@@ -1,0 +1,110 @@
+import "#flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+interface TestableWebAuthnStage extends HTMLElement {
+    authenticating: boolean;
+    challenge: object | null;
+    deviceChallenge: { challenge: object };
+    errorMessage?: string;
+    authenticate(): Promise<boolean>;
+    tryAuthenticating(): Promise<unknown>;
+    updateComplete: Promise<boolean>;
+    updated(changedProperties: Map<PropertyKey, unknown>): void;
+}
+
+const mounted: HTMLElement[] = [];
+
+function createStage(): TestableWebAuthnStage {
+    const stage = document.createElement(
+        "ak-stage-authenticator-validate-webauthn",
+    ) as unknown as TestableWebAuthnStage;
+    document.body.append(stage);
+    mounted.push(stage);
+
+    return stage;
+}
+
+afterEach(() => {
+    for (const element of mounted.splice(0)) element.remove();
+});
+
+describe("AuthenticatorValidateStageWebAuthn", () => {
+    it("renders as authenticating before the initial challenge update", () => {
+        const stage = createStage();
+        expect(stage.authenticating).toBe(true);
+    });
+
+    it("does not expose retry without an authentication error", async () => {
+        const stage = createStage();
+        stage.authenticating = false;
+        await stage.updateComplete;
+
+        expect(stage.shadowRoot?.textContent).toContain("Authenticating...");
+        expect(stage.shadowRoot?.textContent).not.toContain("Retry authentication");
+        expect(stage.shadowRoot?.querySelector("ak-empty-state")?.hasAttribute("loading")).toBe(
+            true,
+        );
+    });
+
+    it("remains authenticating after the flow advances successfully", async () => {
+        const stage = createStage();
+        stage.authenticating = false;
+        stage.authenticate = vi.fn().mockResolvedValue(true);
+        await stage.tryAuthenticating();
+        expect(stage.authenticating).toBe(true);
+    });
+
+    it("remains authenticating until a rejected assertion challenge is rendered", async () => {
+        const stage = createStage();
+        stage.authenticating = false;
+        stage.authenticate = vi.fn().mockResolvedValue(false);
+        await stage.tryAuthenticating();
+        expect(stage.authenticating).toBe(true);
+    });
+
+    it("stops authenticating when a new challenge contains response errors", () => {
+        const stage = createStage();
+        stage.authenticating = true;
+        stage.challenge = {
+            responseErrors: {
+                webauthn: [{ code: "invalid", string: "Invalid assertion" }],
+            },
+        };
+        stage.deviceChallenge = { challenge: { challenge: "AA==" } };
+        stage.authenticate = vi.fn().mockResolvedValue(true);
+        stage.updated(new Map([["challenge", {}]]));
+
+        expect(stage.authenticating).toBe(false);
+        expect(stage.errorMessage).toBe("Invalid assertion");
+        expect(stage.authenticate).not.toHaveBeenCalled();
+    });
+
+    it("uses a fallback for an empty response error", () => {
+        const stage = createStage();
+        stage.challenge = {
+            responseErrors: {
+                webauthn: [{ code: "invalid", string: "" }],
+            },
+        };
+        stage.deviceChallenge = { challenge: { challenge: "AA==" } };
+        stage.authenticate = vi.fn().mockResolvedValue(true);
+        stage.updated(new Map([["challenge", {}]]));
+
+        expect(stage.authenticating).toBe(false);
+        expect(stage.errorMessage).toBe("Failed to authenticate");
+    });
+
+    it("starts authentication again when the element receives a new challenge", () => {
+        const stage = createStage();
+        stage.authenticating = true;
+        stage.challenge = {};
+        stage.deviceChallenge = { challenge: { challenge: "AA==" } };
+        stage.errorMessage = "Previous error";
+        stage.authenticate = vi.fn().mockResolvedValue(true);
+        stage.updated(new Map([["challenge", {}]]));
+
+        expect(stage.authenticate).toHaveBeenCalledOnce();
+        expect(stage.errorMessage).toBeUndefined();
+    });
+});

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.browser.test.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.browser.test.ts
@@ -1,110 +1,187 @@
 import "#flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn";
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { StageHost } from "#flow/types";
 
-interface TestableWebAuthnStage extends HTMLElement {
-    authenticating: boolean;
-    challenge: object | null;
-    deviceChallenge: { challenge: object };
-    errorMessage?: string;
-    authenticate(): Promise<boolean>;
-    tryAuthenticating(): Promise<unknown>;
-    updateComplete: Promise<boolean>;
-    updated(changedProperties: Map<PropertyKey, unknown>): void;
+import {
+    AuthenticatorValidationChallenge,
+    DeviceChallenge,
+    DeviceClassesEnum,
+} from "@goauthentik/api";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const deviceChallenge: DeviceChallenge = {
+    deviceClass: DeviceClassesEnum.Webauthn,
+    deviceUid: "1",
+    challenge: { challenge: "AA==" },
+    lastUsed: new Date(),
+};
+
+function challengeOf(
+    overrides: Partial<AuthenticatorValidationChallenge> = {},
+): AuthenticatorValidationChallenge {
+    return {
+        pendingUser: "akadmin",
+        pendingUserAvatar: "",
+        deviceChallenges: [deviceChallenge],
+        configurationStages: [],
+        ...overrides,
+    };
+}
+
+/**
+ * A minimal stand-in for the credential an authenticator would hand back.
+ *
+ * The stage narrows the result with `instanceof PublicKeyCredential`, whose constructor is
+ * not callable, so the stand-in borrows the real prototype. Own properties are declared
+ * first, shadowing the prototype's getter-only accessors.
+ */
+function assertionOf(): PublicKeyCredential {
+    const bytes = () => Uint8Array.from([1, 2, 3]).buffer;
+
+    return Object.setPrototypeOf(
+        {
+            id: "credential-id",
+            type: "public-key",
+            rawId: bytes(),
+            response: {
+                clientDataJSON: bytes(),
+                authenticatorData: bytes(),
+                signature: bytes(),
+                userHandle: null,
+            },
+            getClientExtensionResults: () => ({}),
+        },
+        PublicKeyCredential.prototype,
+    ) as PublicKeyCredential;
 }
 
 const mounted: HTMLElement[] = [];
 
-function createStage(): TestableWebAuthnStage {
-    const stage = document.createElement(
-        "ak-stage-authenticator-validate-webauthn",
-    ) as unknown as TestableWebAuthnStage;
+let submit: ReturnType<typeof vi.fn>;
+let credentialsGet: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+    submit = vi.fn().mockResolvedValue(true);
+    credentialsGet = vi.fn().mockResolvedValue(assertionOf());
+
+    vi.stubGlobal("navigator", {
+        ...navigator,
+        credentials: { get: credentialsGet },
+    });
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+
+    for (const element of mounted.splice(0)) {
+        element.remove();
+    }
+});
+
+function createStage() {
+    const stage = document.createElement("ak-stage-authenticator-validate-webauthn");
+
+    stage.host = { submit } as unknown as StageHost;
+    stage.deviceChallenge = deviceChallenge;
+
     document.body.append(stage);
     mounted.push(stage);
 
     return stage;
 }
 
-afterEach(() => {
-    for (const element of mounted.splice(0)) element.remove();
-});
+const retryButton = (stage: HTMLElement) =>
+    Array.from(stage.shadowRoot?.querySelectorAll("button") ?? []).find((button) =>
+        button.textContent?.includes("Retry authentication"),
+    );
+
+const spinning = (stage: HTMLElement) =>
+    stage.shadowRoot?.querySelector("ak-empty-state")?.hasAttribute("loading") ?? false;
 
 describe("AuthenticatorValidateStageWebAuthn", () => {
-    it("renders as authenticating before the initial challenge update", () => {
+    it("renders a spinner and no retry before the first challenge", async () => {
         const stage = createStage();
-        expect(stage.authenticating).toBe(true);
-    });
 
-    it("does not expose retry without an authentication error", async () => {
-        const stage = createStage();
-        stage.authenticating = false;
         await stage.updateComplete;
 
         expect(stage.shadowRoot?.textContent).toContain("Authenticating...");
-        expect(stage.shadowRoot?.textContent).not.toContain("Retry authentication");
-        expect(stage.shadowRoot?.querySelector("ak-empty-state")?.hasAttribute("loading")).toBe(
-            true,
-        );
+        expect(spinning(stage)).toBe(true);
+        expect(retryButton(stage)).toBeUndefined();
     });
 
-    it("remains authenticating after the flow advances successfully", async () => {
+    it("submits the assertion and keeps spinning while the flow advances", async () => {
         const stage = createStage();
-        stage.authenticating = false;
-        stage.authenticate = vi.fn().mockResolvedValue(true);
-        await stage.tryAuthenticating();
-        expect(stage.authenticating).toBe(true);
+
+        stage.challenge = challengeOf();
+
+        await vi.waitFor(() => expect(submit).toHaveBeenCalledOnce());
+        await stage.updateComplete;
+
+        expect(credentialsGet).toHaveBeenCalledOnce();
+        expect(submit.mock.calls[0][0]).toMatchObject({ webauthn: { id: "credential-id" } });
+        expect(submit.mock.calls[0][1]).toEqual({ invisible: true });
+
+        // The regression: no retry button, no error, no flicker out of the spinner.
+        expect(retryButton(stage)).toBeUndefined();
+        expect(spinning(stage)).toBe(true);
     });
 
-    it("remains authenticating until a rejected assertion challenge is rendered", async () => {
+    it("offers retry when the ceremony fails", async () => {
+        credentialsGet.mockRejectedValue(new DOMException("denied", "NotAllowedError"));
+
         const stage = createStage();
-        stage.authenticating = false;
-        stage.authenticate = vi.fn().mockResolvedValue(false);
-        await stage.tryAuthenticating();
-        expect(stage.authenticating).toBe(true);
+
+        stage.challenge = challengeOf();
+
+        await vi.waitFor(() => expect(retryButton(stage)).toBeDefined());
+
+        expect(spinning(stage)).toBe(false);
+        expect(stage.shadowRoot?.textContent).toContain("cancelled or timed out");
+        expect(submit).not.toHaveBeenCalled();
     });
 
-    it("stops authenticating when a new challenge contains response errors", () => {
-        const stage = createStage();
-        stage.authenticating = true;
-        stage.challenge = {
-            responseErrors: {
-                webauthn: [{ code: "invalid", string: "Invalid assertion" }],
-            },
-        };
-        stage.deviceChallenge = { challenge: { challenge: "AA==" } };
-        stage.authenticate = vi.fn().mockResolvedValue(true);
-        stage.updated(new Map([["challenge", {}]]));
+    it("starts a single new ceremony per retry click", async () => {
+        credentialsGet.mockRejectedValue(new DOMException("denied", "NotAllowedError"));
 
-        expect(stage.authenticating).toBe(false);
-        expect(stage.errorMessage).toBe("Invalid assertion");
-        expect(stage.authenticate).not.toHaveBeenCalled();
+        const stage = createStage();
+
+        stage.challenge = challengeOf();
+
+        await vi.waitFor(() => expect(retryButton(stage)).toBeDefined());
+
+        credentialsGet.mockReturnValue(new Promise(() => {}));
+
+        retryButton(stage)!.click();
+        await stage.updateComplete;
+        retryButton(stage)?.click();
+
+        expect(credentialsGet).toHaveBeenCalledTimes(2);
     });
 
-    it("uses a fallback for an empty response error", () => {
+    it("renders a response error instead of re-running the ceremony", async () => {
         const stage = createStage();
-        stage.challenge = {
-            responseErrors: {
-                webauthn: [{ code: "invalid", string: "" }],
-            },
-        };
-        stage.deviceChallenge = { challenge: { challenge: "AA==" } };
-        stage.authenticate = vi.fn().mockResolvedValue(true);
-        stage.updated(new Map([["challenge", {}]]));
 
-        expect(stage.authenticating).toBe(false);
-        expect(stage.errorMessage).toBe("Failed to authenticate");
+        stage.challenge = challengeOf({
+            responseErrors: { webauthn: [{ code: "invalid", string: "Invalid assertion" }] },
+        });
+
+        await stage.updateComplete;
+
+        expect(stage.shadowRoot?.textContent).toContain("Invalid assertion");
+        expect(retryButton(stage)).toBeDefined();
+        expect(credentialsGet).not.toHaveBeenCalled();
     });
 
-    it("starts authentication again when the element receives a new challenge", () => {
+    it("falls back to a generic message for an empty response error", async () => {
         const stage = createStage();
-        stage.authenticating = true;
-        stage.challenge = {};
-        stage.deviceChallenge = { challenge: { challenge: "AA==" } };
-        stage.errorMessage = "Previous error";
-        stage.authenticate = vi.fn().mockResolvedValue(true);
-        stage.updated(new Map([["challenge", {}]]));
 
-        expect(stage.authenticate).toHaveBeenCalledOnce();
-        expect(stage.errorMessage).toBeUndefined();
+        stage.challenge = challengeOf({
+            responseErrors: { webauthn: [{ code: "invalid", string: "" }] },
+        });
+
+        await stage.updateComplete;
+
+        expect(stage.shadowRoot?.textContent).toContain("Failed to authenticate");
     });
 });

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
@@ -1,6 +1,6 @@
 import "#elements/EmptyState";
 
-import { parseAPIResponseError } from "#common/errors/network";
+import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
 import {
     assertWebAuthnSupported,
     ensurePublicKeyCredential,
@@ -11,7 +11,7 @@ import {
 
 import { SlottedTemplateResult } from "#elements/types";
 
-import { AKFormErrors, ErrorProp } from "#components/ak-field-errors";
+import { ErrorProp } from "#components/ak-field-errors";
 
 import { BaseDeviceStage } from "#flow/stages/authenticator_validate/base";
 
@@ -23,6 +23,7 @@ import {
 import { msg } from "@lit/localize";
 import { html, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { map } from "lit/directives/map.js";
 
 @customElement("ak-stage-authenticator-validate-webauthn")
 export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
@@ -92,6 +93,7 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
             return;
         }
 
+        this.errorMessages = null;
         this.authenticating = true;
 
         return this.#authenticate();
@@ -119,6 +121,7 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
             this.errorMessages = responseErrors.some((error) => error.string)
                 ? responseErrors
                 : [msg("Failed to authenticate")];
+
             this.authenticating = false;
 
             return;
@@ -142,6 +145,42 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
 
     // #region Rendering
 
+    protected renderAuthenticationActions(): SlottedTemplateResult {
+        const errorMessages = this.errorMessages ?? [];
+
+        if (!errorMessages.length && !this.showBackButton) {
+            return null;
+        }
+
+        return html`<fieldset class="ak-c-fieldset pf-c-form__group pf-m-action">
+            <legend class="sr-only">${msg("Form actions")}</legend>
+            ${errorMessages.length
+                ? html`<button
+                      class="pf-c-button pf-m-primary pf-m-block"
+                      @click=${this.tryAuthenticating}
+                      type="button"
+                  >
+                      ${msg("Retry authentication")}
+                  </button>`
+                : null}
+            ${this.renderReturnToDevicePicker()}
+        </fieldset>`;
+    }
+
+    protected renderAuthenticationStatus(): SlottedTemplateResult {
+        const { errorMessages } = this;
+
+        if (!errorMessages?.length) {
+            return html`<div>${msg("Authenticating...")}</div>`;
+        }
+
+        return map(errorMessages, (error) => {
+            const detail = pluckErrorDetail(error);
+
+            return html`<p role="alert">${detail}</p>`;
+        });
+    }
+
     protected override render(): SlottedTemplateResult {
         const hasError = !!this.errorMessages?.length;
         const loading = this.authenticating || !hasError;
@@ -149,27 +188,9 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
         return html`<form class="pf-c-form">
             ${this.renderUserInfo()}
             <ak-empty-state ?loading=${loading} icon="fa-times">
-                <div>
-                    ${this.errorMessages?.length
-                        ? AKFormErrors({ errors: this.errorMessages })
-                        : msg("Authenticating...")}
-                </div>
+                ${this.renderAuthenticationStatus()}
             </ak-empty-state>
-            ${hasError || this.showBackButton
-                ? html`<fieldset class="ak-c-fieldset pf-c-form__group pf-m-action">
-                      <legend class="sr-only">${msg("Form actions")}</legend>
-                      ${hasError
-                          ? html`<button
-                                class="pf-c-button pf-m-primary pf-m-block"
-                                @click=${this.tryAuthenticating}
-                                type="button"
-                            >
-                                ${msg("Retry authentication")}
-                            </button>`
-                          : null}
-                      ${this.renderReturnToDevicePicker()}
-                  </fieldset>`
-                : null}
+            ${this.renderAuthenticationActions()}
         </form>`;
     }
 

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
@@ -1,8 +1,9 @@
 import "#elements/EmptyState";
 
-import { parseAPIResponseError, pluckErrorDetail } from "#common/errors/network";
+import { parseAPIResponseError } from "#common/errors/network";
 import {
     assertWebAuthnSupported,
+    ensurePublicKeyCredential,
     isWebAuthnNotAllowedError,
     transformAssertionForServer,
     transformCredentialRequestOptions,
@@ -10,16 +11,17 @@ import {
 
 import { SlottedTemplateResult } from "#elements/types";
 
+import { AKFormErrors, ErrorProp } from "#components/ak-field-errors";
+
 import { BaseDeviceStage } from "#flow/stages/authenticator_validate/base";
 
 import {
     AuthenticatorValidationChallenge,
     AuthenticatorValidationChallengeResponseRequest,
-    DeviceChallenge,
 } from "@goauthentik/api";
 
 import { msg } from "@lit/localize";
-import { html, nothing, PropertyValues } from "lit";
+import { html, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 @customElement("ak-stage-authenticator-validate-webauthn")
@@ -28,37 +30,45 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
     AuthenticatorValidationChallengeResponseRequest
 > {
     @property({ attribute: false })
-    public deviceChallenge?: DeviceChallenge;
-
-    @property({ attribute: false })
-    public errorMessage?: string;
-
-    @property({ type: Boolean })
-    public showBackButton = false;
+    public errorMessages: readonly ErrorProp[] | null = null;
 
     @state()
     protected authenticating = true;
 
-    transformedCredentialRequestOptions?: PublicKeyCredentialRequestOptions;
+    protected transformedCredentialRequestOptions: PublicKeyCredentialRequestOptions | null = null;
+
+    /**
+     * Whether a {@linkcode https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential | PublicKeyCredential} ceremony should start once the pending render has committed.
+     *
+     * Reactive state is derived in {@linkcode willUpdate} so it lands in the same render, but the
+     * ceremony itself is a side effect and belongs after the DOM has been written.
+     */
+    protected ceremonyPending = false;
+
+    #authenticate = async (): Promise<unknown> => {
+        return this.authenticate().catch(async (error: unknown) => {
+            const reason = msg("Failed to authenticate");
+            this.logger.warn(reason, error);
+
+            const parsedError = await parseAPIResponseError(error);
+
+            this.errorMessages = [parsedError];
+            this.authenticating = false;
+
+            return false;
+        });
+    };
 
     protected async authenticate(): Promise<boolean> {
         assertWebAuthnSupported();
 
-        // request the authenticator to create an assertion signature using the
-        // credential private key
+        // Request the authenticator to create an assertion signature using the
+        // credential private key.
 
         const assertion = await navigator.credentials
-            .get({
-                publicKey: this.transformedCredentialRequestOptions,
-            })
-            .then((assertion) => {
-                if (!assertion) {
-                    throw new Error(msg("No assertion was returned by the authenticator"));
-                }
-
-                return assertion as PublicKeyCredential;
-            })
-            .catch((cause) => {
+            .get({ publicKey: this.transformedCredentialRequestOptions || undefined })
+            .then(ensurePublicKeyCredential)
+            .catch((cause: unknown) => {
                 if (isWebAuthnNotAllowedError(cause)) {
                     throw new Error(msg("Authentication was cancelled or timed out"), { cause });
                 }
@@ -69,47 +79,12 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
         // We now have an authentication assertion! encode the byte arrays contained
         // in the assertion data as strings for posting to the server
 
-        const transformedAssertionForServer = transformAssertionForServer(assertion);
-
         // Post the assertion to the server for verification.
         return this.host
-            ?.submit(
-                {
-                    webauthn: transformedAssertionForServer,
-                },
-                {
-                    invisible: true,
-                },
-            )
-            .catch((cause) => {
+            ?.submit({ webauthn: transformAssertionForServer(assertion) }, { invisible: true })
+            .catch((cause: unknown) => {
                 throw new Error(`Error when validating assertion on server`, { cause });
             });
-    }
-
-    public override updated(changedProperties: PropertyValues<this>): void {
-        super.updated(changedProperties);
-
-        if (changedProperties.has("challenge") && this.challenge) {
-            this.authenticating = false;
-            this.errorMessage = undefined;
-
-            // convert certain members of the PublicKeyCredentialRequestOptions into
-            // byte arrays as expected by the spec.
-            const credentialRequestOptions = this.deviceChallenge
-                ?.challenge as PublicKeyCredentialRequestOptions;
-            this.transformedCredentialRequestOptions =
-                transformCredentialRequestOptions(credentialRequestOptions);
-
-            const responseErrors = Object.values(this.challenge.responseErrors ?? {}).flat();
-            if (responseErrors.length > 0) {
-                this.errorMessage =
-                    responseErrors.map((error) => error.string).join(", ") ||
-                    msg("Failed to authenticate");
-                return;
-            }
-
-            this.tryAuthenticating();
-        }
     }
 
     protected tryAuthenticating = async (): Promise<unknown> => {
@@ -119,27 +94,66 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
 
         this.authenticating = true;
 
-        return this.authenticate().catch(async (error: unknown) => {
-            const reason = msg("Failed to authenticate");
-            this.logger.warn(reason, error);
-
-            const parsedError = await parseAPIResponseError(error);
-
-            this.errorMessage = pluckErrorDetail(parsedError, reason);
-            this.authenticating = false;
-
-            return false;
-        });
+        return this.#authenticate();
     };
 
+    // #region Lifecycle
+
+    protected override willUpdate(changedProperties: PropertyValues<this>): void {
+        super.willUpdate(changedProperties);
+
+        if (!changedProperties.has("challenge") || !this.challenge) return;
+
+        this.errorMessages = null;
+
+        // convert certain members of the PublicKeyCredentialRequestOptions into
+        // byte arrays as expected by the spec.
+        const credentialRequestOptions = this.deviceChallenge
+            ?.challenge as PublicKeyCredentialRequestOptions;
+        this.transformedCredentialRequestOptions =
+            transformCredentialRequestOptions(credentialRequestOptions);
+
+        const responseErrors = Object.values(this.challenge.responseErrors ?? {}).flat();
+
+        if (responseErrors.length) {
+            this.errorMessages = responseErrors.some((error) => error.string)
+                ? responseErrors
+                : [msg("Failed to authenticate")];
+            this.authenticating = false;
+
+            return;
+        }
+
+        this.ceremonyPending = true;
+        this.authenticating = true;
+    }
+
+    public override updated(changedProperties: PropertyValues<this>): void {
+        super.updated(changedProperties);
+
+        if (!this.ceremonyPending) return;
+
+        this.ceremonyPending = false;
+
+        this.#authenticate();
+    }
+
+    // #endregion
+
+    // #region Rendering
+
     protected override render(): SlottedTemplateResult {
-        const hasError = this.errorMessage !== undefined;
+        const hasError = !!this.errorMessages?.length;
         const loading = this.authenticating || !hasError;
 
         return html`<form class="pf-c-form">
             ${this.renderUserInfo()}
-            <ak-empty-state ?loading="${loading}" icon="fa-times">
-                <span>${hasError ? this.errorMessage : msg("Authenticating...")}</span>
+            <ak-empty-state ?loading=${loading} icon="fa-times">
+                <div>
+                    ${this.errorMessages?.length
+                        ? AKFormErrors({ errors: this.errorMessages })
+                        : msg("Authenticating...")}
+                </div>
             </ak-empty-state>
             ${hasError || this.showBackButton
                 ? html`<fieldset class="ak-c-fieldset pf-c-form__group pf-m-action">
@@ -152,12 +166,14 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
                             >
                                 ${msg("Retry authentication")}
                             </button>`
-                          : nothing}
+                          : null}
                       ${this.renderReturnToDevicePicker()}
                   </fieldset>`
-                : nothing}
+                : null}
         </form>`;
     }
+
+    // #endregion
 }
 
 declare global {

--- a/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
+++ b/web/src/flow/stages/authenticator_validate/AuthenticatorValidateStageWebAuthn.ts
@@ -37,7 +37,7 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
     public showBackButton = false;
 
     @state()
-    protected authenticating = false;
+    protected authenticating = true;
 
     transformedCredentialRequestOptions?: PublicKeyCredentialRequestOptions;
 
@@ -90,12 +90,23 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
         super.updated(changedProperties);
 
         if (changedProperties.has("challenge") && this.challenge) {
+            this.authenticating = false;
+            this.errorMessage = undefined;
+
             // convert certain members of the PublicKeyCredentialRequestOptions into
             // byte arrays as expected by the spec.
             const credentialRequestOptions = this.deviceChallenge
                 ?.challenge as PublicKeyCredentialRequestOptions;
             this.transformedCredentialRequestOptions =
                 transformCredentialRequestOptions(credentialRequestOptions);
+
+            const responseErrors = Object.values(this.challenge.responseErrors ?? {}).flat();
+            if (responseErrors.length > 0) {
+                this.errorMessage =
+                    responseErrors.map((error) => error.string).join(", ") ||
+                    msg("Failed to authenticate");
+                return;
+            }
 
             this.tryAuthenticating();
         }
@@ -108,34 +119,32 @@ export class AuthenticatorValidateStageWebAuthn extends BaseDeviceStage<
 
         this.authenticating = true;
 
-        return this.authenticate()
-            .catch(async (error: unknown) => {
-                const reason = msg("Failed to authenticate");
-                this.logger.warn(reason, error);
+        return this.authenticate().catch(async (error: unknown) => {
+            const reason = msg("Failed to authenticate");
+            this.logger.warn(reason, error);
 
-                const parsedError = await parseAPIResponseError(error);
+            const parsedError = await parseAPIResponseError(error);
 
-                this.errorMessage = pluckErrorDetail(parsedError, reason);
-            })
-            .finally(() => {
-                this.authenticating = false;
-            });
+            this.errorMessage = pluckErrorDetail(parsedError, reason);
+            this.authenticating = false;
+
+            return false;
+        });
     };
 
     protected override render(): SlottedTemplateResult {
+        const hasError = this.errorMessage !== undefined;
+        const loading = this.authenticating || !hasError;
+
         return html`<form class="pf-c-form">
             ${this.renderUserInfo()}
-            <ak-empty-state ?loading="${this.authenticating}" icon="fa-times">
-                <span
-                    >${this.authenticating
-                        ? msg("Authenticating...")
-                        : this.errorMessage || msg("Loading")}</span
-                >
+            <ak-empty-state ?loading="${loading}" icon="fa-times">
+                <span>${hasError ? this.errorMessage : msg("Authenticating...")}</span>
             </ak-empty-state>
-            ${!this.authenticating || this.showBackButton
+            ${hasError || this.showBackButton
                 ? html`<fieldset class="ak-c-fieldset pf-c-form__group pf-m-action">
                       <legend class="sr-only">${msg("Form actions")}</legend>
-                      ${!this.authenticating
+                      ${hasError
                           ? html`<button
                                 class="pf-c-button pf-m-primary pf-m-block"
                                 @click=${this.tryAuthenticating}

--- a/web/src/flow/utils/autosubmit.browser.test.ts
+++ b/web/src/flow/utils/autosubmit.browser.test.ts
@@ -1,0 +1,31 @@
+import { submitAutosubmitChallenge } from "#flow/utils/autosubmit";
+
+import { afterEach, expect, it, vi } from "vitest";
+
+afterEach(() => {
+    document.querySelectorAll("form[data-test-autosubmit]").forEach((form) => form.remove());
+    vi.restoreAllMocks();
+});
+
+it("submits an autosubmit challenge using a native form", () => {
+    const submit = vi.spyOn(HTMLFormElement.prototype, "submit").mockImplementation(function submit(
+        this: HTMLFormElement,
+    ) {
+        this.dataset.testAutosubmit = "true";
+    });
+
+    submitAutosubmitChallenge({
+        component: "ak-stage-autosubmit",
+        url: "https://example.com/sso",
+        attrs: { RelayState: "state", SAMLResponse: "response", submit: "value" },
+    });
+
+    const submittedForm = submit.mock.instances[0] as unknown as HTMLFormElement;
+    expect(submittedForm.action).toBe("https://example.com/sso");
+    expect(submittedForm.method).toBe("post");
+    expect(Object.fromEntries(new FormData(submittedForm))).toEqual({
+        RelayState: "state",
+        SAMLResponse: "response",
+        submit: "value",
+    });
+});

--- a/web/src/flow/utils/autosubmit.ts
+++ b/web/src/flow/utils/autosubmit.ts
@@ -1,0 +1,19 @@
+import { AutosubmitChallenge } from "@goauthentik/api";
+
+export function submitAutosubmitChallenge(challenge: AutosubmitChallenge): void {
+    const form = document.createElement("form");
+    form.action = challenge.url;
+    form.method = "post";
+    form.hidden = true;
+
+    for (const [name, value] of Object.entries(challenge.attrs)) {
+        const input = document.createElement("input");
+        input.type = "hidden";
+        input.name = name;
+        input.value = value;
+        form.append(input);
+    }
+
+    document.body.append(form);
+    HTMLFormElement.prototype.submit.call(form);
+}

--- a/web/test/browser/101-session-lifecycle.test.ts
+++ b/web/test/browser/101-session-lifecycle.test.ts
@@ -90,14 +90,9 @@ test.describe("Session Lifecycle", () => {
         });
 
         await test.step("Sign out and verify username is remembered", async () => {
-            const signOutLink = page.getByRole("link", { name: "Sign out" });
-
-            await expect(signOutLink, "Sign out link is visible").toBeVisible();
-
-            await signOutLink.click();
+            await session.signOut();
 
             await navigator.waitForPathname("/if/flow/default-authentication-flow/?next=%2F");
-            await session.$identificationStage.waitFor({ state: "visible" });
 
             const passwordEmbedded = await session.$passwordField.isVisible();
 

--- a/web/test/browser/102-passkeys.test.ts
+++ b/web/test/browser/102-passkeys.test.ts
@@ -1,0 +1,171 @@
+import { expect, test } from "#e2e";
+import { randomName } from "#e2e/utils/generators";
+
+import { IDGenerator } from "@goauthentik/core/id";
+import { series } from "@goauthentik/core/promises";
+
+import { snakeCase } from "change-case";
+
+const CREDENTIALS_SETTINGS = `/if/user/#/settings;${JSON.stringify({ page: "page-credentials" })}`;
+
+test.describe("Passkeys", () => {
+    const usernames = new Map<string, string>();
+    const displayNames = new Map<string, string>();
+    const passwords = new Map<string, string>();
+
+    //#region Lifecycle
+
+    test.beforeEach("Prepare enrollee", async ({ passkey, session }, { testId }) => {
+        const seed = IDGenerator.randomID(6);
+        const displayName = `${randomName(seed)} (${seed})`;
+
+        displayNames.set(testId, displayName);
+        usernames.set(testId, snakeCase(displayName));
+        passwords.set(testId, `passkey-${IDGenerator.randomID(12)}`);
+
+        // Before any navigation — the override is injected at document start, so a page
+        // that has already loaded keeps the real `navigator.credentials`.
+        await test.step("Install virtual authenticator", () => passkey.install());
+
+        await test.step("Authenticate as admin", () =>
+            session.login({ to: "/if/admin/#/identity/users" }));
+    });
+
+    //#endregion
+
+    //#region Tests
+
+    // A passkey is enrolled against a throwaway user rather than the shared admin: a device
+    // on `test-admin` would push every other suite's `session.login()` through the MFA
+    // validation stage, which they have no authenticator to answer.
+
+    test("Enroll a passkey and sign in with it", async ({
+        session,
+        navigator,
+        form,
+        pointer,
+        passkey,
+        page,
+    }, testInfo) => {
+        const username = usernames.get(testInfo.testId)!;
+        const displayName = displayNames.get(testInfo.testId)!;
+        const password = passwords.get(testInfo.testId)!;
+
+        const { fill, search } = form;
+        const { click } = pointer;
+
+        await test.step("Create the user", async () => {
+            const dialog = page.getByRole("dialog", { name: "New User Wizard" });
+
+            await expect(dialog, "Dialog is initially closed").toBeHidden();
+
+            await click("New User", "button");
+
+            await expect(dialog, "Dialog opens").toBeVisible();
+
+            // TODO: `force` matches the users suite — slotted button content reads as
+            // invisible to Playwright until native dialog modals land.
+            await dialog.getByRole("radio", { name: "Internal" }).click({ force: true });
+
+            await series(
+                [fill, /^Username/, username, dialog],
+                [fill, /^Display Name/, displayName, dialog],
+                [fill, /^Email Address/, `${username}@example.com`, dialog],
+                [fill, /^Path/, "users", dialog],
+            );
+
+            await dialog.getByRole("button", { name: "Create" }).click();
+
+            await expect(dialog, "Dialog closes after creating user").toBeHidden();
+        });
+
+        await test.step("Set the user's password", async () => {
+            const $user = await search(username);
+
+            await expect($user, "User is visible").toBeVisible();
+
+            await $user.getByRole("link", { name: `View details for ${displayName}` }).click();
+
+            const dialog = page.getByRole("dialog", { name: /password/i });
+
+            await click("Set password", "button");
+
+            await expect(dialog, "Password dialog opens").toBeVisible();
+
+            await fill("New Password", password, dialog);
+
+            await dialog.getByRole("button", { name: "Set Password" }).click();
+
+            await expect(dialog, "Password dialog closes after saving").toBeHidden();
+        });
+
+        await test.step("Sign out of the admin session", () => session.signOut());
+
+        await test.step("Sign in as the enrollee", () =>
+            session.login({ username, password, to: "/if/user/" }));
+
+        await test.step("Open the credentials settings", async () => {
+            // Not `navigator.navigate`: the MFA table writes its own page state into the
+            // route as soon as it mounts, so the URL never settles on what we asked for.
+            // The enroll control appearing is the meaningful wait.
+            await page.goto(CREDENTIALS_SETTINGS);
+
+            await expect(
+                page.getByRole("button", { name: "Enroll" }),
+                "Enroll control is visible",
+            ).toBeVisible({ timeout: 15_000 });
+        });
+
+        await test.step("Enroll a WebAuthn device", async () => {
+            await click("Enroll", "button");
+
+            // The menu item links straight into the `default-authenticator-webauthn-setup`
+            // flow, which returns here via `?next=`.
+            await click("WebAuthn device", "menuitem");
+
+            await navigator.waitForPathname("/if/user/");
+        });
+
+        const $device = await test.step("Confirm the device was recorded", async () => {
+            const row = page.getByRole("row").filter({ hasText: /webauthn/i });
+
+            await expect(row, "WebAuthn device is listed").toBeVisible({ timeout: 15_000 });
+
+            return row;
+        });
+
+        await expect($device, "Device row names the authenticator type").toContainText(/webauthn/i);
+
+        await test.step("Confirm the authenticator holds the credential", async () => {
+            const credentials = await passkey.credentials();
+
+            expect(credentials, "Virtual authenticator holds one credential").toHaveLength(1);
+        });
+
+        await test.step("Sign out of the enrollee session", () => session.signOut());
+
+        await test.step("Sign back in through the passkey challenge", async () => {
+            // No interaction with the WebAuthn stage: the virtual authenticator answers the
+            // assertion and the flow advances on its own, too fast to observe by rendering.
+            // Landing on `/if/user/` alone would also pass if the MFA stage never fired, so
+            // watch for the assertion actually reaching the flow executor.
+            const assertionSubmitted = page.waitForRequest(
+                (request) =>
+                    request.method() === "POST" &&
+                    request.url().includes("/api/v3/flows/executor/default-authentication-flow/") &&
+                    (request.postData() ?? "").includes("webauthn"),
+            );
+
+            await session.login({ username, password, to: "/if/user/" });
+
+            await assertionSubmitted;
+
+            await expect(
+                page.getByRole("button", { name: "Switch user" }),
+                "Enrollee is authenticated after the passkey challenge",
+            ).toBeVisible();
+        });
+    });
+
+    //#endregion
+});

--- a/web/test/browser/600-providers.test.ts
+++ b/web/test/browser/600-providers.test.ts
@@ -17,7 +17,10 @@ test.describe("Provider Wizard", () => {
 
         const dialog = page.getByRole("dialog", { name: "New Provider Wizard" });
 
-        await test.step("Authenticate", async () => session.login());
+        await test.step("Authenticate", async () =>
+            session.login({
+                to: "/if/admin/#/core/providers",
+            }));
 
         await test.step("Navigate to provider wizard", async () => {
             await expect(dialog, "Dialog is initially closed").toBeHidden();

--- a/web/test/browser/900-invitations.test.ts
+++ b/web/test/browser/900-invitations.test.ts
@@ -28,7 +28,7 @@ test.describe("Invitation form", () => {
     // CodeMirror editor must not block submission.
     test("Create invitation with custom attributes", async ({ page, form, pointer }, testInfo) => {
         const name = invitationNames.get(testInfo.testId)!;
-        const { fill } = form;
+        const { fill, selectSearchValue } = form;
         const { click } = pointer;
 
         const $dialog = page.getByRole("dialog", { name: "New Invitation" });
@@ -46,8 +46,7 @@ test.describe("Invitation form", () => {
         await test.step("Fill invitation details", async () => {
             await fill("Invitation Name", name, $dialog);
 
-            await $dialog.getByPlaceholder("Select a flow...").click();
-            await page.getByRole("option", { name: /default-source-enrollment/ }).click();
+            await selectSearchValue("Flow", /default-source-enrollment/, $dialog);
         });
 
         await test.step("Edit custom attributes (#22637)", async () => {
@@ -89,9 +88,13 @@ test.describe("Invitation form", () => {
         form,
         pointer,
     }, testInfo) => {
+        // The blueprint import in the middle of this test eats most of the default
+        // budget on its own; the remaining steps still need room after it.
+        test.setTimeout(90_000);
+
         const name = invitationNames.get(testInfo.testId)!;
         const seed = name.replace("invite-", "");
-        const { fill } = form;
+        const { fill, selectSearchValue } = form;
         const { click } = pointer;
 
         const $dialog = page.getByRole("dialog", { name: "New Invitation" });
@@ -105,26 +108,37 @@ test.describe("Invitation form", () => {
         });
 
         await test.step("Open the stacked enrollment flow form via the flow select", async () => {
-            await $dialog.getByPlaceholder("Select a flow...").click();
-
-            await page.getByRole("option", { name: "Create a new enrollment flow" }).click();
+            await selectSearchValue("Flow", /Create a new enrollment flow/, $dialog);
 
             await expect($flowDialog, "Enrollment flow form opens on top").toBeVisible();
         });
 
         await test.step("Create the enrollment flow and invitation stage", async () => {
             await fill("Flow Name", `Invite Flow ${seed}`, $flowDialog);
+            // Seed the slug too. It defaults to a fixed `enrollment-with-invitation`, and
+            // the blueprint import upserts by slug — so without this every run targets the
+            // same flow record and the assertion below reads back a previous run's name.
+            await fill("Flow Slug", `invite-flow-${seed}`, $flowDialog);
             await fill("Invitation Stage Name", `invite-stage-${seed}`, $flowDialog);
 
             await click("Create Enrollment Flow", "button", $flowDialog);
 
-            await expect($flowDialog, "Flow form closes after creation").toBeHidden();
+            // Creating the flow posts a blueprint import, which builds the flow, the
+            // invitation stage, and the binding between them in one synchronous request.
+            // That runs well past the 5s default.
+            await expect($flowDialog, "Flow form closes after creation").toBeHidden({
+                timeout: 20_000,
+            });
             await expect($dialog, "Invitation form is still open underneath").toBeVisible();
         });
 
         await test.step("The newly created flow is selected", async () => {
+            // Scoped to the view rather than the placeholder: `ak-flow-search` composes
+            // three elements deep and each level carries a real input with the same
+            // placeholder — the host, `ak-search-select`'s hidden value input holding the
+            // flow UUID, and the view's display input. Only the last shows the label.
             await expect(
-                $dialog.getByPlaceholder("Select a flow..."),
+                $dialog.locator("ak-search-select-view").getByRole("textbox"),
                 "Flow search adopts the newly created flow",
             ).toHaveValue(new RegExp(seed));
         });

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -73,6 +73,7 @@ export default defineConfig({
                     name: "Browser Tests",
                     browser: {
                         enabled: true,
+                        headless: true,
                         provider: playwright(),
 
                         instances: [


### PR DESCRIPTION
## Summary
During WebAuthn authentication followed by an autosubmit redirect, the UI briefly replaced the authentication spinner with “Loading” or “Retry authentication.” This caused a distracting flicker during successful sign-in and most noticeable with a prompt stage after webauthn.
## This change:
- Keeps WebAuthn in its authenticating state unless a real error occurs.
- Preserves the current stage while autosubmit navigation begins.
- Disables interaction during terminal navigation.
- Leaves direct autosubmit behavior unchanged.
- Adds regression coverage for these transitions.

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [ ] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
