### PR TITLE
server/core: relay negotiated websocket subprotocol and stop offering extensions upstream

### DIFF
--- a/src/server/core.rs
+++ b/src/server/core.rs
@@ -412,9 +412,6 @@ mod websockets {
 
         let ws_accept = derive_accept_key(ws_key.as_bytes());
 
-        // The bridge relays frames unchanged and `tokio-tungstenite` is built
-        // without deflate support, so the application must not get the chance to
-        // negotiate an extension that changes the framing.
         request.headers_mut().remove(SEC_WEBSOCKET_EXTENSIONS);
 
         let path_q = request
@@ -431,17 +428,10 @@ mod websockets {
         }
         let ws_request = ws_request.body(())?;
 
-        // Connect upstream before answering the client, because the response has
-        // to name the subprotocol the application selected, which is only known
-        // once the upstream handshake completed.
         let stream = UnixStream::connect(socket_path).await?;
         let (upstream_ws, upstream_response) = match client_async(ws_request, stream).await {
             Ok(upstream) => upstream,
             Err(TungsteniteError::Http(upstream_response)) => {
-                // The application answered the handshake with a regular response
-                // instead of accepting it, for example when a consumer denies the
-                // connection. Pass the status on rather than switching protocols
-                // on a connection the application has already given up on.
                 return Ok((upstream_response.status(), "").into_response());
             }
             Err(err) => return Err(err.into()),

--- a/src/server/core.rs
+++ b/src/server/core.rs
@@ -151,7 +151,7 @@ async fn forward_request(
         .insert(X_FORWARDED_PROTO, HeaderValue::from_str(scheme.as_ref())?);
 
     if is_websocket_upgrade(request.headers()) {
-        return handle_websocket_upgrade(request, server).await;
+        return handle_websocket_upgrade(request, &server.socket_path).await;
     }
 
     if let Some(tls_state) = tls_state
@@ -351,7 +351,7 @@ mod tests {
 }
 
 mod websockets {
-    use std::sync::Arc;
+    use std::path::Path;
 
     use ak_axum::error::{AppError, Result};
     use axum::{
@@ -360,21 +360,23 @@ mod websockets {
         http::{
             HeaderMap, HeaderValue, StatusCode,
             header::{
-                CONNECTION, SEC_WEBSOCKET_ACCEPT, SEC_WEBSOCKET_KEY, SEC_WEBSOCKET_VERSION, UPGRADE,
+                CONNECTION, SEC_WEBSOCKET_ACCEPT, SEC_WEBSOCKET_EXTENSIONS, SEC_WEBSOCKET_KEY,
+                SEC_WEBSOCKET_PROTOCOL, SEC_WEBSOCKET_VERSION, UPGRADE,
             },
         },
         response::{IntoResponse as _, Response},
     };
     use futures::{SinkExt as _, StreamExt as _};
+    use hyper::upgrade::OnUpgrade;
     use hyper_util::rt::TokioIo;
     use tokio::{net::UnixStream, sync::mpsc};
     use tokio_tungstenite::{
         WebSocketStream, client_async,
-        tungstenite::{Message, handshake::derive_accept_key, protocol::Role},
+        tungstenite::{
+            Error as TungsteniteError, Message, handshake::derive_accept_key, protocol::Role,
+        },
     };
     use tracing::{debug, trace, warn};
-
-    use crate::server::Server;
 
     pub(super) fn is_websocket_upgrade(headers: &HeaderMap<HeaderValue>) -> bool {
         let has_upgrade = headers
@@ -397,8 +399,8 @@ mod websockets {
     }
 
     pub(super) async fn handle_websocket_upgrade(
-        request: Request,
-        server: Arc<Server>,
+        mut request: Request,
+        socket_path: &Path,
     ) -> Result<Response> {
         let Some(ws_key) = request
             .headers()
@@ -409,6 +411,11 @@ mod websockets {
         };
 
         let ws_accept = derive_accept_key(ws_key.as_bytes());
+
+        // The bridge relays frames unchanged and `tokio-tungstenite` is built
+        // without deflate support, so the application must not get the chance to
+        // negotiate an extension that changes the framing.
+        request.headers_mut().remove(SEC_WEBSOCKET_EXTENSIONS);
 
         let path_q = request
             .uri()
@@ -424,15 +431,35 @@ mod websockets {
         }
         let ws_request = ws_request.body(())?;
 
-        let response = Response::builder()
+        // Connect upstream before answering the client, because the response has
+        // to name the subprotocol the application selected, which is only known
+        // once the upstream handshake completed.
+        let stream = UnixStream::connect(socket_path).await?;
+        let (upstream_ws, upstream_response) = match client_async(ws_request, stream).await {
+            Ok(upstream) => upstream,
+            Err(TungsteniteError::Http(upstream_response)) => {
+                // The application answered the handshake with a regular response
+                // instead of accepting it, for example when a consumer denies the
+                // connection. Pass the status on rather than switching protocols
+                // on a connection the application has already given up on.
+                return Ok((upstream_response.status(), "").into_response());
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        let mut response = Response::builder()
             .status(StatusCode::SWITCHING_PROTOCOLS)
             .header(UPGRADE, "websocket")
             .header(CONNECTION, "upgrade")
-            .header(SEC_WEBSOCKET_ACCEPT, ws_accept)
-            .body(Body::empty())?;
+            .header(SEC_WEBSOCKET_ACCEPT, ws_accept);
+        if let Some(selected) = upstream_response.headers().get(SEC_WEBSOCKET_PROTOCOL) {
+            response = response.header(SEC_WEBSOCKET_PROTOCOL, selected);
+        }
+        let response = response.body(Body::empty())?;
 
+        let client_upgrade = hyper::upgrade::on(&mut request);
         tokio::spawn(async move {
-            if let Err(err) = handle_websocket_connection(request, server, ws_request).await {
+            if let Err(err) = handle_websocket_connection(client_upgrade, upstream_ws).await {
                 warn!("WebSocket connection error: {}", err.0);
             }
         });
@@ -441,19 +468,15 @@ mod websockets {
     }
 
     async fn handle_websocket_connection(
-        request: Request,
-        server: Arc<Server>,
-        ws_request: tokio_tungstenite::tungstenite::handshake::client::Request,
+        client_upgrade: OnUpgrade,
+        upstream_ws: WebSocketStream<UnixStream>,
     ) -> Result<()> {
-        let upgraded = hyper::upgrade::on(request).await?;
-        let io = TokioIo::new(upgraded);
-        let client_ws = WebSocketStream::from_raw_socket(io, Role::Server, None).await;
-
-        let upstream_ws = {
-            let stream = UnixStream::connect(&server.socket_path).await?;
-            let (ws_stream, _) = client_async(ws_request, stream).await?;
-            ws_stream
-        };
+        let client_ws = WebSocketStream::from_raw_socket(
+            TokioIo::new(client_upgrade.await?),
+            Role::Server,
+            None,
+        )
+        .await;
 
         let (mut client_sender, mut client_receiver) = client_ws.split();
         let (mut upstream_sender, mut upstream_receiver) = upstream_ws.split();
@@ -540,5 +563,206 @@ mod websockets {
         }
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::time::Duration;
+
+        use axum::http::header::HOST;
+        use tempfile::TempDir;
+        use tokio::{
+            io::{AsyncReadExt as _, AsyncWriteExt as _},
+            net::UnixListener,
+            sync::oneshot,
+            time::timeout,
+        };
+        use tokio_tungstenite::{
+            accept_hdr_async,
+            tungstenite::handshake::server::{
+                ErrorResponse, Request as UpstreamRequest, Response as UpstreamResponse,
+            },
+        };
+
+        use super::*;
+
+        const WS_KEY: &str = "dGhlIHNhbXBsZSBub25jZQ==";
+
+        /// Stands in for the ASGI application on `socket_path`, answering the
+        /// handshake the way uvicorn's wsproto implementation does: it names the
+        /// subprotocol the application selected, and accepts `permessage-deflate`
+        /// whenever the handshake offers it.
+        ///
+        /// Resolves to the headers the upstream handshake was made with.
+        fn spawn_upstream(
+            socket_path: &Path,
+            subprotocol: Option<&'static str>,
+        ) -> oneshot::Receiver<HeaderMap> {
+            let listener = UnixListener::bind(socket_path).expect("failed to bind upstream socket");
+            let (headers_tx, headers_rx) = oneshot::channel();
+
+            tokio::spawn(async move {
+                let (stream, _) = listener.accept().await.expect("failed to accept");
+                #[expect(
+                    clippy::result_large_err,
+                    reason = "the callback signature is dictated by tungstenite"
+                )]
+                let callback = |request: &UpstreamRequest, mut response: UpstreamResponse| {
+                    let headers = request.headers().clone();
+                    if let Some(subprotocol) = subprotocol {
+                        response.headers_mut().insert(
+                            SEC_WEBSOCKET_PROTOCOL,
+                            HeaderValue::from_static(subprotocol),
+                        );
+                    }
+                    if headers.contains_key(SEC_WEBSOCKET_EXTENSIONS) {
+                        response.headers_mut().insert(
+                            SEC_WEBSOCKET_EXTENSIONS,
+                            HeaderValue::from_static("permessage-deflate"),
+                        );
+                    }
+                    drop(headers_tx.send(headers));
+                    Ok::<_, ErrorResponse>(response)
+                };
+                let _upstream = accept_hdr_async(stream, callback)
+                    .await
+                    .expect("upstream handshake failed");
+                // Hold the connection open for the rest of the test.
+                std::future::pending::<()>().await;
+            });
+
+            headers_rx
+        }
+
+        /// Rejects the handshake instead of upgrading, the way the application
+        /// answers when a consumer denies the connection.
+        fn spawn_rejecting_upstream(socket_path: &Path) {
+            let listener = UnixListener::bind(socket_path).expect("failed to bind upstream socket");
+
+            tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.expect("failed to accept");
+                let mut request = Vec::new();
+                let mut byte = [0_u8; 1];
+                while !request.ends_with(b"\r\n\r\n") {
+                    if stream.read(&mut byte).await.expect("failed to read") == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&byte);
+                }
+                stream
+                    .write_all(b"HTTP/1.1 403 Forbidden\r\ncontent-length: 0\r\n\r\n")
+                    .await
+                    .expect("failed to write rejection");
+            });
+        }
+
+        fn client_request(subprotocol: Option<&str>, extensions: Option<&str>) -> Request {
+            let mut builder = Request::builder()
+                // `forward_request` rewrites the URI before handing the request over.
+                .uri("http://localhost:8000/ws/rac/connection-token/")
+                .header(HOST, "authentik.company")
+                .header(UPGRADE, "websocket")
+                .header(CONNECTION, "upgrade")
+                .header(SEC_WEBSOCKET_KEY, WS_KEY)
+                .header(SEC_WEBSOCKET_VERSION, "13");
+            if let Some(subprotocol) = subprotocol {
+                builder = builder.header(SEC_WEBSOCKET_PROTOCOL, subprotocol);
+            }
+            if let Some(extensions) = extensions {
+                builder = builder.header(SEC_WEBSOCKET_EXTENSIONS, extensions);
+            }
+            builder
+                .body(Body::empty())
+                .expect("failed to build client request")
+        }
+
+        /// RAC is the only consumer that negotiates a subprotocol, and browsers
+        /// fail a connection when they offered one and the 101 names none.
+        #[tokio::test]
+        async fn upgrade_echoes_upstream_subprotocol() {
+            let dir = TempDir::new().expect("failed to create temp dir");
+            let socket_path = dir.path().join("authentik.sock");
+            let _upstream = spawn_upstream(&socket_path, Some("guacamole"));
+
+            let response =
+                handle_websocket_upgrade(client_request(Some("guacamole"), None), &socket_path)
+                    .await
+                    .expect("upgrade should succeed");
+
+            assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+            assert_eq!(
+                response.headers().get(SEC_WEBSOCKET_PROTOCOL),
+                Some(&HeaderValue::from_static("guacamole")),
+                "the 101 must name the subprotocol the application selected"
+            );
+        }
+
+        /// The bridge relays frames unchanged and cannot decode a compressed one,
+        /// so the client's extension offer must not reach the application.
+        #[tokio::test]
+        async fn upgrade_does_not_offer_extensions_upstream() {
+            let dir = TempDir::new().expect("failed to create temp dir");
+            let socket_path = dir.path().join("authentik.sock");
+            let upstream = spawn_upstream(&socket_path, Some("guacamole"));
+
+            let response = handle_websocket_upgrade(
+                client_request(
+                    Some("guacamole"),
+                    Some("permessage-deflate; client_max_window_bits"),
+                ),
+                &socket_path,
+            )
+            .await
+            .expect("upgrade should succeed");
+
+            assert!(
+                !response.headers().contains_key(SEC_WEBSOCKET_EXTENSIONS),
+                "the 101 must not name an extension"
+            );
+
+            let upstream_headers = timeout(Duration::from_secs(5), upstream)
+                .await
+                .expect("upstream did not receive a handshake")
+                .expect("upstream dropped the handshake");
+            assert!(
+                !upstream_headers.contains_key(SEC_WEBSOCKET_EXTENSIONS),
+                "the upstream handshake must not offer extensions"
+            );
+        }
+
+        /// Every other consumer accepts without a subprotocol; naming one the
+        /// client did not ask for makes browsers drop the connection.
+        #[tokio::test]
+        async fn upgrade_without_subprotocol_names_none() {
+            let dir = TempDir::new().expect("failed to create temp dir");
+            let socket_path = dir.path().join("authentik.sock");
+            let _upstream = spawn_upstream(&socket_path, None);
+
+            let response = handle_websocket_upgrade(client_request(None, None), &socket_path)
+                .await
+                .expect("upgrade should succeed");
+
+            assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+            assert!(
+                !response.headers().contains_key(SEC_WEBSOCKET_PROTOCOL),
+                "the 101 must not name a subprotocol that was not requested"
+            );
+        }
+
+        /// An application that denies the connection must not be preceded by a
+        /// 101 the client would have to tear down immediately.
+        #[tokio::test]
+        async fn upgrade_propagates_upstream_rejection() {
+            let dir = TempDir::new().expect("failed to create temp dir");
+            let socket_path = dir.path().join("authentik.sock");
+            spawn_rejecting_upstream(&socket_path);
+
+            let response =
+                handle_websocket_upgrade(client_request(Some("guacamole"), None), &socket_path)
+                    .await
+                    .expect("upgrade should return a response");
+
+            assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        }
     }
 }


### PR DESCRIPTION
## Details

### What does this PR change?

`handle_websocket_upgrade` in `src/server/core.rs`:

- performs the upstream handshake **before** answering the client, and names the subprotocol the application selected in the `101`
- removes `Sec-WebSocket-Extensions` from the handshake it forwards to the application
- relays the application's response status when it rejects the handshake, instead of switching protocols on a connection that is already gone
- takes the gunicorn socket path instead of the whole `Server` (the only field it used), so the handshake can be tested against a stand-in application

The frame relay itself is unchanged.

### Why is this change needed?

Two separate defects, both in the WebSocket bridge that replaced the Go reverse proxy in #24320 and first shipped in 2026.8.0-rc1. Both are in the core server rather than the RAC outpost, so downgrading the outpost does not help.

**1. The `101` never named the negotiated subprotocol.** The bridge synthesised its own handshake response from three hardcoded headers and discarded the upstream one (`let (ws_stream, _) = client_async(...)`). It also answered *before* connecting upstream, so it could not know what the application had selected. RAC is the only consumer that negotiates a subprotocol (`authentik/providers/rac/consumer_client.py:65`, `await self.accept("guacamole")`), and guacamole-common-js requests it (`new WebSocket(tunnelURL + "?" + data, "guacamole")`). Browsers fail a connection when they offered a subprotocol and the response names none, which is the `WebSocket connection ... failed` seen in the console.

**2. `permessage-deflate` was negotiated upstream but could not be decoded.** `Sec-WebSocket-Extensions` was not stripped, and every client header was copied into the upstream handshake, so the browser's compression offer reached uvicorn, which appends `PerMessageDeflate()` unless `ws_per_message_deflate` is disabled. The negotiated extension was then dropped from the `101` in the same way as the subprotocol, so the upstream leg ran compressed while the browser leg did not. `tokio-tungstenite` is built without a deflate feature and rejects the first frame with RSV1 set (`ProtocolError::NonZeroReservedBits`), which ends the upstream-to-client task. This is the second failure stage: the tunnel opens, the outpost reaches guacd, the session establishes, and then no data reaches the browser until guacd logs `User is not responding` about 11 s later, matching the frontend's `tunnel.receiveTimeout` of 10 s.

The module is identical on `main` and `version-2026.8`, so the change applies to both.

### How was this tested?

**Unit tests** (new, in `mod websockets`): a stand-in application on a unix socket answers the handshake the way uvicorn's wsproto implementation does — it names the subprotocol the consumer selected and accepts `permessage-deflate` when the handshake offers it. Three of the four tests fail before this change:

- `upgrade_echoes_upstream_subprotocol` — the `101` names the selection (defect 1)
- `upgrade_does_not_offer_extensions_upstream` — the forwarded handshake carries no extensions (defect 2)
- `upgrade_without_subprotocol_names_none` — nothing is named when nothing was negotiated, for the other consumers
- `upgrade_propagates_upstream_rejection` — a rejecting application yields its status, not a `101`

`cargo nextest run --workspace` (165 tests), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt --all --check`, `cargo deny check` and `cargo machete` all pass.

**Protocol level.** Comparing `ghcr.io/goauthentik/server:2026.8.0` against an image built from `version/2026.8.0` plus this change, against the same database, with a raw handshake sent from a socket (no client library in the way):

| Handshake | 2026.8.0 | with this change |
| --- | --- | --- |
| offers `guacamole` + `permessage-deflate` | `101`, no subprotocol named | `101`, names `guacamole`, no extension |
| `HELLO` on a consumer, **with** a deflate offer | no reply ever arrives | reply arrives, RSV1 clear |
| `HELLO` on a consumer, no deflate offer | reply arrives | reply arrives |
| connection denied before accept | `101`, then silence | `403` |

Asking gunicorn directly on the same image shows the other half: it answers `Sec-WebSocket-Protocol: guacamole` and `Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits=15`, both of which the bridge discarded.

**In production.** Running the patched server and worker images on 2026.8.0 with the stock RAC outpost, and with the nginx workaround removed: RDP sessions connect and stay usable. The `proxy_set_header Sec-WebSocket-Extensions ""` / `add_header Sec-WebSocket-Protocol "guacamole"` workaround is no longer needed with this change.

### Linked issues

closes #25361

### AI assistance

Disclosed per [`AI_POLICY.md`](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md): I used Claude Code to help analyse the two failure modes, write this patch and its tests. I reviewed the change, ran the test and lint suites myself, and verified it on my own infrastructure with a real RDP session before opening this PR.

---

## Checklist

- [x] The project has been linted, built, and tested (`make all`) (Rust targets, listed above; this change is Rust-only)
- [x] The documentation has been updated and formatted (`make docs`)
- [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
