### PR TITLE
blueprints: handle absent blueprint references

### DIFF
--- a/authentik/blueprints/tests/test_v1_state.py
+++ b/authentik/blueprints/tests/test_v1_state.py
@@ -3,9 +3,12 @@
 from django.test import TransactionTestCase
 
 from authentik.blueprints.v1.importer import Importer
-from authentik.flows.models import Flow
+from authentik.flows.models import Flow, FlowDesignation, FlowStageBinding
 from authentik.lib.generators import generate_id
 from authentik.lib.tests.utils import load_fixture
+from authentik.stages.identification.models import IdentificationStage
+from authentik.stages.password.models import PasswordStage
+from authentik.stages.user_login.models import UserLoginStage
 
 
 class TestBlueprintsV1State(TransactionTestCase):
@@ -81,3 +84,61 @@ class TestBlueprintsV1State(TransactionTestCase):
         self.assertTrue(importer.apply())
         flow: Flow = Flow.objects.filter(slug=flow_slug).first()
         self.assertIsNone(flow)
+
+    def test_state_absent_with_key_of(self):
+        """Test state absent with KeyOf references"""
+        password_stage = PasswordStage.objects.create(name=generate_id(), backends=[])
+        identification_stage = IdentificationStage.objects.create(
+            name=generate_id(), password_stage=password_stage
+        )
+        import_yaml = f"""
+            version: 1
+            entries:
+                - model: authentik_stages_password.passwordstage
+                  id: password-stage
+                  state: absent
+                  identifiers:
+                      name: {password_stage.name}
+                - model: authentik_stages_identification.identificationstage
+                  state: absent
+                  identifiers:
+                      name: {identification_stage.name}
+                  attrs:
+                      password_stage: !KeyOf password-stage
+        """
+
+        importer = Importer.from_string(import_yaml)
+        self.assertTrue(importer.validate()[0])
+        self.assertTrue(importer.apply())
+        self.assertFalse(PasswordStage.objects.filter(pk=password_stage.pk).exists())
+        self.assertFalse(IdentificationStage.objects.filter(pk=identification_stage.pk).exists())
+
+    def test_state_absent_with_missing_flow_stage_binding(self):
+        """Test state absent with a missing flow stage binding"""
+        flow = Flow.objects.create(
+            name=generate_id(),
+            slug=generate_id(),
+            title=generate_id(),
+            designation=FlowDesignation.AUTHENTICATION,
+        )
+        stage = UserLoginStage.objects.create(name=generate_id())
+        FlowStageBinding.objects.create(target=flow, stage=stage, order=0)
+        import_yaml = f"""
+            version: 1
+            entries:
+                - model: authentik_flows.flowstagebinding
+                  state: absent
+                  identifiers:
+                      target: {flow.pk}
+                      stage: {stage.pk}
+                      order: 0
+        """
+
+        importer = Importer.from_string(import_yaml)
+        self.assertTrue(importer.validate()[0])
+        self.assertTrue(importer.apply())
+        self.assertFalse(FlowStageBinding.objects.filter(target=flow, stage=stage).exists())
+
+        importer = Importer.from_string(import_yaml)
+        self.assertTrue(importer.validate()[0])
+        self.assertTrue(importer.apply())

--- a/authentik/blueprints/v1/importer.py
+++ b/authentik/blueprints/v1/importer.py
@@ -443,6 +443,7 @@ class Importer:
                 self._apply_permissions(instance, entry)
             elif state == BlueprintEntryDesiredState.ABSENT:
                 instance: Model | None = serializer.instance
+                entry._state = BlueprintEntryState(instance)
                 if instance and instance.pk:
                     instance.delete()
                     self.logger.debug("Deleted model", mode=instance)


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?
Stores the resolved instance state for blueprint entries marked as `absent` before deleting the instance.

Adds regression coverage for:

- Deleting entries that reference another absent entry through `!KeyOf`.
- Reapplying deletion of an already-missing flow stage binding.

### Why is this change needed?
`!KeyOf` resolves references using the state stored on another blueprint entry. Entries marked as `absent` did not store their resolved instance before deletion, causing later entries referencing them to fail during blueprint application.

Recording the entry state before deletion keeps reference resolution consistent with entries in other states and allows absent blueprints to be applied idempotently.

### How was this tested?

### Linked issues
closes #25329
<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
