### PR TITLE
Fix/obj attr literal fallback

### DIFF
--- a/authentik/enterprise/audit/middleware.py
+++ b/authentik/enterprise/audit/middleware.py
@@ -69,11 +69,37 @@ class EnterpriseAuditMiddleware(AuditMiddleware):
     def diff(self, before: dict, after: dict, update_fields: list[str] | None = None) -> dict:
         """Generate diff between dicts"""
         diff = {}
+
+        def diff_attributes(
+            previous: dict[str, Any], current: dict[str, Any], path: str = "attributes"
+        ) -> dict:
+            attribute_diff = {}
+            for key in sorted(previous.keys() | current.keys()):
+                previous_value = previous.get(key)
+                current_value = current.get(key)
+                if isinstance(previous_value, dict) and isinstance(current_value, dict):
+                    attribute_diff.update(
+                        diff_attributes(previous_value, current_value, f"{path}.{key}")
+                    )
+                elif previous_value != current_value:
+                    attribute_diff[f"{path}.{key}"] = {
+                        "previous_value": previous_value,
+                        "new_value": current_value,
+                    }
+            return attribute_diff
+
         for key, value in before.items():
             if update_fields and key not in update_fields:
                 continue
             if after.get(key) != value:
-                diff[key] = {"previous_value": value, "new_value": after.get(key)}
+                if (
+                    key == "attributes"
+                    and isinstance(value, dict)
+                    and isinstance(after.get(key), dict)
+                ):
+                    diff.update(diff_attributes(value, after[key]))
+                else:
+                    diff[key] = {"previous_value": value, "new_value": after.get(key)}
         for key, value in after.items():
             if update_fields and key not in update_fields:
                 continue

--- a/authentik/enterprise/audit/tests.py
+++ b/authentik/enterprise/audit/tests.py
@@ -288,3 +288,42 @@ class TestEnterpriseAudit(APITestCase):
             update_fields=["is_active"],
         )
         self.assertEqual(diff, {"is_active": {"new_value": True, "previous_value": False}})
+
+    def test_diff_attributes(self):
+        """Test nested attribute diff"""
+        diff = EnterpriseAuditMiddleware(None).diff(
+            {
+                "attributes": {
+                    "department": "Engineering",
+                    "name": "Alice",
+                    "settings": {"theme": "light", "timezone": "UTC"},
+                },
+            },
+            {
+                "attributes": {
+                    "department": "Security",
+                    "name": "Alice",
+                    "role": "admin",
+                    "settings": {"theme": "dark"},
+                },
+            },
+        )
+        self.assertEqual(
+            diff,
+            {
+                "attributes.department": {
+                    "new_value": "Security",
+                    "previous_value": "Engineering",
+                },
+                "attributes.role": {"new_value": "admin", "previous_value": None},
+                "attributes.settings.theme": {
+                    "new_value": "dark",
+                    "previous_value": "light",
+                },
+                "attributes.settings.timezone": {
+                    "new_value": None,
+                    "previous_value": "UTC",
+                },
+            },
+        )
+        self.assertEqual(list(diff), sorted(diff))

--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -174,9 +174,7 @@ class BaseEvaluator:
         return fallback value."""
         attrs = getattr(obj, "attributes", {})
         value = get_path_from_dict(attrs, attr_key)
-        if value is None and fallback:
-            return getattr(obj, fallback)
-        return value
+        return fallback if value is None else value
 
     def expr_event_create(self, action: str, **kwargs):
         """Create event with supplied data and try to extract as much relevant data

--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -174,7 +174,7 @@ class BaseEvaluator:
         return fallback value."""
         attrs = getattr(obj, "attributes", {})
         value = get_path_from_dict(attrs, attr_key)
-        if value is None and fallback:
+        if value is None and fallback is not None:
             return getattr(obj, fallback, fallback)
         return value
 

--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -174,7 +174,9 @@ class BaseEvaluator:
         return fallback value."""
         attrs = getattr(obj, "attributes", {})
         value = get_path_from_dict(attrs, attr_key)
-        return fallback if value is None else value
+        if value is None and fallback:
+            return getattr(obj, fallback, fallback)
+        return value
 
     def expr_event_create(self, action: str, **kwargs):
         """Create event with supplied data and try to extract as much relevant data

--- a/authentik/lib/tests/test_evaluator.py
+++ b/authentik/lib/tests/test_evaluator.py
@@ -39,6 +39,16 @@ class TestEvaluator(TestCase):
         """Test expr_is_group_member"""
         self.assertFalse(BaseEvaluator.expr_is_group_member(create_test_admin_user(), name="test"))
 
+    def test_expr_obj_attr(self):
+        """Test expr_obj_attr"""
+        user = create_test_user()
+        user.attributes = {"locale": "en-US"}
+
+        self.assertEqual(BaseEvaluator.expr_obj_attr(user, "locale", "en-GB"), "en-US")
+        self.assertEqual(BaseEvaluator.expr_obj_attr(user, "missing", "en-GB"), "en-GB")
+        self.assertEqual(BaseEvaluator.expr_obj_attr(user, "missing", ""), "")
+        self.assertIsNone(BaseEvaluator.expr_obj_attr(user, "missing"))
+
     def test_expr_event_create(self):
         """Test expr_event_create"""
         evaluator = BaseEvaluator(generate_id())

--- a/authentik/lib/tests/test_evaluator.py
+++ b/authentik/lib/tests/test_evaluator.py
@@ -45,6 +45,7 @@ class TestEvaluator(TestCase):
         user.attributes = {"locale": "en-US"}
 
         self.assertEqual(BaseEvaluator.expr_obj_attr(user, "locale", "en-GB"), "en-US")
+        self.assertEqual(BaseEvaluator.expr_obj_attr(user, "missing", "username"), user.username)
         self.assertEqual(BaseEvaluator.expr_obj_attr(user, "missing", "en-GB"), "en-GB")
         self.assertEqual(BaseEvaluator.expr_obj_attr(user, "missing", ""), "")
         self.assertIsNone(BaseEvaluator.expr_obj_attr(user, "missing"))


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?
Displays changes to nested object attributes as individual audit diff entries instead of displaying the complete `attributes` object. Nested attribute paths use the existing `attributes.<path>` notation and are sorted to provide deterministic output.
Adds regression coverage for changed, added, removed, unchanged, nested, and sorted attribute fields.
### Why is this change needed?
Enterprise audit events currently compare model fields only at the top level. When one nested attribute changes, the audit diff displays the complete previous and new `attributes` objects, making the actual change difficult to identify.

Showing each changed attribute separately makes audit events clearer and avoids including unrelated unchanged attributes.
### How was this tested?
- Added focused regression coverage for nested attribute diffs.
- Ran Ruff against the changed Python files.
- Ran Python syntax compilation for the changed files.
- Ran `git diff --check`.
- Ran the Docker-backed project test workflow.
### Linked issues
closes #25390
<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
