### PR TITLE
stages/email: make rate limit apply across flow restarts, not just on "resend email" button

### DIFF
--- a/authentik/stages/email/stage.py
+++ b/authentik/stages/email/stage.py
@@ -156,6 +156,9 @@ class EmailStageView(ChallengeStageView):
             return self.executor.stage_invalid()
         # Check if we've already sent the initial e-mail
         if PLAN_CONTEXT_EMAIL_SENT not in self.executor.plan.context:
+            if minutes_left := self._is_rate_limited():
+                messages.error(self.request, self._rate_limit_error(minutes_left))
+                return super().get(request, *args, **kwargs)
             try:
                 self.send_email()
             except StageInvalidException as exc:
@@ -190,8 +193,9 @@ class EmailStageView(ChallengeStageView):
         cache_key = self._get_cache_key()
         attempts = cache.get(cache_key, [])
 
-        stage = self.executor.current_stage
-        stage.refresh_from_db()
+        # Fetch a fresh copy for the current rate limit configuration, without
+        # overwriting the rest of the stage config pickled into the flow plan
+        stage = EmailStage.objects.get(pk=self.executor.current_stage.pk)
         max_attempts = stage.recovery_max_attempts
         cache_timeout_delta = timedelta_from_string(stage.recovery_cache_timeout)
 
@@ -223,12 +227,14 @@ class EmailStageView(ChallengeStageView):
 
         return None
 
+    def _rate_limit_error(self, minutes_left: int) -> str:
+        return _(
+            "Too many account verification attempts. Please try again after {minutes} minutes."
+        ).format(minutes=minutes_left)
+
     def challenge_invalid(self, response: ChallengeResponse) -> HttpResponse:
         if minutes_left := self._is_rate_limited():
-            error = _(
-                "Too many account verification attempts. Please try again after {minutes} minutes."
-            ).format(minutes=minutes_left)
-            messages.error(self.request, error)
+            messages.error(self.request, self._rate_limit_error(minutes_left))
             return super().challenge_invalid(response)
 
         if PLAN_CONTEXT_PENDING_USER not in self.executor.plan.context:

--- a/authentik/stages/email/tests/test_stage.py
+++ b/authentik/stages/email/tests/test_stage.py
@@ -463,3 +463,30 @@ class TestEmailStage(FlowTestCase):
                 "Too many account verification attempts. Please try again after 5 minutes.",
                 message_list[-1].message,
             )
+
+    @patch(
+        "authentik.stages.email.models.EmailStage.backend_class",
+        PropertyMock(return_value=EmailBackend),
+    )
+    def test_initial_send_rate_limited_on_flow_restart(self):
+        """Tests that restarting the flow does not bypass the rate limit
+        applied to resending the email."""
+        self.stage.recovery_max_attempts = 2
+        self.stage.recovery_cache_timeout = "minutes=10"
+        self.stage.save()
+
+        url = reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug})
+        # Each iteration simulates a full flow restart by seeding a fresh plan,
+        # so the initial email is attempted every time
+        for expected_mails in (1, 2, 2):
+            plan = FlowPlan(
+                flow_pk=self.flow.pk.hex, bindings=[self.binding], markers=[StageMarker()]
+            )
+            plan.context[PLAN_CONTEXT_PENDING_USER] = self.user
+            session = self.client.session
+            session[SESSION_KEY_PLAN] = plan
+            session.save()
+
+            response = self.client.get(url)
+            self.assertStageResponse(response, self.flow, component="ak-stage-email")
+            self.assertEqual(len(mail.outbox), expected_mails)


### PR DESCRIPTION
## Details

The Email stage supports rate-limiting to prevent malicious actors from toggling an avalanche of emails to a user's email address. However currently the limit can  be bypassed by re-starting the flow.  This PR addresses that deficiency.

### What does this PR change?

This adds a rate-limit check in `EmailStageView.get` where it was previously missing. 

### How was this tested?

A regression test is added for this scenario + the fix was tested manually via UI.

### AI disclosure 

The patch was implemented using Claude Code / Fable 5, then reviewed and edited manually.

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
