### PR TITLE
flows: show the user's name, not their username, on the user chip

### DIFF
--- a/authentik/flows/challenge.py
+++ b/authentik/flows/challenge.py
@@ -98,6 +98,9 @@ class WithUserInfoChallenge(Challenge):
     """Challenge base which shows some user info"""
 
     pending_user = CharField(allow_blank=True)
+    # What to show a human. `pending_user` has to stay the username because the
+    # web UI feeds it to a hidden autocomplete input for password managers.
+    pending_user_display = CharField(allow_blank=True, required=False)
     pending_user_avatar = CharField()
 
 

--- a/authentik/flows/stage.py
+++ b/authentik/flows/stage.py
@@ -221,6 +221,11 @@ class ChallengeStageView(StageView):
                 # If there's no user set, an error is raised later.
                 if user := self.get_pending_user(for_display=True):
                     challenge.initial_data["pending_user"] = user.username
+                    # Directories often make the login an opaque identifier: a
+                    # short uid, an employee number. Showing that back to
+                    # somebody who has just typed their e-mail address is
+                    # needlessly cold, and sometimes unrecognisable.
+                    challenge.initial_data["pending_user_display"] = user.name or user.username
                 challenge.initial_data["pending_user_avatar"] = DEFAULT_AVATAR
                 if not isinstance(user, AnonymousUser):
                     challenge.initial_data["pending_user_avatar"] = get_avatar(user, self.request)

--- a/web/src/flow/FormStatic.ts
+++ b/web/src/flow/FormStatic.ts
@@ -59,13 +59,13 @@ export interface FlowUserDetailsProps {
 }
 
 export const FlowUserDetails: LitFC<FlowUserDetailsProps> = ({ challenge }) => {
-    const { pendingUserAvatar, pendingUser, flowInfo } = challenge || {};
+    const { pendingUserAvatar, pendingUser, pendingUserDisplay, flowInfo } = challenge || {};
     return guard(
-        [pendingUserAvatar, pendingUser, flowInfo],
+        [pendingUserAvatar, pendingUser, pendingUserDisplay, flowInfo],
         () =>
             html`<ak-form-static
                 .avatar=${ifPresent(pendingUserAvatar)}
-                username=${ifPresent(pendingUser)}
+                username=${ifPresent(pendingUserDisplay || pendingUser)}
             >
                 ${flowInfo?.cancelUrl
                     ? html`


### PR DESCRIPTION
### What this changes

After the identification stage matches an account, the user chip shows
`user.username`. This adds a sibling field, `pending_user_display`, carrying
`user.name or user.username`, and renders that instead.

`pending_user` is deliberately left alone. `web/src/flow/stages/base.ts` feeds it
to a hidden `autocomplete="username"` input, and the comment above the assignment
in `stage.py` already says as much — *"this field is only used by password
managers"*. Changing it would break autofill. The two uses had simply been
sharing one field.

### Why

On directories where the login is an opaque identifier — a short uid, an
employee number — somebody who has just typed their e-mail address is answered
with a string they may not recognise as themselves. `user.name` is already
populated by any source that maps a display name, and is already shown elsewhere
in the interface.

The fallback keeps today's behaviour wherever `name` is empty.

### Files

| File | Change |
| --- | --- |
| `authentik/flows/challenge.py` | new optional field on `WithUserInfoChallenge` |
| `authentik/flows/stage.py` | populate it next to `pending_user` |
| `web/src/flow/FormStatic.ts` | render it, falling back to `pending_user` |

### Not done in this branch

`make gen-build` — the change adds an API field, so `schema.yml` and the
generated TypeScript client need regenerating. I do not have a dev environment
able to run it; happy to push the generated files if you would rather have them
in the same branch, or to have CI regenerate them.

### Compatibility

The field is `required=False, allow_blank=True`. An older web build ignores it
and keeps showing `pending_user`; a newer web build against an older core falls
back the same way.
