### PR TITLE
Update ru-RU frontend locale (lit-localize)

### DIFF
--- a/web/xliff/ru-RU.xlf
+++ b/web/xliff/ru-RU.xlf
@@ -37,12 +37,14 @@
 </trans-unit>
 <trans-unit id="locale-option-localized-label">
   <source><x id="0" equiv-text="${relativeDisplayName}"/> (<x id="1" equiv-text="${localizedDisplayName}"/>)</source>
+  <target><x id="0" equiv-text="${relativeDisplayName}"/> (<x id="1" equiv-text="${localizedDisplayName}"/>)</target>
   <note from="lit-localize">Locale option label showing the localized language name along with the native language name in parentheses.</note>
 </trans-unit>
 <!-- #endregion -->
 
 <trans-unit id="s12d6dde9b30c3093">
   <source>Dismiss</source>
+  <target>Закрыть</target>
 </trans-unit>
 <trans-unit id="sfe629863ba1338c2">
   <source>Connection error, reconnecting...</source>
@@ -50,12 +52,15 @@
 </trans-unit>
 <trans-unit id="sdaecc3c29a27c5c5">
   <source>An unknown error occurred</source>
+  <target>Произошла неизвестная ошибка</target>
 </trans-unit>
 <trans-unit id="se84ba7f105934495">
   <source>Please check the browser console for more details.</source>
+  <target>Пожалуйста, проверьте консоль браузера для получения более подробной информации.</target>
 </trans-unit>
 <trans-unit id="sdea479482318489d">
   <source>Status messages</source>
+  <target>Сообщения о состоянии</target>
 </trans-unit>
 <trans-unit id="s9d8b8aa2b404c2c8">
   <source>Settings</source>
@@ -71,6 +76,7 @@
 </trans-unit>
 <trans-unit id="s6abb1cd87fe0114e">
   <source>Home</source>
+  <target>Дом</target>
 </trans-unit>
 <trans-unit id="s91ae4b6bf981682b">
   <source>authentik Logo</source>
@@ -78,9 +84,11 @@
 </trans-unit>
 <trans-unit id="se58e6ed983bf34b0">
   <source>Collapse navigation</source>
+  <target>Свернуть навигацию</target>
 </trans-unit>
 <trans-unit id="sc6ef25894ed00175">
   <source>Expand navigation</source>
+  <target>Развернуть навигацию</target>
 </trans-unit>
 <trans-unit id="s7031e6928c44cedd">
   <source>User interface</source>
@@ -289,9 +297,7 @@
 </trans-unit>
 <trans-unit id="s0382d73823585617">
   <source><x id="0" equiv-text="${fieldName}"/>: <x id="1" equiv-text="${detail}"/></source>
-  <target>
-        <x id="0" equiv-text="${this.errorMessage}"/>:
-        <x id="1" equiv-text="${e.toString()}"/></target>
+  <target><x id="0" equiv-text="${fieldName}"/>: <x id="1" equiv-text="${detail}"/></target>
 </trans-unit>
 <trans-unit id="sae5d87e99fe081e0">
   <source>Required</source>
@@ -299,6 +305,7 @@
 </trans-unit>
 <trans-unit id="s44872da71d5307c8">
   <source>There was an error submitting the form.</source>
+  <target>Произошла ошибка при отправке формы.</target>
 </trans-unit>
 <trans-unit id="se166e95fe447ebcd">
   <source>Close dialog</source>
@@ -454,21 +461,27 @@
 </trans-unit>
 <trans-unit id="s482bc55a78891ef7">
   <source>A code has been sent to your address: <x id="0" equiv-text="${email}"/></source>
+  <target>Код был отправлен на ваш адрес: <x id="0" equiv-text="${email}"/>.</target>
 </trans-unit>
 <trans-unit id="s5afa3fc77ce8d94d">
   <source>A code has been sent to your email address.</source>
+  <target>Код был отправлен на ваш адрес электронной почты.</target>
 </trans-unit>
 <trans-unit id="s37f47fa981493c3b">
   <source>A one-time use code has been sent to you via SMS text message.</source>
+  <target>Вам был отправлен одноразовый код в виде SMS-сообщения.</target>
 </trans-unit>
 <trans-unit id="sc92a7248dba5f388">
   <source>Open your authenticator app to retrieve a one-time use code.</source>
+  <target>Откройте приложение для аутентификации, чтобы получить одноразовый код.</target>
 </trans-unit>
 <trans-unit id="s21d95b4651ad7a1e">
   <source>Enter a one-time recovery code for this user.</source>
+  <target>Введите одноразовый код восстановления для этого пользователя.</target>
 </trans-unit>
 <trans-unit id="s2e1d5a7d320c25ef">
   <source>Enter the code from your authenticator device.</source>
+  <target>Введите код с вашего устройства аутентификации.</target>
 </trans-unit>
 <trans-unit id="se2d65e13768468e0">
   <source>Internal</source>
@@ -492,6 +505,7 @@
 </trans-unit>
 <trans-unit id="s3633ffed92acaecb">
   <source><x id="0" equiv-text="${this.label || &quot;&quot;}"/> table pagination</source>
+  <target><x id="0" equiv-text="${this.label || &quot;&quot;}"/> нумерация страниц таблицы</target>
 </trans-unit>
 <trans-unit id="s04c5a637328c9b67">
   <source><x id="0" equiv-text="${startIndex}"/> - <x id="1" equiv-text="${endIndex}"/> of <x id="2" equiv-text="${pageCount}"/></source>
@@ -510,6 +524,7 @@
 </trans-unit>
 <trans-unit id="sc57b150b53a3b9e6">
   <source>This field is required.</source>
+  <target>Это поле обязательно к заполнению.</target>
 </trans-unit>
 <trans-unit id="sffa721bb6aa3128d">
   <source>Search...</source>
@@ -517,15 +532,19 @@
 </trans-unit>
 <trans-unit id="s5d929ff1619ac0c9">
   <source>Search</source>
+  <target>Поиск</target>
 </trans-unit>
 <trans-unit id="sbe3756d568bb048e">
   <source>Query suggestions</source>
+  <target>Подсказки запроса</target>
 </trans-unit>
 <trans-unit id="sf6e7447df476939f">
   <source>Query input</source>
+  <target>Ввод запроса</target>
 </trans-unit>
 <trans-unit id="s5638954badbd5b21">
   <source>Table Search</source>
+  <target>Поиск по таблице</target>
 </trans-unit>
 <trans-unit id="s5f4586bc1e2740e6">
   <source>Clear search</source>
@@ -533,6 +552,7 @@
 </trans-unit>
 <trans-unit id="sd9b15395dd103f80">
   <source>Sort by "<x id="0" equiv-text="${label}"/>"</source>
+  <target>Сортировать по "<x id="0" equiv-text="${label}"/>"</target>
 </trans-unit>
 <trans-unit id="sfd44ce578f643145">
   <source>Failed to fetch objects.</source>
@@ -540,12 +560,15 @@
 </trans-unit>
 <trans-unit id="s7dd64bb0c1fa8e87">
   <source>Select "<x id="0" equiv-text="${rowLabel}"/>" row</source>
+  <target>Выберите строку " <x id="0" equiv-text="${rowLabel}"/> ".</target>
 </trans-unit>
 <trans-unit id="sd26f670ca5d5b0c6">
   <source>Collapse row</source>
+  <target>Свернуть строку</target>
 </trans-unit>
 <trans-unit id="s73f51a3532f29159">
   <source>Expand row</source>
+  <target>Развернуть строку</target>
 </trans-unit>
 <trans-unit id="s7b7163270e57e8b4">
   <source>Refresh</source>
@@ -553,21 +576,27 @@
 </trans-unit>
 <trans-unit id="sda170fd79bca1616">
   <source><x id="0" equiv-text="${this.label ?? &quot;Table&quot;}"/> actions</source>
+  <target><x id="0" equiv-text="${this.label ?? &quot;Table&quot;}"/> действия</target>
 </trans-unit>
 <trans-unit id="sd09354b0220a13ce">
   <source>Select all rows on page (<x id="0" equiv-text="${selectedCount}"/> of <x id="1" equiv-text="${pageItemCount}"/> selected)</source>
+  <target>Выбрать все строки на странице (выбрано <x id="0" equiv-text="${selectedCount}"/> из <x id="1" equiv-text="${pageItemCount}"/>)</target>
 </trans-unit>
 <trans-unit id="s76ef34813bff563f">
   <source>Last refreshed</source>
+  <target>Последнее обновление</target>
 </trans-unit>
 <trans-unit id="s59c9e8f57e3a0075">
   <source><x id="0" equiv-text="${this.label}"/> table</source>
+  <target><x id="0" equiv-text="${this.label}"/> таблица</target>
 </trans-unit>
 <trans-unit id="sa25b60b4fac481aa">
   <source>Table content</source>
+  <target>Содержимое таблицы</target>
 </trans-unit>
 <trans-unit id="s15a7e4227737b7c4">
   <source>Column actions</source>
+  <target>Действия столбца</target>
 </trans-unit>
 <trans-unit id="sa65e7bc7ddd3484d">
   <source>Anonymous user</source>
@@ -580,6 +609,7 @@
 </trans-unit>
 <trans-unit id="s7225aacf0eee94d2">
   <source>Authenticated as <x id="0" equiv-text="${renderUsername(event.user.authenticated_as)}"/></source>
+  <target>Аутентифицирован как <x id="0" equiv-text="${renderUsername(event.user.authenticated_as)}"/></target>
 </trans-unit>
 <trans-unit id="s2152f3482784705f">
   <source>Recent events</source>
@@ -611,6 +641,7 @@
 </trans-unit>
 <trans-unit id="sd2fa988f1774cfde">
   <source>System Status</source>
+  <target>Статус системы</target>
 </trans-unit>
 <trans-unit id="s113c05ef9996ca4b">
   <source>Embedded outpost is not configured correctly.</source>
@@ -668,6 +699,7 @@
 </trans-unit>
 <trans-unit id="s82cced87e15e0665">
   <source>Worker with incorrect version connected.</source>
+  <target>Подключился рабочий с неправильной версией.</target>
 </trans-unit>
 <trans-unit id="s98327528f00365a7">
   <source>Failed to fetch data.</source>
@@ -675,9 +707,11 @@
 </trans-unit>
 <trans-unit id="s66f26fdcbe2101eb">
   <source>Chart</source>
+  <target>Диаграмма</target>
 </trans-unit>
 <trans-unit id="s7b58d033cc5112ab">
   <source>Event volume chart</source>
+  <target>График объема событий</target>
 </trans-unit>
 <trans-unit id="s11bc220e8fa9d797">
   <source>Authorizations</source>
@@ -697,6 +731,7 @@
 </trans-unit>
 <trans-unit id="s0914f91b3f985f0f">
   <source>Synchronization status chart</source>
+  <target>Таблица состояния синхронизации</target>
 </trans-unit>
 <trans-unit id="s477de089b505a6ea">
   <source>SCIM Provider</source>
@@ -716,6 +751,7 @@
 </trans-unit>
 <trans-unit id="s334b3924d2bd5d55">
   <source>Kerberos Source</source>
+  <target>Источник Кербероса</target>
 </trans-unit>
 <trans-unit id="s8a75e83497a183a2">
   <source>Healthy</source>
@@ -731,6 +767,7 @@
 </trans-unit>
 <trans-unit id="s3f01dbc864d2a8b9">
   <source>Outpost status chart</source>
+  <target>График статуса аванпоста</target>
 </trans-unit>
 <trans-unit id="sfeb82261bcf99edd">
   <source>Healthy outposts</source>
@@ -767,6 +804,7 @@
 </trans-unit>
 <trans-unit id="sd5e9b70ffb7a8b46">
   <source>Skip to content</source>
+  <target>Перейти к содержимому</target>
 </trans-unit>
 <trans-unit id="sfd13ca8ebd857c2e">
   <source>Create a new application</source>
@@ -810,9 +848,11 @@
 </trans-unit>
 <trans-unit id="s85a488cacb57688b">
   <source>Welcome, <x id="0" equiv-text="${displayName}"/></source>
+  <target>Добро пожаловать, <x id="0" equiv-text="${displayName}"/></target>
 </trans-unit>
 <trans-unit id="scdb1bac161852c73">
   <source>Welcome</source>
+  <target>Добро пожаловать</target>
 </trans-unit>
 <trans-unit id="s41e035c4bb8d15f2">
   <source>General system status</source>
@@ -923,24 +963,31 @@
 </trans-unit>
 <trans-unit id="s7f073c746d0f6324">
   <source>Form actions</source>
+  <target>Действия формы</target>
 </trans-unit>
 <trans-unit id="sfd81bd296e2f7585">
   <source>Submit action</source>
+  <target>Отправить действие</target>
 </trans-unit>
 <trans-unit id="s5baec8151f4a4433">
   <source>Cancel action</source>
+  <target>Отменить действие</target>
 </trans-unit>
 <trans-unit id="sbcdf61483337948a">
   <source>Successfully updated schedule.</source>
+  <target>Расписание успешно обновлено.</target>
 </trans-unit>
 <trans-unit id="sd372fe5b712f6b30">
   <source>Crontab</source>
+  <target>Кронтаб</target>
 </trans-unit>
 <trans-unit id="s95bc8722b2708f8b">
   <source>Paused</source>
+  <target>Приостановлено</target>
 </trans-unit>
 <trans-unit id="se41af830054194bc">
   <source>Pause this schedule</source>
+  <target>Приостановить это расписание</target>
 </trans-unit>
 <trans-unit id="sc0448bc8a76227cb">
   <source>Failed to fetch objects: </source>
@@ -996,6 +1043,7 @@
 </trans-unit>
 <trans-unit id="s7753c012594cc69e">
   <source>Assigned to role</source>
+  <target>Назначено на роль</target>
 </trans-unit>
 <trans-unit id="s67e136af8fc1107b">
   <source>Assign permission</source>
@@ -1031,18 +1079,23 @@
 </trans-unit>
 <trans-unit id="sd091e43d5e99dea4">
   <source>Waiting to run</source>
+  <target>Ожидание запуска</target>
 </trans-unit>
 <trans-unit id="s2f06038e5cfd09df">
   <source>Consumed</source>
+  <target>Потреблено</target>
 </trans-unit>
 <trans-unit id="s556a7cc7c0c9f032">
   <source>Pre-processing</source>
+  <target>Предварительная обработка</target>
 </trans-unit>
 <trans-unit id="s85994a70cd39166c">
   <source>Running</source>
+  <target>Бег</target>
 </trans-unit>
 <trans-unit id="sb37a630168e1e0e5">
   <source>Post-processing</source>
+  <target>Постобработка</target>
 </trans-unit>
 <trans-unit id="sbe9a51f29a4a2c5b">
   <source>Successful</source>
@@ -1058,30 +1111,39 @@
 </trans-unit>
 <trans-unit id="s94f08f46277af7d6">
   <source>Running tasks</source>
+  <target>Запуск задач</target>
 </trans-unit>
 <trans-unit id="s8b551364b894d1ee">
   <source>Queued tasks</source>
+  <target>Задачи в очереди</target>
 </trans-unit>
 <trans-unit id="s2139d19009989a19">
   <source>Successful tasks</source>
+  <target>Успешные задачи</target>
 </trans-unit>
 <trans-unit id="s0787cd9eab5aa6e3">
   <source>Error tasks</source>
+  <target>Задачи с ошибками</target>
 </trans-unit>
 <trans-unit id="s03ee3cfb0919c62c">
   <source>Task</source>
+  <target>Задача</target>
 </trans-unit>
 <trans-unit id="sc7637275f670c938">
   <source>Queue</source>
+  <target>Очередь</target>
 </trans-unit>
 <trans-unit id="s84fb675fb17d4455">
   <source>Retries</source>
+  <target>Повторные попытки</target>
 </trans-unit>
 <trans-unit id="s1d300a2f13c19ab4">
   <source>Planned execution time</source>
+  <target>Планируемое время выполнения</target>
 </trans-unit>
 <trans-unit id="sb91d1be10eb2c7da">
   <source>Last updated</source>
+  <target>Последнее обновление</target>
 </trans-unit>
 <trans-unit id="sad3e3c8146fc920f">
   <source>Status</source>
@@ -1093,39 +1155,51 @@
 </trans-unit>
 <trans-unit id="sa3242c7021e01280">
   <source>Row Actions</source>
+  <target>Действия со строками</target>
 </trans-unit>
 <trans-unit id="s911c2c952e64b223">
   <source>Show only standalone tasks</source>
+  <target>Показывать только отдельные задачи</target>
 </trans-unit>
 <trans-unit id="s14053a4609676b8b">
   <source>Exclude successful tasks</source>
+  <target>Исключить успешные задачи</target>
 </trans-unit>
 <trans-unit id="s8ff646d0515aab2a">
   <source>Retry task</source>
+  <target>Повторить задачу</target>
 </trans-unit>
 <trans-unit id="sac44b0f4dc14c227">
   <source>Current execution logs</source>
+  <target>Текущие журналы выполнения</target>
 </trans-unit>
 <trans-unit id="s5e13dff03b580216">
   <source>Previous executions logs</source>
+  <target>Журналы предыдущих выполнений</target>
 </trans-unit>
 <trans-unit id="s9b8dccb514a0e34c">
   <source>Schedule</source>
+  <target>Расписание</target>
 </trans-unit>
 <trans-unit id="sf92789320708efed">
   <source>Next run</source>
+  <target>Следующий запуск</target>
 </trans-unit>
 <trans-unit id="s1aecc6c0d6cbf4ed">
   <source>Last status</source>
+  <target>Последний статус</target>
 </trans-unit>
 <trans-unit id="s6089c283e28012fb">
   <source>Show only standalone schedules</source>
+  <target>Показать только автономные расписания</target>
 </trans-unit>
 <trans-unit id="s48006fb6e0b1860a">
   <source>Run scheduled task now</source>
+  <target>Запустить запланированное задание сейчас</target>
 </trans-unit>
 <trans-unit id="s6492593d534108e1">
   <source>Update Schedule</source>
+  <target>Расписание обновлений</target>
 </trans-unit>
 <trans-unit id="s64ef2a6c2dd1d3d1">
   <source>Edit</source>
@@ -1133,9 +1207,11 @@
 </trans-unit>
 <trans-unit id="sc797fd9076cc136d">
   <source>Tasks</source>
+  <target>Задачи</target>
 </trans-unit>
 <trans-unit id="sf2d616b20d62240d">
   <source>Schedules</source>
+  <target>Расписания</target>
 </trans-unit>
 <trans-unit id="s3b34d9930e33bd46">
   <source>System Tasks</source>
@@ -1155,9 +1231,11 @@
 </trans-unit>
 <trans-unit id="s56e7ff6cc2abeb0d">
   <source>Wizard steps</source>
+  <target>Шаги мастера</target>
 </trans-unit>
 <trans-unit id="s04e09c193d15e4b4">
   <source>Wizard navigation</source>
+  <target>Мастер навигации</target>
 </trans-unit>
 <trans-unit id="s0c9670f429e74283">
   <source>New application</source>
@@ -1165,6 +1243,7 @@
 </trans-unit>
 <trans-unit id="s140111d464591e6b">
   <source>Create a new application and configure a provider for it.</source>
+  <target>Создайте новое приложение и настройте для него провайдера.</target>
 </trans-unit>
 <trans-unit id="s1a0e95458b44d7f8">
   <source>Any policy must match to grant access</source>
@@ -1176,6 +1255,7 @@
 </trans-unit>
 <trans-unit id="sb80507bed88545a6">
   <source>An application name is required</source>
+  <target>Укажите название приложения.</target>
 </trans-unit>
 <trans-unit id="s39c052006b2b141a">
   <source>Not a valid URL</source>
@@ -1183,15 +1263,19 @@
 </trans-unit>
 <trans-unit id="s317f3ab0da3d068a">
   <source>Not a valid slug</source>
+  <target>Недопустимый пул</target>
 </trans-unit>
 <trans-unit id="s0268ce9f2abb84de">
   <source>Configure the Application</source>
+  <target>Настройте приложение</target>
 </trans-unit>
 <trans-unit id="s07b0bf005510fe29">
   <source>Type an application name...</source>
+  <target>Введите имя приложения...</target>
 </trans-unit>
 <trans-unit id="s972540f502b0f4dc">
   <source>Application Name</source>
+  <target>Имя приложения</target>
 </trans-unit>
 <trans-unit id="s91f70424f5d5d23e">
   <source>Slug</source>
@@ -1207,6 +1291,7 @@
 </trans-unit>
 <trans-unit id="sc22c7703fd074f5f">
   <source>e.g. Collaboration, Communication, Internal, etc.</source>
+  <target>например Сотрудничество, коммуникация, внутреннее и т. д.</target>
 </trans-unit>
 <trans-unit id="sdae55084f6cb2662">
   <source>Optionally enter a group name. Applications with identical groups are shown grouped together.</source>
@@ -1226,6 +1311,7 @@
 </trans-unit>
 <trans-unit id="s71e967b36e080e3c">
   <source>https://...</source>
+  <target>https://...</target>
 </trans-unit>
 <trans-unit id="s992f8d1a776e763c">
   <source>If left empty, authentik will try to extract the launch URL based on the selected provider.</source>
@@ -1257,6 +1343,7 @@
 </trans-unit>
 <trans-unit id="s030ed8a3f12c23ff">
   <source>Configure Bindings</source>
+  <target>Настройка привязок</target>
 </trans-unit>
 <trans-unit id="s030ac0829bb50a49">
   <source>Policy <x id="0" equiv-text="${item.policyObj?.name}"/></source>
@@ -1275,6 +1362,7 @@
 </trans-unit>
 <trans-unit id="sc387b20e6d629087">
   <source>Configure Policy/User/Group Bindings</source>
+  <target>Настройка привязок политики/пользователя/группы</target>
 </trans-unit>
 <trans-unit id="s473f0143efa3f706">
   <source>These policies control which users can access this application.</source>
@@ -1282,6 +1370,7 @@
 </trans-unit>
 <trans-unit id="s71c3ec95efe723ca">
   <source>No bound policies.</source>
+  <target>Никаких связанных политик.</target>
 </trans-unit>
 <trans-unit id="sc15d60377cc8aaac">
   <source>No policies are currently bound to this object.</source>
@@ -1301,6 +1390,7 @@
 </trans-unit>
 <trans-unit id="sac315d5bd28d4efa">
   <source>Don't Pass</source>
+  <target>Не проходи</target>
 </trans-unit>
 <trans-unit id="s40b80eb4cc1f0e0c">
   <source>Edit Binding</source>
@@ -1308,9 +1398,11 @@
 </trans-unit>
 <trans-unit id="s54a37223ce938349">
   <source>Save Binding</source>
+  <target>Сохранить привязку</target>
 </trans-unit>
 <trans-unit id="s931754aabd4a6a47">
   <source>Create a Policy/User/Group Binding</source>
+  <target>Создайте привязку политики/пользователя/группы</target>
 </trans-unit>
 <trans-unit id="s042baf59902a711f">
   <source>Policy</source>
@@ -1326,6 +1418,7 @@
 </trans-unit>
 <trans-unit id="s5eba8fa19126f70a">
   <source>Learn more about the enterprise license.</source>
+  <target>Узнайте больше о корпоративной лицензии.</target>
 </trans-unit>
 <trans-unit id="s7181a5504472e856">
   <source>Apply changes</source>
@@ -1333,9 +1426,11 @@
 </trans-unit>
 <trans-unit id="s498d08fb8f63727f">
   <source>UNNAMED</source>
+  <target>БЕЗ НАЗВАНИЯ</target>
 </trans-unit>
 <trans-unit id="s74b47e964bb82e5f">
   <source>Wizard content</source>
+  <target>Содержание мастера</target>
 </trans-unit>
 <trans-unit id="sad59707375956ad2">
   <source>Finish</source>
@@ -1347,6 +1442,7 @@
 </trans-unit>
 <trans-unit id="s7d4ec232535a36f0">
   <source>Choose a Provider</source>
+  <target>Выберите провайдера</target>
 </trans-unit>
 <trans-unit id="sb7be945aa799b8d7">
   <source>Please choose a provider type before proceeding.</source>
@@ -1362,6 +1458,7 @@
 </trans-unit>
 <trans-unit id="s9bcd7cad5f5e2b15">
   <source>Select a certificate...</source>
+  <target>Выберите сертификат...</target>
 </trans-unit>
 <trans-unit id="sc25edca57df81461">
   <source>Authentication</source>
@@ -1417,6 +1514,7 @@
 </trans-unit>
 <trans-unit id="sd939185840181160">
   <source>Select a flow...</source>
+  <target>Выберите поток...</target>
 </trans-unit>
 <trans-unit id="s0db494ff61b48438">
   <source>Add All Available</source>
@@ -1448,12 +1546,15 @@
 </trans-unit>
 <trans-unit id="s4127b943d6826b8b">
   <source>Search <x id="0" equiv-text="${this.availableLabel}"/>...</source>
+  <target>Найдите <x id="0" equiv-text="${this.availableLabel}"/>...</target>
 </trans-unit>
 <trans-unit id="ha8e91858b300a3b7">
   <source>(Format: <x id="0" equiv-text="&lt;code&gt;"/>hours=-1;minutes=-2;seconds=-3)<x id="1" equiv-text="&lt;/code&gt;"/>.</source>
+  <target>(Формат: <x id="0" equiv-text="&lt;code&gt;"/>часы=-1;минуты=-2;секунды=-3)<x id="1" equiv-text="&lt;/code&gt;"/>.</target>
 </trans-unit>
 <trans-unit id="hbe8e6353371ecb22">
   <source>(Format: <x id="0" equiv-text="&lt;code&gt;"/>hours=1;minutes=2;seconds=3).<x id="1" equiv-text="&lt;/code&gt;"/></source>
+  <target>(Формат: <x id="0" equiv-text="&lt;code&gt;"/>часы=1;минуты=2;секунды=3).<x id="1" equiv-text="&lt;/code&gt;"/></target>
 </trans-unit>
 <trans-unit id="sbb8ad22c83d375b1">
   <source>The following keywords are supported:</source>
@@ -1513,9 +1614,11 @@
 </trans-unit>
 <trans-unit id="sdb16a3d366135cef">
   <source>Provider Name</source>
+  <target>Имя поставщика</target>
 </trans-unit>
 <trans-unit id="s96dc816b1d1c3be0">
   <source>Type a provider name...</source>
+  <target>Введите имя поставщика...</target>
 </trans-unit>
 <trans-unit id="scef3f4ad80abbd22">
   <source>Configure how the outpost authenticates requests.</source>
@@ -1539,6 +1642,7 @@
 </trans-unit>
 <trans-unit id="s6773ec2a233bbf41">
   <source>Flow used for unbinding users.</source>
+  <target>Поток, используемый для отвязывания пользователей.</target>
 </trans-unit>
 <trans-unit id="sfe388f0313f52da2">
   <source>Protocol settings</source>
@@ -1546,7 +1650,7 @@
 </trans-unit>
 <trans-unit id="s55d731be1ef66efe">
   <source>Base DN</source>
-  <target>Base DN</target>
+  <target>Базовый DN</target>
 </trans-unit>
 <trans-unit id="s0b15ff11a0049cfd">
   <source>LDAP DN under which bind requests and search requests can be made.</source>
@@ -1558,9 +1662,11 @@
 </trans-unit>
 <trans-unit id="sf9686d31d28fcf7d">
   <source>Show field content</source>
+  <target>Показать содержимое поля</target>
 </trans-unit>
 <trans-unit id="sb1b05a7573ab618c">
   <source>Hide field content</source>
+  <target>Скрыть содержимое поля</target>
 </trans-unit>
 <trans-unit id="s6cee92a3b310e650">
   <source>Add entry</source>
@@ -1568,9 +1674,11 @@
 </trans-unit>
 <trans-unit id="s58bec0ecd4f3ccd4">
   <source>Strict</source>
+  <target>Строгий</target>
 </trans-unit>
 <trans-unit id="sd27a8f54aca5d278">
   <source>Regex</source>
+  <target>регулярное выражение</target>
 </trans-unit>
 <trans-unit id="s61eacb19db252f5e">
   <source>URL</source>
@@ -1594,15 +1702,19 @@
 </trans-unit>
 <trans-unit id="sa3056b3252b4b52c">
   <source>Back-channel</source>
+  <target>Обратный канал</target>
 </trans-unit>
 <trans-unit id="saa3d821fc889a636">
   <source>Server-to-server logout notifications</source>
+  <target>Уведомления о выходе из системы между серверами</target>
 </trans-unit>
 <trans-unit id="s9f448d01a0354e8e">
   <source>Front-channel</source>
+  <target>Фронтальный канал</target>
 </trans-unit>
 <trans-unit id="s83ba71823baf9a51">
   <source>Browser iframe logout notifications</source>
+  <target>Уведомления о выходе из браузера iframe</target>
 </trans-unit>
 <trans-unit id="sccc47f82044453f9">
   <source>Based on the User's hashed ID</source>
@@ -1646,6 +1758,7 @@
 </trans-unit>
 <trans-unit id="s4c49d27de60a532b">
   <source>To allow any redirect URI, set the mode to Regex and the value to ".*". Be aware of the possible security implications this can have.</source>
+  <target>Чтобы разрешить любой URI перенаправления, установите режим Regex и значение «.*». Помните о возможных последствиях для безопасности, которые это может иметь.</target>
 </trans-unit>
 <trans-unit id="s62f7c59b0606a8d6">
   <source>Authorization flow</source>
@@ -1653,6 +1766,7 @@
 </trans-unit>
 <trans-unit id="s69d33a50b908b96f">
   <source>Select an authorization flow...</source>
+  <target>Выберите процесс авторизации...</target>
 </trans-unit>
 <trans-unit id="sfbaeb0de54fbfdbb">
   <source>Flow used when authorizing this provider.</source>
@@ -1672,15 +1786,19 @@
 </trans-unit>
 <trans-unit id="s145480489b87a109">
   <source>Logout URI</source>
+  <target>URI выхода из системы</target>
 </trans-unit>
 <trans-unit id="s37018999e29f65b3">
   <source>URI to send logout notifications to when users log out. Required for OpenID Connect Logout functionality.</source>
+  <target>URI для отправки уведомлений о выходе из системы, когда пользователи выходят из системы. Требуется для функции выхода из системы OpenID Connect.</target>
 </trans-unit>
 <trans-unit id="s2dcb6d1fd145b834">
   <source>Logout Method</source>
+  <target>Метод выхода из системы</target>
 </trans-unit>
 <trans-unit id="s2e527acc2a73da87">
   <source>The logout method determines how the logout URI is called — back-channel (server-to-server) or front-channel (browser iframe).</source>
+  <target>Метод выхода из системы определяет, как вызывается URI выхода из системы — обратный канал (между сервером) или передний канал (iframe браузера).</target>
 </trans-unit>
 <trans-unit id="s55787f4dfcdce52b">
   <source>Signing Key</source>
@@ -1688,6 +1806,7 @@
 </trans-unit>
 <trans-unit id="s9139b576e9944704">
   <source>Select a signing key...</source>
+  <target>Выберите ключ подписи...</target>
 </trans-unit>
 <trans-unit id="sc6c57419ad3a01a8">
   <source>Key used to sign the tokens.</source>
@@ -1695,9 +1814,11 @@
 </trans-unit>
 <trans-unit id="s4347135696fc7cde">
   <source>Advanced flow settings</source>
+  <target>Расширенные настройки потока</target>
 </trans-unit>
 <trans-unit id="s91675ea72a0ebe3e">
   <source>Select an authentication flow...</source>
+  <target>Выберите поток аутентификации...</target>
 </trans-unit>
 <trans-unit id="sa72a3bd1e7e89926">
   <source>Flow used when a user access this provider and is not authenticated.</source>
@@ -1705,9 +1826,11 @@
 </trans-unit>
 <trans-unit id="s19714b5520312d9a">
   <source>Select an invalidation flow...</source>
+  <target>Выберите поток аннулирования...</target>
 </trans-unit>
 <trans-unit id="s0159c800f16ee1a5">
   <source>Flow used when logging out of this provider.</source>
+  <target>Поток, используемый при выходе из этого провайдера.</target>
 </trans-unit>
 <trans-unit id="s124f93a61ee772d6">
   <source>Advanced protocol settings</source>
@@ -1727,6 +1850,7 @@
 </trans-unit>
 <trans-unit id="sdff424992223a264">
   <source>When renewing a refresh token, if the existing refresh token's expiry is within this threshold, the refresh token will be renewed. Set to seconds=0 to always renew the refresh token.</source>
+  <target>Если при обновлении токена обновления срок действия существующего токена обновления находится в пределах этого порога, токен обновления будет продлен. Установите значение секунд=0, чтобы всегда обновлять токен обновления.</target>
 </trans-unit>
 <trans-unit id="s2e3ef41a0edd8608">
   <source>Scopes</source>
@@ -1750,12 +1874,15 @@
 </trans-unit>
 <trans-unit id="sb52c56e87be6cd0c">
   <source>Select an encryption key...</source>
+  <target>Выберите ключ шифрования...</target>
 </trans-unit>
 <trans-unit id="sbdab4eb1812adc78">
   <source>Key used to encrypt the tokens. Only enable this if the application using this provider supports JWE tokens.</source>
+  <target>Ключ, используемый для шифрования токенов. Включайте это только в том случае, если приложение, использующее этот поставщик, поддерживает токены JWE.</target>
 </trans-unit>
 <trans-unit id="s998fea0fa7bb4188">
   <source>authentik only supports RSA-OAEP-256 for encryption.</source>
+  <target>authentik поддерживает шифрование только RSA-OAEP-256.</target>
 </trans-unit>
 <trans-unit id="s9f23ed1799b4d49a">
   <source>Configure what data should be used as unique User Identifier. For most cases, the default should be fine.</source>
@@ -1783,9 +1910,11 @@
 </trans-unit>
 <trans-unit id="sa52bf79fe1ccb13e">
   <source>Federated OIDC Sources</source>
+  <target>Федеративные источники OIDC</target>
 </trans-unit>
 <trans-unit id="sa42be520242dec2a">
   <source>Available Sources</source>
+  <target>Доступные источники</target>
 </trans-unit>
 <trans-unit id="s876e75cf2c07b38e">
   <source>Selected Sources</source>
@@ -1805,6 +1934,7 @@
 </trans-unit>
 <trans-unit id="s4f8a3f7792e6b940">
   <source>JWTs signed by the selected providers can be used to authenticate to this provider.</source>
+  <target>JWT, подписанные выбранными поставщиками, можно использовать для аутентификации у этого поставщика.</target>
 </trans-unit>
 <trans-unit id="s89ae85c3a9df8a6f">
   <source>Configure OAuth2 Provider</source>
@@ -1820,9 +1950,11 @@
 </trans-unit>
 <trans-unit id="sfc238215103c6162">
   <source>An error occurred while updating the provider.</source>
+  <target>Произошла ошибка при обновлении провайдера.</target>
 </trans-unit>
 <trans-unit id="sc055fffc26e97237">
   <source>An error occurred while creating the provider.</source>
+  <target>Произошла ошибка при создании поставщика.</target>
 </trans-unit>
 <trans-unit id="s072c6d12d3d37501">
   <source>HTTP-Basic Username Key</source>
@@ -1870,6 +2002,7 @@
 </trans-unit>
 <trans-unit id="sd144a9315e8f87c1">
   <source>http(s)://...</source>
+  <target>http(s)://...</target>
 </trans-unit>
 <trans-unit id="sf05e384059a0a7c1">
   <source>Upstream host that the requests are forwarded to.</source>
@@ -1921,6 +2054,7 @@
 </trans-unit>
 <trans-unit id="sf8633bb541bfb123">
   <source>domain.tld</source>
+  <target>домен.tld</target>
 </trans-unit>
 <trans-unit id="s211b75e868072162">
   <source>Set this to the domain you wish the authentication to be valid for. Must be a parent domain of the URL above. If you're running applications as app1.domain.tld, app2.domain.tld, set this to 'domain.tld'.</source>
@@ -1984,6 +2118,7 @@
 </trans-unit>
 <trans-unit id="s881271a499c9db98">
   <source>Configure Remote Access Provider</source>
+  <target>Настройка поставщика удаленного доступа</target>
 </trans-unit>
 <trans-unit id="sa2ea0fcd3ffa80e0">
   <source>Connection expiry</source>
@@ -2015,6 +2150,7 @@
 </trans-unit>
 <trans-unit id="sd5746b2550ac4852">
   <source>Certificate used for EAP-TLS. Requires Mutual TLS Stage in authentication flow.</source>
+  <target>Сертификат, используемый для EAP-TLS. Требуется этап взаимного TLS в потоке аутентификации.</target>
 </trans-unit>
 <trans-unit id="s2c8c6f89089b31d4">
   <source>Configure Radius Provider</source>
@@ -2026,43 +2162,55 @@
 </trans-unit>
 <trans-unit id="sb357ea19a722d827">
   <source>Post</source>
-  <target>Post</target>
+  <target>POST</target>
 </trans-unit>
 <trans-unit id="s5aebe06e3ddf6ca9">
   <source>Sign assertions</source>
+  <target>Подпишите утверждения</target>
 </trans-unit>
 <trans-unit id="s4e2329ffa0ef6b74">
   <source>When enabled, the assertion element of the SAML response will be signed.</source>
+  <target>Если этот параметр включен, элемент утверждения ответа SAML будет подписан.</target>
 </trans-unit>
 <trans-unit id="s2ad1b968b37ded68">
   <source>Sign responses</source>
+  <target>Подпишите ответы</target>
 </trans-unit>
 <trans-unit id="sa30ba280de276758">
   <source>When enabled, the SAML response will be signed.</source>
+  <target>Если эта опция включена, ответ SAML будет подписан.</target>
 </trans-unit>
 <trans-unit id="sa4bd902fbc432ab8">
   <source>Sign logout requests</source>
+  <target>Подписывать запросы на выход</target>
 </trans-unit>
 <trans-unit id="sb1e6dc6d91ce352e">
   <source>When enabled, SAML logout requests will be signed.</source>
+  <target>Если этот параметр включен, запросы на выход SAML будут подписаны.</target>
 </trans-unit>
 <trans-unit id="sd1ab93a011b2f1f5">
   <source>Front-channel (Iframe)</source>
+  <target>Фронтальный канал (Iframe)</target>
 </trans-unit>
 <trans-unit id="s885ea9abccda30d8">
   <source>Front-channel (Native)</source>
+  <target>Передний канал (родной)</target>
 </trans-unit>
 <trans-unit id="s34cd8ae3ee828045">
   <source>Back-channel (POST)</source>
+  <target>Обратный канал (POST)</target>
 </trans-unit>
 <trans-unit id="s7f7be294b1bef506">
   <source>SLS Binding</source>
+  <target>SLS-привязка</target>
 </trans-unit>
 <trans-unit id="s9104cd1063aa6a4a">
   <source>Determines how authentik sends the logout response back to the Service Provider.</source>
+  <target>Определяет, как authentik отправляет ответ о выходе обратно поставщику услуг.</target>
 </trans-unit>
 <trans-unit id="sd1fba3c745c016a8">
   <source>Method to use for logout when SLS URL is configured.</source>
+  <target>Метод, используемый для выхода из системы, если настроен URL-адрес SLS.</target>
 </trans-unit>
 <trans-unit id="s11204eeb1e27ea8f">
   <source>ACS URL</source>
@@ -2086,9 +2234,11 @@
 </trans-unit>
 <trans-unit id="sc71892084574cf32">
   <source>SLS URL</source>
+  <target>URL-адрес SLS</target>
 </trans-unit>
 <trans-unit id="s21658078c6fdf964">
   <source>Optional Single Logout Service URL to send logout responses to. If not set, no logout response will be sent.</source>
+  <target>Необязательный URL-адрес службы единого выхода из системы, на который можно отправлять ответы о выходе. Если не установлено, ответ на выход из системы отправлен не будет.</target>
 </trans-unit>
 <trans-unit id="sc741d9ebe07ad103">
   <source>Signing Certificate</source>
@@ -2112,6 +2262,7 @@
 </trans-unit>
 <trans-unit id="sb416d07987093cd5">
   <source>When selected, assertions will be encrypted using this keypair.</source>
+  <target>Если этот параметр выбран, утверждения будут зашифрованы с использованием этой пары ключей.</target>
 </trans-unit>
 <trans-unit id="s0619413371f33083">
   <source>Available User Property Mappings</source>
@@ -2131,9 +2282,11 @@
 </trans-unit>
 <trans-unit id="sc838e297aa5e58ba">
   <source>AuthnContextClassRef Property Mapping</source>
+  <target>Сопоставление свойств AuthnContextClassRef</target>
 </trans-unit>
 <trans-unit id="sd7ba1793c3abf4fe">
   <source>Configure how the AuthnContextClassRef value will be created. When left empty, the AuthnContextClassRef will be set based on which authentication methods the user used to authenticate.</source>
+  <target>Настройте способ создания значения AuthnContextClassRef. Если оставить пустым, AuthnContextClassRef будет установлен в зависимости от того, какие методы аутентификации использовал пользователь для аутентификации.</target>
 </trans-unit>
 <trans-unit id="s9f91cc8bcfabb40f">
   <source>Assertion valid not before</source>
@@ -2169,6 +2322,7 @@
 </trans-unit>
 <trans-unit id="s9839619155ed2cf6">
   <source>Default NameID Policy</source>
+  <target>Политика NameID по умолчанию</target>
 </trans-unit>
 <trans-unit id="s004e9a2c90f23900">
   <source>Persistent</source>
@@ -2192,6 +2346,7 @@
 </trans-unit>
 <trans-unit id="s0c48c5f754275796">
   <source>Configure the default NameID Policy used by IDP-initiated logins and when an incoming assertion doesn't specify a NameID Policy (also applies when using a custom NameID Mapping).</source>
+  <target>Настройте политику NameID по умолчанию, используемую при входе в систему, инициированном IDP, и когда входящее утверждение не указывает политику NameID (также применяется при использовании пользовательского сопоставления NameID).</target>
 </trans-unit>
 <trans-unit id="s2a0f60e74b478804">
   <source>Digest algorithm</source>
@@ -2211,18 +2366,23 @@
 </trans-unit>
 <trans-unit id="seb250c3885733522">
   <source>Token to authenticate with.</source>
+  <target>Токен для аутентификации.</target>
 </trans-unit>
 <trans-unit id="scdafec223d3840e9">
   <source>OAuth Source</source>
+  <target>Источник OAuth</target>
 </trans-unit>
 <trans-unit id="s2111b3384e12349c">
   <source>Specify OAuth source used for authentication.</source>
+  <target>Укажите источник OAuth, используемый для аутентификации.</target>
 </trans-unit>
 <trans-unit id="s1876401267e31dd0">
   <source>OAuth Parameters</source>
+  <target>Параметры OAuth</target>
 </trans-unit>
 <trans-unit id="sc5ca1b55a5391535">
   <source>Additional OAuth parameters, such as grant_type.</source>
+  <target>Дополнительные параметры OAuth, такие как Grant_type.</target>
 </trans-unit>
 <trans-unit id="sb21f33b039c86322">
   <source>SCIM base url, usually ends in /v2.</source>
@@ -2230,18 +2390,23 @@
 </trans-unit>
 <trans-unit id="s99060120f626df5b">
   <source>Verify SCIM server's certificates</source>
+  <target>Проверьте сертификаты сервера SCIM</target>
 </trans-unit>
 <trans-unit id="s6e4af789dec357dc">
   <source>Authentication Mode</source>
+  <target>Режим аутентификации</target>
 </trans-unit>
 <trans-unit id="s24d7ac2fc280ca5e">
   <source>Authenticate SCIM requests using a static token.</source>
+  <target>Аутентификация запросов SCIM с использованием статического токена.</target>
 </trans-unit>
 <trans-unit id="s1c34cb0a4cccc041">
   <source>Authenticate SCIM requests using OAuth.</source>
+  <target>Аутентификация запросов SCIM с использованием OAuth.</target>
 </trans-unit>
 <trans-unit id="s3483d693c72e412e">
   <source>Compatibility Mode</source>
+  <target>Режим совместимости</target>
 </trans-unit>
 <trans-unit id="s11326fd2590f4e5e">
   <source>Default</source>
@@ -2249,6 +2414,7 @@
 </trans-unit>
 <trans-unit id="se7195530fa981896">
   <source>Default behavior.</source>
+  <target>Поведение по умолчанию.</target>
 </trans-unit>
 <trans-unit id="sfa5ba219a0991116">
   <source>AWS</source>
@@ -2256,6 +2422,7 @@
 </trans-unit>
 <trans-unit id="s44e80dc905ab2ecc">
   <source>Altered behavior for usage with Amazon Web Services.</source>
+  <target>Изменено поведение при использовании Amazon Web Services.</target>
 </trans-unit>
 <trans-unit id="s2f5e2bcd583fbc27">
   <source>Slack</source>
@@ -2263,21 +2430,27 @@
 </trans-unit>
 <trans-unit id="s7f40ef46b7f213ea">
   <source>Altered behavior for usage with Slack.</source>
+  <target>Изменено поведение при использовании со Slack.</target>
 </trans-unit>
 <trans-unit id="s2ce58eab7841b342">
   <source>Salesforce</source>
+  <target>Salesforce</target>
 </trans-unit>
 <trans-unit id="s7392b5925a4803af">
   <source>Altered behavior for usage with Salesforce.</source>
+  <target>Изменено поведение при использовании с Salesforce.</target>
 </trans-unit>
 <trans-unit id="s054cb3c0a84eefe5">
   <source>Alter authentik's behavior for vendor-specific SCIM implementations.</source>
+  <target>Измените поведение authentik для реализаций SCIM конкретного поставщика.</target>
 </trans-unit>
 <trans-unit id="s4d3933feb8dc7cee">
   <source>Enable dry-run mode</source>
+  <target>Включить режим пробного запуска</target>
 </trans-unit>
 <trans-unit id="s8c9ca09b5eeb5ae9">
   <source>When enabled, mutating requests will be dropped and logged instead.</source>
+  <target>Если этот параметр включен, мутирующие запросы будут отбрасываться и регистрироваться.</target>
 </trans-unit>
 <trans-unit id="sfc8bb104e2c05af8">
   <source>User filtering</source>
@@ -2321,18 +2494,23 @@
 </trans-unit>
 <trans-unit id="s25afe36fa73d2e5b">
   <source>Sync settings</source>
+  <target>Синхронизировать настройки</target>
 </trans-unit>
 <trans-unit id="s2c859e13e182be6b">
   <source>Page size</source>
+  <target>Размер страницы</target>
 </trans-unit>
 <trans-unit id="sb984354bb46c8bed">
   <source>Controls the number of objects synced in a single task.</source>
+  <target>Управляет количеством объектов, синхронизируемых в одной задаче.</target>
 </trans-unit>
 <trans-unit id="sc24408fbc7ff26b5">
   <source>Page timeout</source>
+  <target>Тайм-аут страницы</target>
 </trans-unit>
 <trans-unit id="s7faa17601278029a">
   <source>Timeout for synchronization of a single page.</source>
+  <target>Таймаут синхронизации одной страницы.</target>
 </trans-unit>
 <trans-unit id="s7ccce0ec8d228db6">
   <source>Configure SCIM Provider</source>
@@ -2348,12 +2526,15 @@
 </trans-unit>
 <trans-unit id="s669b18c6d2d9c95b">
   <source>None</source>
+  <target>Никто</target>
 </trans-unit>
 <trans-unit id="s7055edd8fab866f4">
   <source>strict</source>
+  <target>строгий</target>
 </trans-unit>
 <trans-unit id="s5e57ca23b946c1b8">
   <source>regexp</source>
+  <target>регулярное выражение</target>
 </trans-unit>
 <trans-unit id="sc6e8a34361c7c272">
   <source>Forward auth (domain-level)</source>
@@ -2389,6 +2570,7 @@
 </trans-unit>
 <trans-unit id="sd226dc54c414585a">
   <source>Review and Submit Application</source>
+  <target>Просмотрите и подайте заявку</target>
 </trans-unit>
 <trans-unit id="scda8dc24b561e205">
   <source>There was an error in the application.</source>
@@ -2408,6 +2590,7 @@
 </trans-unit>
 <trans-unit id="s828ded9ade500ffc">
   <source>There was an error. Please go back and review the application.</source>
+  <target>Произошла ошибка. Пожалуйста, вернитесь и просмотрите заявку.</target>
 </trans-unit>
 <trans-unit id="s9fdda682893624a1">
   <source>There was an error:</source>
@@ -2415,6 +2598,7 @@
 </trans-unit>
 <trans-unit id="s201ee6bc6d9f97da">
   <source>Please go back and review the application.</source>
+  <target>Пожалуйста, вернитесь и просмотрите заявку.</target>
 </trans-unit>
 <trans-unit id="s7a6b3453209e1066">
   <source>There was an error creating the application, but no error message was sent. Please review the server logs.</source>
@@ -2422,6 +2606,7 @@
 </trans-unit>
 <trans-unit id="s9c09ef16900241fa">
   <source>Review the Application and Provider</source>
+  <target>Обзор приложения и поставщика</target>
 </trans-unit>
 <trans-unit id="s7f5869b3d14d7cbc">
   <source>Provider</source>
@@ -2433,9 +2618,11 @@
 </trans-unit>
 <trans-unit id="s0a0a21f7bcf9d865">
   <source>Saving application...</source>
+  <target>Сохранение приложения...</target>
 </trans-unit>
 <trans-unit id="se669a4b939be0891">
   <source>authentik was unable to complete this process.</source>
+  <target>authentik не смог завершить этот процесс.</target>
 </trans-unit>
 <trans-unit id="s71c5d51d5a357dbd">
   <source>Don't show this message again.</source>
@@ -2455,9 +2642,11 @@
 </trans-unit>
 <trans-unit id="sa9a4ce20b507b232">
   <source>New Provider</source>
+  <target>Новый провайдер</target>
 </trans-unit>
 <trans-unit id="sf397c39bda7abfc6">
   <source>Open the wizard to create a new provider.</source>
+  <target>Откройте мастер, чтобы создать нового поставщика.</target>
 </trans-unit>
 <trans-unit id="sa817aa9f6f88a991">
   <source>Credentials</source>
@@ -2557,12 +2746,15 @@
 </trans-unit>
 <trans-unit id="se8dd47dfaf01d6c9">
   <source>Key used to sign the events.</source>
+  <target>Ключ, используемый для подписи событий.</target>
 </trans-unit>
 <trans-unit id="sd1b31f8fba05d429">
   <source>Event Retention</source>
+  <target>Хранение событий</target>
 </trans-unit>
 <trans-unit id="sd760b123cced4675">
   <source>Determines how long events are stored for. If an event could not be sent correctly, its expiration is also increased by this duration.</source>
+  <target>Определяет, как долго хранятся события. Если событие не удалось отправить корректно, срок его действия также увеличивается на эту продолжительность.</target>
 </trans-unit>
 <trans-unit id="sb0b86b8ca6ab13bd">
   <source>Providers</source>
@@ -2574,6 +2766,7 @@
 </trans-unit>
 <trans-unit id="s0c9d1c885a69abe8">
   <source>Provider Search</source>
+  <target>Поиск поставщика</target>
 </trans-unit>
 <trans-unit id="s10929ca568ae10bc">
   <source>Provider(s)</source>
@@ -2589,6 +2782,7 @@
 </trans-unit>
 <trans-unit id="s0fb31bb136cc353a">
   <source>Provider not assigned to any application.</source>
+  <target>Поставщик не назначен ни одному приложению.</target>
 </trans-unit>
 <trans-unit id="s3b579c4bb6b447ae">
   <source>Successfully triggered sync.</source>
@@ -2600,9 +2794,11 @@
 </trans-unit>
 <trans-unit id="sc4bf1a365af696eb">
   <source>Override dry-run mode</source>
+  <target>Отмена режима сухого хода</target>
 </trans-unit>
 <trans-unit id="s94a5233931be4110">
   <source>When enabled, this sync will still execute mutating requests regardless of the dry-run mode in the provider.</source>
+  <target>Если эта синхронизация включена, она по-прежнему будет выполнять запросы на изменение независимо от режима пробного запуска в поставщике.</target>
 </trans-unit>
 <trans-unit id="s05073d2537b45d1a">
   <source>Sync</source>
@@ -2630,21 +2826,27 @@
 </trans-unit>
 <trans-unit id="s3f63421908094590">
   <source>Current status</source>
+  <target>Текущий статус</target>
 </trans-unit>
 <trans-unit id="s4412853e1655ebb3">
   <source>Sync is currently running.</source>
+  <target>Синхронизация в данный момент выполняется.</target>
 </trans-unit>
 <trans-unit id="s08661004803c26b0">
   <source>Sync is not currently running.</source>
+  <target>Синхронизация в данный момент не выполняется.</target>
 </trans-unit>
 <trans-unit id="s81d16aa9ec62262c">
   <source>Last successful sync</source>
+  <target>Последняя успешная синхронизация</target>
 </trans-unit>
 <trans-unit id="sd1eb8f8acdbcd1d3">
   <source>No successful sync found.</source>
+  <target>Успешная синхронизация не найдена.</target>
 </trans-unit>
 <trans-unit id="s6b0eeb3de1789c6e">
   <source>Last sync status</source>
+  <target>Статус последней синхронизации</target>
 </trans-unit>
 <trans-unit id="s6c3daaac4eed12f9">
   <source>Changelog</source>
@@ -2664,6 +2866,7 @@
 </trans-unit>
 <trans-unit id="sc2473aae093ce256">
   <source>Dry-run</source>
+  <target>Сухой ход</target>
 </trans-unit>
 <trans-unit id="sd520a4089006ca93">
   <source>Update Google Workspace Provider</source>
@@ -2687,6 +2890,7 @@
 </trans-unit>
 <trans-unit id="s5e0c81c05565bf42">
   <source>Using this form will only create an Application. In order to authenticate with the application, you will have to manually pair it with a Provider.</source>
+  <target>Использование этой формы приведет только к созданию приложения. Чтобы пройти аутентификацию в приложении, вам придется вручную связать его с провайдером.</target>
 </trans-unit>
 <trans-unit id="s350a616ff5e145ec">
   <source>Select a provider that this application should use.</source>
@@ -2754,7 +2958,7 @@
 </trans-unit>
 <trans-unit id="sb7794c2910b1a9ec">
   <source>Bind DN</source>
-  <target>Bind DN</target>
+  <target>DN для bind</target>
 </trans-unit>
 <trans-unit id="s5694f9421c428227">
   <source>Bind Password</source>
@@ -2910,6 +3114,7 @@
 </trans-unit>
 <trans-unit id="s48a0d160d9e0a7be">
   <source>Hostname/IP to connect to. Optionally specify the port.</source>
+  <target>Имя хоста/IP-адрес для подключения. При желании укажите порт.</target>
 </trans-unit>
 <trans-unit id="sc39f6abf0daedb0f">
   <source>Maximum concurrent connections</source>
@@ -2925,12 +3130,15 @@
 </trans-unit>
 <trans-unit id="s1ec022562e3d515b">
   <source>Search for users by username or display name...</source>
+  <target>Поиск пользователей по имени пользователя или отображаемому имени...</target>
 </trans-unit>
 <trans-unit id="s65f6a2f5e2b848e1">
   <source>Search Users</source>
+  <target>Поиск пользователей</target>
 </trans-unit>
 <trans-unit id="sd416adae573583d5">
   <source>Select Users</source>
+  <target>Выберите пользователей</target>
 </trans-unit>
 <trans-unit id="sa45a194b58837e4f">
   <source>Active</source>
@@ -2942,9 +3150,11 @@
 </trans-unit>
 <trans-unit id="s93d69514c94ad635">
   <source>Select users</source>
+  <target>Выберите пользователей</target>
 </trans-unit>
 <trans-unit id="sb85774dc5d18ff0f">
   <source>Confirm</source>
+  <target>Подтверждать</target>
 </trans-unit>
 <trans-unit id="s75d5ff5dd8d3c6d2">
   <source>Successfully updated group.</source>
@@ -2956,15 +3166,19 @@
 </trans-unit>
 <trans-unit id="s9436f1bf4400f6a6">
   <source>Type a group name...</source>
+  <target>Введите название группы...</target>
 </trans-unit>
 <trans-unit id="s2d9356347ff7c77f">
   <source>Group Name</source>
+  <target>Имя группы</target>
 </trans-unit>
 <trans-unit id="sf45dac7c571f18bd">
   <source>Superuser Privileges</source>
+  <target>Привилегии суперпользователя</target>
 </trans-unit>
 <trans-unit id="sbf8a7af4eafa87f8">
   <source>Whether users added to this group will have superuser privileges.</source>
+  <target>Будут ли пользователи, добавленные в эту группу, иметь права суперпользователя.</target>
 </trans-unit>
 <trans-unit id="s6b2beba7ab637e9e">
   <source>Roles</source>
@@ -3048,6 +3262,7 @@
 </trans-unit>
 <trans-unit id="sa82f8948649d0989">
   <source>Matches Event's Client IP (strict matching, for network matching use an Expression Policy).</source>
+  <target>Соответствует IP-адресу клиента события (строгое соответствие, для сопоставления сети используйте политику выражения).</target>
 </trans-unit>
 <trans-unit id="s5a15a8f39c699273">
   <source>Match events created by selected application. When left empty, all applications are matched.</source>
@@ -3087,42 +3302,55 @@
 </trans-unit>
 <trans-unit id="s035bfd9c5f97e4d3">
   <source>Distance settings</source>
+  <target>Настройки расстояния</target>
 </trans-unit>
 <trans-unit id="s207e6f8a8b3515fd">
   <source>Check historical distance of logins</source>
+  <target>Проверьте историческое расстояние входа в систему</target>
 </trans-unit>
 <trans-unit id="s8158f4b3e5c869be">
   <source>When this option enabled, the GeoIP data of the policy request is compared to the specified number of historical logins.</source>
+  <target>Если этот параметр включен, данные GeoIP запроса политики сравниваются с указанным количеством исторических входов в систему.</target>
 </trans-unit>
 <trans-unit id="sb8b7450c8515894c">
   <source>Maximum distance</source>
+  <target>Максимальное расстояние</target>
 </trans-unit>
 <trans-unit id="s40cdbaa532bc9899">
   <source>Maximum distance a login attempt is allowed from in kilometers.</source>
+  <target>Максимальное расстояние, с которого разрешена попытка входа в систему, в километрах.</target>
 </trans-unit>
 <trans-unit id="seef852b5c0f8a529">
   <source>Distance tolerance</source>
+  <target>Допуск на расстояние</target>
 </trans-unit>
 <trans-unit id="sce567ced300aeb8a">
   <source>Tolerance in checking for distances in kilometers.</source>
+  <target>Допуски при проверке расстояний в километрах.</target>
 </trans-unit>
 <trans-unit id="s9ea9cdabd74f8f97">
   <source>Historical Login Count</source>
+  <target>Историческое количество входов в систему</target>
 </trans-unit>
 <trans-unit id="s27aec4c2de1ae777">
   <source>Amount of previous login events to check against.</source>
+  <target>Количество предыдущих событий входа в систему, по которым необходимо свериться.</target>
 </trans-unit>
 <trans-unit id="s48611ce6e85874dc">
   <source>Check impossible travel</source>
+  <target>Проверить невозможность путешествия</target>
 </trans-unit>
 <trans-unit id="s8cf926e8311f8065">
   <source>When this option enabled, the GeoIP data of the policy request is compared to the specified number of historical logins and if the travel would have been possible in the amount of time since the previous event.</source>
+  <target>Если эта опция включена, данные GeoIP запроса политики сравниваются с указанным количеством исторических входов в систему и с тем, было ли путешествие возможным за период времени, прошедший с момента предыдущего события.</target>
 </trans-unit>
 <trans-unit id="sa963d05af436770b">
   <source>Impossible travel tolerance</source>
+  <target>Невозможная переносимость путешествий</target>
 </trans-unit>
 <trans-unit id="s5760cd97ca42a238">
   <source>Static rule settings</source>
+  <target>Статические настройки правил</target>
 </trans-unit>
 <trans-unit id="s26c2828bf8db525e">
   <source>ASNs</source>
@@ -3265,9 +3493,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s86cf007b861152ca">
   <source>Ensure that the user's new password is different from their previous passwords. The number of past passwords to check is configurable.</source>
+  <target>Убедитесь, что новый пароль пользователя отличается от его предыдущих паролей. Количество прошлых паролей для проверки можно настроить.</target>
 </trans-unit>
 <trans-unit id="s79b3fcd40dd63921">
   <source>Number of previous passwords to check</source>
+  <target>Количество предыдущих паролей для проверки</target>
 </trans-unit>
 <trans-unit id="s5b1fb0d4c0daeba8">
   <source>Create Binding</source>
@@ -3283,12 +3513,15 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sb3087c7347bed341">
   <source>Company employees with access to the full enterprise feature set.</source>
+  <target>Сотрудники компании имеют доступ к полному набору корпоративных функций.</target>
 </trans-unit>
 <trans-unit id="sc7266f960c466de6">
   <source>External consultants or B2C customers without access to enterprise features.</source>
+  <target>Внешние консультанты или клиенты B2C без доступа к корпоративным функциям.</target>
 </trans-unit>
 <trans-unit id="sf4ad4d9f8a5c868b">
   <source>Machine-to-machine authentication or other automations.</source>
+  <target>Межмашинная аутентификация или другие средства автоматизации.</target>
 </trans-unit>
 <trans-unit id="s3d2a8b86a4f5a810">
   <source>Successfully created user and added to group <x id="0" equiv-text="${this.targetGroup.name}"/></source>
@@ -3300,15 +3533,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s7819072445baceee">
   <source>The user's primary identifier used for authentication. 150 characters or fewer.</source>
+  <target>Основной идентификатор пользователя, используемый для аутентификации. 150 символов или меньше.</target>
 </trans-unit>
 <trans-unit id="s11b2e9ecce28690c">
   <source>Display Name</source>
+  <target>Отображаемое имя</target>
 </trans-unit>
 <trans-unit id="s237e9858014b1205">
   <source>Type an optional display name...</source>
+  <target>Введите необязательное отображаемое имя...</target>
 </trans-unit>
 <trans-unit id="sc82cf82ad6cb26cc">
   <source>The user's display name.</source>
+  <target>Отображаемое имя пользователя.</target>
 </trans-unit>
 <trans-unit id="s9f9492d30a96b9c6">
   <source>User type</source>
@@ -3320,15 +3557,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s755bfddac3729eaa">
   <source>Managed by authentik and cannot be assigned manually.</source>
+  <target>Управляется authentik и не может быть назначен вручную.</target>
 </trans-unit>
 <trans-unit id="s1e2e135dac5ba993">
   <source>Email Address</source>
+  <target>Адрес электронной почты</target>
 </trans-unit>
 <trans-unit id="s9fd0516c9193c73e">
   <source>Type an optional email address...</source>
+  <target>Введите дополнительный адрес электронной почты...</target>
 </trans-unit>
 <trans-unit id="s4c5000e84bc2189a">
   <source>Whether this user is active and allowed to authenticate. Setting this to inactive can be used to temporarily disable a user without deleting their account.</source>
+  <target>Активен ли этот пользователь и ему разрешено пройти аутентификацию. Установка этого параметра в неактивное значение может использоваться для временного отключения пользователя без удаления его учетной записи.</target>
 </trans-unit>
 <trans-unit id="s2e532e19ed477a56">
   <source>Path</source>
@@ -3336,12 +3577,15 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s3a15d06c4a39515a">
   <source>Type a path for the user...</source>
+  <target>Введите путь для пользователя...</target>
 </trans-unit>
 <trans-unit id="s1fa5309c30d174b7">
   <source>Paths can be used to organize users into folders depending on which source created them or organizational structure.</source>
+  <target>Пути можно использовать для организации пользователей по папкам в зависимости от источника, создавшего их, или организационной структуры.</target>
 </trans-unit>
 <trans-unit id="s5701b3d3a6678723">
   <source>Paths may not start or end with a slash, but they can contain any other character as path segments. The paths are currently purely used for organization, it does not affect their permissions, group memberships, or anything else.</source>
+  <target>Пути не могут начинаться или заканчиваться косой чертой, но могут содержать любые другие символы в качестве сегментов пути. В настоящее время пути используются исключительно для организации и не влияют на их разрешения, членство в группах или что-либо еще.</target>
 </trans-unit>
 <trans-unit id="s50c312bea93b6925">
   <source>Edit Policy</source>
@@ -3365,9 +3609,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s775f81ca91aa2d0c">
   <source>Policy actions</source>
+  <target>Политические действия</target>
 </trans-unit>
 <trans-unit id="sb7af25ce6e30d61a">
   <source>The currently selected policy engine mode is <x id="0" equiv-text="${policyEngineMode.label}"/>:</source>
+  <target>Текущий выбранный режим механизма политики — <x id="0" equiv-text="${policyEngineMode.label}"/>:</target>
 </trans-unit>
 <trans-unit id="s8276649077e8715c">
   <source>Endpoint(s)</source>
@@ -3455,12 +3701,15 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sc83697908e3e2b46">
   <source>SSF URL</source>
+  <target>URL-адрес SSF</target>
 </trans-unit>
 <trans-unit id="s5a1fc8f3b2e072d0">
   <source>No assigned application</source>
+  <target>Нет назначенного приложения</target>
 </trans-unit>
 <trans-unit id="sa412f34efd88e962">
   <source>Streams</source>
+  <target>Потоки</target>
 </trans-unit>
 <trans-unit id="s6ba50bb0842ba1e2">
   <source>Applications</source>
@@ -3468,6 +3717,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s66f572bec2bde9c4">
   <source>External applications that use <x id="0" equiv-text="${this.brandingTitle}"/> as an identity provider via protocols like OAuth2 and SAML. All applications are shown here, even ones you cannot access.</source>
+  <target>Внешние приложения, которые используют <x id="0" equiv-text="${this.brandingTitle}"/> в качестве поставщика удостоверений через такие протоколы, как OAuth2 и SAML. Здесь показаны все приложения, даже те, к которым у вас нет доступа.</target>
 </trans-unit>
 <trans-unit id="sb564f81eb057342e">
   <source>Application Icon</source>
@@ -3479,6 +3729,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s0a3fdba3a68a2730">
   <source>Applications Documentation</source>
+  <target>Документация по приложениям</target>
 </trans-unit>
 <trans-unit id="sd20f6cd02c90867f">
   <source>Application(s)</source>
@@ -3486,6 +3737,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sf07bfbe5316e7cc7">
   <source>Application icon for "<x id="0" equiv-text="${item.name}"/>"</source>
+  <target>Значок приложения для " <x id="0" equiv-text="${item.name}"/> "</target>
 </trans-unit>
 <trans-unit id="sa347e31efbb60be2">
   <source>Update Application</source>
@@ -3493,9 +3745,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s037f22187581bf8f">
   <source>Edit "<x id="0" equiv-text="${this.outpost?.name || &quot;outpost&quot;}"/>"</source>
+  <target>Изменить "<x id="0" equiv-text="${this.outpost?.name || &quot;outpost&quot;}"/>"</target>
 </trans-unit>
 <trans-unit id="sdb3b903354fbfb17">
   <source>Open "<x id="0" equiv-text="${item.name}"/>"</source>
+  <target>Открыть "<x id="0" equiv-text="${item.name}"/>"</target>
 </trans-unit>
 <trans-unit id="s1f7698c061c208c9">
   <source>Open</source>
@@ -3503,9 +3757,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s34661765d81e7340">
   <source>Successfully cleared application cache</source>
+  <target>Кеш приложения успешно очищен.</target>
 </trans-unit>
 <trans-unit id="s9377ae285bc0157c">
   <source>Failed to delete application cache</source>
+  <target>Не удалось удалить кэш приложения.</target>
 </trans-unit>
 <trans-unit id="s3ed5607ad78d4224">
   <source>Clear cache</source>
@@ -3513,9 +3769,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s754153d9e524ffce">
   <source>Clear Application cache</source>
+  <target>Очистить кэш приложения</target>
 </trans-unit>
 <trans-unit id="sea5092df2c72b064">
   <source>Are you sure you want to clear the application cache? This will cause all policies to be re-evaluated on their next usage.</source>
+  <target>Вы уверены, что хотите очистить кэш приложения? Это приведет к повторной оценке всех политик при их следующем использовании.</target>
 </trans-unit>
 <trans-unit id="sd9b556a84ae25690">
   <source>Successfully sent test-request.</source>
@@ -3523,36 +3781,47 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sa36117e97f49c86e">
   <source>Successfully updated entitlement.</source>
+  <target>Разрешение успешно обновлено.</target>
 </trans-unit>
 <trans-unit id="s86bee999b735111f">
   <source>Successfully created entitlement.</source>
+  <target>Разрешение успешно создано.</target>
 </trans-unit>
 <trans-unit id="s8a48455905fc14e6">
   <source>Application entitlement(s)</source>
+  <target>Права на применение</target>
 </trans-unit>
 <trans-unit id="sae971cbff672090b">
   <source>Update Entitlement</source>
+  <target>Обновить право</target>
 </trans-unit>
 <trans-unit id="s537a58ae0ff50f1c">
   <source>These bindings control which users have access to this entitlement.</source>
+  <target>Эти привязки определяют, какие пользователи имеют доступ к этому праву.</target>
 </trans-unit>
 <trans-unit id="s05849efeac672dc7">
   <source>No app entitlements created.</source>
+  <target>Права для приложений не созданы.</target>
 </trans-unit>
 <trans-unit id="sab4db6a3bd6abc1e">
   <source>This application does currently not have any application entitlements defined.</source>
+  <target>Для этого приложения в настоящее время не определены какие-либо права приложения.</target>
 </trans-unit>
 <trans-unit id="sf0bd204ce3fea1de">
   <source>Create Entitlement</source>
+  <target>Создать право</target>
 </trans-unit>
 <trans-unit id="s55d8e42d0a1c057e">
   <source>Create entitlement</source>
+  <target>Создать право</target>
 </trans-unit>
 <trans-unit id="sb6fcdabf769208a1">
   <source>Failed to fetch application "<x id="0" equiv-text="${this.applicationSlug}"/>".</source>
+  <target>Не удалось получить приложение «<x id="0" equiv-text="${this.applicationSlug}"/>».</target>
 </trans-unit>
 <trans-unit id="application.outpost.missing.warning">
   <source>Warning: Application is not used by any Outpost.</source>
+  <target>Внимание: Приложение не используется ни одним Outpost.</target>
 </trans-unit>
 <trans-unit id="sb6cbd4f92ebaf5d8">
   <source>Related</source>
@@ -3580,9 +3849,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sc6479479c936939f">
   <source>Application entitlements</source>
+  <target>Права приложения</target>
 </trans-unit>
 <trans-unit id="s8e1c375a007d1839">
   <source>These entitlements can be used to configure user access in this application.</source>
+  <target>Эти права можно использовать для настройки доступа пользователей в этом приложении.</target>
 </trans-unit>
 <trans-unit id="s2b1bc31276c4c477">
   <source>Policy / Group / User Bindings</source>
@@ -3590,6 +3861,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s64330d6dc06337c9">
   <source>Loading application...</source>
+  <target>Загрузка приложения...</target>
 </trans-unit>
 <trans-unit id="sea2f00b34b385a43">
   <source>Successfully updated device.</source>
@@ -3597,15 +3869,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s2b8e875dc18e2690">
   <source>Device name...</source>
+  <target>Имя устройства...</target>
 </trans-unit>
 <trans-unit id="s81f57ffc163f9f82">
   <source>Device name</source>
+  <target>Имя устройства</target>
 </trans-unit>
 <trans-unit id="s0ae9fd7db25fa3e0">
   <source>Device Group</source>
+  <target>Группа устройств</target>
 </trans-unit>
 <trans-unit id="s335acddfb181e9ad">
   <source>Connector setup</source>
+  <target>Настройка соединителя</target>
 </trans-unit>
 <trans-unit id="s3687049d1af562c4">
   <source>Copy</source>
@@ -3613,60 +3889,79 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sd1dc37bdc04758eb">
   <source>Download the latest package from here:</source>
+  <target>Загрузите последний пакет отсюда:</target>
 </trans-unit>
 <trans-unit id="sf96a86df0756bc7b">
   <source>Afterwards, select the enrollment token you want to use:</source>
+  <target>После этого выберите токен регистрации, который вы хотите использовать:</target>
 </trans-unit>
 <trans-unit id="s12f523a52b843ea2">
   <source>macOS</source>
+  <target>macOS</target>
 </trans-unit>
 <trans-unit id="s7845e3b545ffe6bd">
   <source>Linux</source>
+  <target>Линукс</target>
 </trans-unit>
 <trans-unit id="s50ad561b4139dc06">
   <source>Configured connector does not support setup.</source>
+  <target>Настроенный соединитель не поддерживает настройку.</target>
 </trans-unit>
 <trans-unit id="s3624e780118ae113">
   <source>No connectors configured. Navigate to connectors in the sidebar and create a connector.</source>
+  <target>Разъемы не настроены. Перейдите к соединителям на боковой панели и создайте соединитель.</target>
 </trans-unit>
 <trans-unit id="s8f26d4f086cc1323">
   <source>Unix</source>
+  <target>Юникс</target>
 </trans-unit>
 <trans-unit id="s16125219b0c92b52">
   <source>BSD</source>
+  <target>БСД</target>
 </trans-unit>
 <trans-unit id="sefe707c1bfb1d3cc">
   <source>Android</source>
+  <target>Андроид</target>
 </trans-unit>
 <trans-unit id="s2c0fca192c3375e6">
   <source>iOS</source>
+  <target>iOS</target>
 </trans-unit>
 <trans-unit id="scfe39d24bc958960">
   <source>Devices</source>
+  <target>Устройства</target>
 </trans-unit>
 <trans-unit id="s091d3507b5b2f9d7">
   <source>OS</source>
+  <target>ОС</target>
 </trans-unit>
 <trans-unit id="s150cf10289852e4a">
   <source>Endpoint Devices are in preview.</source>
+  <target>Конечные устройства находятся в предварительной версии.</target>
 </trans-unit>
 <trans-unit id="s672b3d1982f585fa">
   <source>Total devices</source>
+  <target>Всего устройств</target>
 </trans-unit>
 <trans-unit id="sf3a81f931deb9f96">
   <source>Total count of devices across all groups</source>
+  <target>Общее количество устройств во всех группах</target>
 </trans-unit>
 <trans-unit id="sd4566519aa4dbd8e">
   <source>Unreachable devices</source>
+  <target>Недоступные устройства</target>
 </trans-unit>
 <trans-unit id="sf1580fcb88cbcfd8">
   <source>Devices that authentik hasn't received information about in 24h.</source>
+  <target>Устройства, о которых authentik не получил информацию в течение 24 часов.</target>
 </trans-unit>
 <trans-unit id="s303ef08d87cd21fd">
   <source>Outdated agents</source>
+  <target>Устаревшие агенты</target>
 </trans-unit>
 <trans-unit id="s0a5821461d41f627">
   <source>Devices running an outdated version of an agent</source>
+  <target>Устройства с устаревшей версией агента</target>
 </trans-unit>
 <trans-unit id="sabb56f74492e7e96">
   <source>Update Device</source>
@@ -3674,15 +3969,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sf655f75d8e14d5fe">
   <source>Endpoint Device(s)</source>
+  <target>Конечное устройство(а)</target>
 </trans-unit>
 <trans-unit id="sd667856c73082c35">
   <source>Device <x id="0" equiv-text="${this.device?.name}"/></source>
+  <target>Устройство <x id="0" equiv-text="${this.device?.name}"/></target>
 </trans-unit>
 <trans-unit id="s6d4cc88f2426efaf">
   <source>Loading device...</source>
+  <target>Загрузочное устройство...</target>
 </trans-unit>
 <trans-unit id="s2addf9fd0d89ba11">
   <source>Device details</source>
+  <target>Сведения об устройстве</target>
 </trans-unit>
 <trans-unit id="s1e176e35c828318c">
   <source>Hostname</source>
@@ -3690,45 +3989,59 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s974564539ea1cafa">
   <source>Serial number</source>
+  <target>Серийный номер</target>
 </trans-unit>
 <trans-unit id="s361c13a7f20ea559">
   <source>Operating system</source>
+  <target>Операционная система</target>
 </trans-unit>
 <trans-unit id="se990a968b7dfcfd8">
   <source>Firewall enabled</source>
+  <target>Брандмауэр включен</target>
 </trans-unit>
 <trans-unit id="sc5e304b166165519">
   <source>Hardware</source>
+  <target>Аппаратное обеспечение</target>
 </trans-unit>
 <trans-unit id="scb320e45978d3390">
   <source>Manufacturer</source>
+  <target>Производитель</target>
 </trans-unit>
 <trans-unit id="s0b453a19aa0f85a9">
   <source>CPU</source>
+  <target>Процессор</target>
 </trans-unit>
 <trans-unit id="sa10af889ecd36687">
   <source><x id="0" equiv-text="${this.device?.facts?.data.hardware?.cpuCount}"/> x <x id="1" equiv-text="${this.device?.facts?.data.hardware?.cpuName}"/></source>
+  <target><x id="0" equiv-text="${this.device?.facts?.data.hardware?.cpuCount}"/> x <x id="1" equiv-text="${this.device?.facts?.data.hardware?.cpuName}"/></target>
 </trans-unit>
 <trans-unit id="s16e1bead7b9c95ce">
   <source>Memory</source>
+  <target>Память</target>
 </trans-unit>
 <trans-unit id="s94a50f1495fb5ccd">
   <source>Disk encryption</source>
+  <target>Шифрование диска</target>
 </trans-unit>
 <trans-unit id="s416211a967a6db4e">
   <source>Users / Groups</source>
+  <target>Пользователи/группы</target>
 </trans-unit>
 <trans-unit id="sfdd447bcde2c13ba">
   <source>Processes</source>
+  <target>Процессы</target>
 </trans-unit>
 <trans-unit id="s4a7ce90bfc6ce013">
   <source>Connector name</source>
+  <target>Имя соединителя</target>
 </trans-unit>
 <trans-unit id="s44200a04fda1fa29">
   <source>Flow used for users to authorize.</source>
+  <target>Поток, используемый для авторизации пользователей.</target>
 </trans-unit>
 <trans-unit id="s1d3f07bfba32fc84">
   <source>Certificate used for signing device compliance challenges.</source>
+  <target>Сертификат, используемый для подписи проблем соответствия устройств.</target>
 </trans-unit>
 <trans-unit id="sb85ffe141d7c229d">
   <source>Session duration</source>
@@ -3736,33 +4049,43 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s5567310faa112bc6">
   <source>Configure how long an authenticated session is valid for.</source>
+  <target>Настройте продолжительность действия аутентифицированного сеанса.</target>
 </trans-unit>
 <trans-unit id="sa3b5c0d4b4fd12ff">
   <source>Terminate authenticated sessions on token expiry</source>
+  <target>Завершить сеансы с аутентификацией по истечении срока действия токена</target>
 </trans-unit>
 <trans-unit id="sf4372a571ffb02cd">
   <source>Refresh interval</source>
+  <target>Интервал обновления</target>
 </trans-unit>
 <trans-unit id="s3f009bda38b93134">
   <source>Interval how frequently the agent tries to update its config.</source>
+  <target>Интервал, как часто агент пытается обновить свою конфигурацию.</target>
 </trans-unit>
 <trans-unit id="seb040746311faa64">
   <source>Unix settings</source>
+  <target>Настройки Юникс</target>
 </trans-unit>
 <trans-unit id="s5758d1421a791cc6">
   <source>NSS User ID offset</source>
+  <target>Смещение идентификатора пользователя NSS</target>
 </trans-unit>
 <trans-unit id="sfb33118d419cd3c0">
   <source>NSS Group ID offset</source>
+  <target>Смещение идентификатора группы NSS</target>
 </trans-unit>
 <trans-unit id="sffc7bf978a049970">
   <source>Connectors are required to create devices. Depending on connector type, agents either directly talk to them or they talk to and external API to create devices.</source>
+  <target>Для создания устройств необходимы соединители. В зависимости от типа соединителя агенты либо напрямую общаются с ними, либо обращаются к внешнему API для создания устройств.</target>
 </trans-unit>
 <trans-unit id="s80b0feb2a6b98ef9">
   <source>Connectors</source>
+  <target>Разъемы</target>
 </trans-unit>
 <trans-unit id="s06b8c7e7fb99c1d8">
   <source>Connector(s)</source>
+  <target>Разъем(ы)</target>
 </trans-unit>
 <trans-unit id="s476ffc07e6d66f18">
   <source>Successfully updated token.</source>
@@ -3778,6 +4101,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s47be0f8c26355135">
   <source>Token name</source>
+  <target>Имя токена</target>
 </trans-unit>
 <trans-unit id="s1b14062c44e5ef45">
   <source>Expiring</source>
@@ -3793,6 +4117,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="se85e2f1923fd96ac">
   <source>Enrollment Token(s)</source>
+  <target>Токен(ы) регистрации</target>
 </trans-unit>
 <trans-unit id="scc3487e74c5a3e89">
   <source>Copy token</source>
@@ -3800,15 +4125,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sfbf16ea8fef96f6d">
   <source>Enrollment Tokens</source>
+  <target>Токены регистрации</target>
 </trans-unit>
 <trans-unit id="s3a38fceae14534dd">
   <source>Device access groups</source>
+  <target>Группы доступа к устройствам</target>
 </trans-unit>
 <trans-unit id="sbe0fb540e9dee187">
   <source>Create groups of devices to manage access.</source>
+  <target>Создавайте группы устройств для управления доступом.</target>
 </trans-unit>
 <trans-unit id="s7924cdccf3592aa8">
   <source>Device Group(s)</source>
+  <target>Группа(ы) устройств</target>
 </trans-unit>
 <trans-unit id="s24875d5475e82526">
   <source>Successfully updated source.</source>
@@ -3852,9 +4181,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s8bf373b1a2bfefed">
   <source>Promoted</source>
+  <target>Продвинутый</target>
 </trans-unit>
 <trans-unit id="s4a600d70e4348810">
   <source>When enabled, this source will be displayed as a prominent button on the login page, instead of a small icon.</source>
+  <target>Если этот параметр включен, этот источник будет отображаться в виде заметной кнопки на странице входа, а не в виде маленького значка.</target>
 </trans-unit>
 <trans-unit id="s39d6971531a270b6">
   <source>Update internal password on login</source>
@@ -3874,14 +4205,15 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sf52ff57fd136cc2f">
   <source>Enable this option to write password changes made in authentik back to Kerberos. Ignored if sync is disabled.</source>
+  <target>Включите эту опцию, чтобы записать изменения пароля, сделанные в authentik, обратно в Kerberos. Игнорируется, если синхронизация отключена.</target>
 </trans-unit>
 <trans-unit id="s14a16542f956e11d">
   <source>Realm settings</source>
-  <target>Настройки Realm</target>
+  <target>Настройки области</target>
 </trans-unit>
 <trans-unit id="s9c2eae548d3c1c30">
   <source>Realm</source>
-  <target>Realm</target>
+  <target>Область</target>
 </trans-unit>
 <trans-unit id="s6b032212997e2491">
   <source>Kerberos 5 configuration</source>
@@ -3889,6 +4221,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sbf50181022f47de3">
   <source>Kerberos 5 configuration. See man krb5.conf(5) for configuration format. If left empty, a default krb5.conf will be used.</source>
+  <target>Конфигурация Керберос 5. См. man krb5.conf(5) для формата конфигурации. Если оставить пустым, будет использоваться файл krb5.conf по умолчанию.</target>
 </trans-unit>
 <trans-unit id="s81a87652ade099e4">
   <source>User matching mode</source>
@@ -3900,21 +4233,27 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s2386539a0bd62fab">
   <source>Sync connection settings</source>
+  <target>Синхронизировать настройки подключения</target>
 </trans-unit>
 <trans-unit id="s3cc2b33d2a8000d3">
   <source>KAdmin type</source>
+  <target>Тип КАдмина</target>
 </trans-unit>
 <trans-unit id="s624e1c8739507529">
   <source>MIT krb5 kadmin</source>
+  <target>MIT krb5 кадмин</target>
 </trans-unit>
 <trans-unit id="s6d225d9e74dfff6f">
   <source>Heimdal kadmin</source>
+  <target>Хеймдаль кадмин</target>
 </trans-unit>
 <trans-unit id="s0d1a6f3fe81351f8">
   <source>Sync principal</source>
+  <target>Принцип синхронизации</target>
 </trans-unit>
 <trans-unit id="sa691d6e1974295fa">
   <source>Principal used to authenticate to the KDC for syncing.</source>
+  <target>Принципал используется для аутентификации в KDC для синхронизации.</target>
 </trans-unit>
 <trans-unit id="s977b9c629eed3d33">
   <source>Sync password</source>
@@ -3922,42 +4261,55 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s77772860385de948">
   <source>Password used to authenticate to the KDC for syncing. Optional if Sync keytab or Sync credentials cache is provided.</source>
+  <target>Пароль, используемый для аутентификации в KDC для синхронизации. Необязательно, если предусмотрена вкладка «Синхронизация ключей» или «Кэш учетных данных синхронизации».</target>
 </trans-unit>
 <trans-unit id="sc59ec59c3d5e74dc">
   <source>Sync keytab</source>
+  <target>Синхронизация клавиатуры</target>
 </trans-unit>
 <trans-unit id="scd42997958453f05">
   <source>Keytab used to authenticate to the KDC for syncing. Optional if Sync password or Sync credentials cache is provided. Must be base64 encoded or in the form TYPE:residual.</source>
+  <target>Keytab используется для аутентификации в KDC для синхронизации. Необязательно, если указан пароль синхронизации или кэш учетных данных синхронизации. Должно быть в кодировке Base64 или в форме TYPE:residual.</target>
 </trans-unit>
 <trans-unit id="s60eaf439ccdca1f2">
   <source>Sync credentials cache</source>
+  <target>Синхронизировать кэш учетных данных</target>
 </trans-unit>
 <trans-unit id="s95722900b0c9026f">
   <source>Credentials cache used to authenticate to the KDC for syncing. Optional if Sync password or Sync keytab is provided. Must be in the form TYPE:residual.</source>
+  <target>Кэш учетных данных, используемый для аутентификации в KDC для синхронизации. Необязательно, если указан пароль синхронизации или вкладка клавиатуры синхронизации. Должен быть в форме ТИП:остаток.</target>
 </trans-unit>
 <trans-unit id="sf9c055db98d7994a">
   <source>SPNEGO settings</source>
+  <target>Настройки СПНЕГО</target>
 </trans-unit>
 <trans-unit id="sab580a45dc46937f">
   <source>SPNEGO server name</source>
+  <target>Имя сервера SPNEGO</target>
 </trans-unit>
 <trans-unit id="s7a79d6174d17ab2d">
   <source>Force the use of a specific server name for SPNEGO. Must be in the form HTTP@domain</source>
+  <target>Принудительно использовать определенное имя сервера для SPNEGO. Должно быть в формате HTTP@домен.</target>
 </trans-unit>
 <trans-unit id="sa4ba2b2081472ccd">
   <source>SPNEGO keytab</source>
+  <target>Клавиатура SPNEGO</target>
 </trans-unit>
 <trans-unit id="s64adda975c1106c0">
   <source>Keytab used for SPNEGO. Optional if SPNEGO credentials cache is provided. Must be base64 encoded or in the form TYPE:residual.</source>
+  <target>Keytab используется для SPNEGO. Необязательно, если предоставляется кэш учетных данных SPNEGO. Должно быть в кодировке Base64 или в форме TYPE:residual.</target>
 </trans-unit>
 <trans-unit id="s92247825b92587b5">
   <source>SPNEGO credentials cache</source>
+  <target>Кэш учетных данных SPNEGO</target>
 </trans-unit>
 <trans-unit id="sd9757c345e4062f8">
   <source>Credentials cache used for SPNEGO. Optional if SPNEGO keytab is provided. Must be in the form TYPE:residual.</source>
+  <target>Кэш учетных данных, используемый для SPNEGO. Необязательно, если имеется таблица ключей SPNEGO. Должен быть в форме ТИП:остаток.</target>
 </trans-unit>
 <trans-unit id="s734ab8fbcae0b69e">
   <source>Kerberos Attribute mapping</source>
+  <target>Сопоставление атрибутов Kerberos</target>
 </trans-unit>
 <trans-unit id="s8e2de27afeb78e5a">
   <source>Property mappings for user creation.</source>
@@ -3997,9 +4349,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s42b57339ad2f3ac7">
   <source>Delete Not Found Objects</source>
+  <target>Удалить не найденные объекты</target>
 </trans-unit>
 <trans-unit id="se3b26b762110bda0">
   <source>Delete authentik users and groups which were previously supplied by this source, but are now missing from it.</source>
+  <target>Удалите пользователей и группы authentik, которые ранее были предоставлены этим источником, но теперь в нем отсутствуют.</target>
 </trans-unit>
 <trans-unit id="s2035f889f576bca6">
   <source>Connection settings</source>
@@ -4043,7 +4397,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sb7684e2910a33a1f">
   <source>Bind CN</source>
-  <target>Bind CN</target>
+  <target>CN для bind</target>
 </trans-unit>
 <trans-unit id="s3de6db803012016a">
   <source>LDAP Attribute mapping</source>
@@ -4055,6 +4409,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sfa6b7b105640e457">
   <source>Additional User DN</source>
+  <target>Дополнительный DN пользователя</target>
 </trans-unit>
 <trans-unit id="s9ae089fd248e72db">
   <source>Additional user DN, prepended to the Base DN.</source>
@@ -4062,6 +4417,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s04bb32ec9f359507">
   <source>Additional Group DN</source>
+  <target>Дополнительный групповой DN</target>
 </trans-unit>
 <trans-unit id="sfae9f4ea5749a36b">
   <source>Additional group DN, prepended to the Base DN.</source>
@@ -4089,18 +4445,23 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s4e1d2cb86cf5ecd0">
   <source>Field which contains members of a group. The value of this field is matched against User membership attribute.</source>
+  <target>Поле, содержащее участников группы. Значение этого поля сопоставляется с атрибутом членства пользователя.</target>
 </trans-unit>
 <trans-unit id="s6478025f3e0174fa">
   <source>User membership attribute</source>
+  <target>Атрибут членства пользователя</target>
 </trans-unit>
 <trans-unit id="s344be99cf5d36407">
   <source>Attribute which matches the value of Group membership field.</source>
+  <target>Атрибут, соответствующий значению поля «Членство в группе».</target>
 </trans-unit>
 <trans-unit id="s1d47b4f61ca53e8e">
   <source>Lookup using user attribute</source>
+  <target>Поиск с использованием атрибута пользователя</target>
 </trans-unit>
 <trans-unit id="s17359123e1f24504">
   <source>Field which contains DNs of groups the user is a member of. This field is used to lookup groups from users, e.g. 'memberOf'. To lookup nested groups in an Active Directory environment use 'memberOf:1.2.840.113556.1.4.1941:'.</source>
+  <target>Поле, содержащее DN групп, членом которых является пользователь. Это поле используется для поиска групп пользователей, например. 'членОф'. Для поиска вложенных групп в среде Active Directory используйтеmemberOf:1.2.840.113556.1.4.1941:.</target>
 </trans-unit>
 <trans-unit id="s026555347e589f0e">
   <source>Object uniqueness field</source>
@@ -4112,15 +4473,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s4d5cb134999b50df">
   <source>HTTP Basic Auth</source>
+  <target>Базовая HTTP-аутентификация</target>
 </trans-unit>
 <trans-unit id="s6927635d1c339cfc">
   <source>Include the client ID and secret as request parameters</source>
+  <target>Включите идентификатор и секрет клиента в качестве параметров запроса.</target>
 </trans-unit>
 <trans-unit id="s139200afa0695967">
   <source>Plain</source>
+  <target>Простой</target>
 </trans-unit>
 <trans-unit id="s7a316723c6bb33eb">
   <source>S256</source>
+  <target>С256</target>
 </trans-unit>
 <trans-unit id="sd04376c4216c921f">
   <source>URL settings</source>
@@ -4168,7 +4533,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s9db2c836ade1339c">
   <source>OIDC JWKS URL</source>
-  <target>OIDC JWKS URL</target>
+  <target>URL OIDC JWKS</target>
 </trans-unit>
 <trans-unit id="s4b2a1b657c160f5b">
   <source>JSON Web Key URL. Keys from the URL will be used to validate JWTs from this source.</source>
@@ -4184,15 +4549,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s311c22ee852736e9">
   <source>PKCE Method</source>
+  <target>Метод ПКСЕ</target>
 </trans-unit>
 <trans-unit id="sa9afb0f84a3c380d">
   <source>Configure Proof Key for Code Exchange for this source.</source>
+  <target>Настройте ключ подтверждения для обмена кодами для этого источника.</target>
 </trans-unit>
 <trans-unit id="s4fca384c634e1a92">
   <source>Authorization code authentication method</source>
+  <target>Метод аутентификации по коду авторизации</target>
 </trans-unit>
 <trans-unit id="sdc02c276ed429008">
   <source>How to perform authentication during an authorization_code token request flow</source>
+  <target>Как выполнить аутентификацию во время потока запроса токена авторизации_кода</target>
 </trans-unit>
 <trans-unit id="se8987bdfb35e46b2">
   <source>Consumer key</source>
@@ -4224,6 +4593,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s4f820625804ed29b">
   <source>Re-authenticate with Plex</source>
+  <target>Повторная аутентификация с помощью Plex</target>
 </trans-unit>
 <trans-unit id="sc297b2e13c28ecf9">
   <source>Allow friends to authenticate via Plex, even if you don't share any servers</source>
@@ -4243,15 +4613,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s2e7448caf3df574a">
   <source>Verify Assertion Signature</source>
+  <target>Проверка подписи утверждения</target>
 </trans-unit>
 <trans-unit id="s0069939a0fcc3986">
   <source>When enabled, authentik will look for a Signature inside of the Assertion element.</source>
+  <target>Если эта функция включена, authentik будет искать подпись внутри элемента утверждения.</target>
 </trans-unit>
 <trans-unit id="s6bf8b26e6e8a7059">
   <source>Verify Response Signature</source>
+  <target>Проверка подписи ответа</target>
 </trans-unit>
 <trans-unit id="s435805a99af456d3">
   <source>When enabled, authentik will look for a Signature inside of the Response element.</source>
+  <target>Если эта опция включена, authentik будет искать подпись внутри элемента Response.</target>
 </trans-unit>
 <trans-unit id="s31d7f3ba04d306a5">
   <source>SSO URL</source>
@@ -4339,15 +4713,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sd5d9adfcbd8abdfe">
   <source>Bot username</source>
+  <target>Имя пользователя бота</target>
 </trans-unit>
 <trans-unit id="saf5316edc3679fef">
   <source>Bot token</source>
+  <target>Токен бота</target>
 </trans-unit>
 <trans-unit id="s64b935d223a99731">
   <source>Request access to send messages from your bot</source>
+  <target>Запросить доступ для отправки сообщений от вашего бота</target>
 </trans-unit>
 <trans-unit id="s500a041b1fab7aac">
   <source>Telegram Attribute mapping</source>
+  <target>Сопоставление атрибутов Telegram</target>
 </trans-unit>
 <trans-unit id="sb1a4e9b288e2f005">
   <source>Federation and Social login</source>
@@ -4371,6 +4749,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="scc1a17d28912e974">
   <source>Kerberos Source is in preview.</source>
+  <target>Источник Kerberos находится в предварительной версии.</target>
 </trans-unit>
 <trans-unit id="s2c378e86e025fdb2">
   <source>Update Kerberos Source</source>
@@ -4449,9 +4828,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s463491b90193d86b">
   <source>Telegram bot</source>
+  <target>Телеграм-бот</target>
 </trans-unit>
 <trans-unit id="s4014853299a8bb20">
   <source>Update Telegram Source</source>
+  <target>Обновить исходный код Telegram</target>
 </trans-unit>
 <trans-unit id="s643d8f2e5e5e930d">
   <source>Successfully updated mapping.</source>
@@ -4639,6 +5020,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s98d6b06b0fb7da64">
   <source>Logo shown in sidebar/header and flow executor.</source>
+  <target>Логотип отображается на боковой панели/заголовке и в исполнителе потока.</target>
 </trans-unit>
 <trans-unit id="s3626433940124897">
   <source>Favicon</source>
@@ -4650,9 +5032,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s8e56764914a939d2">
   <source>Default flow background</source>
+  <target>Фон потока по умолчанию</target>
 </trans-unit>
 <trans-unit id="sea64900dbcf879c8">
   <source>Default background used during flow execution. Can be overridden per flow.</source>
+  <target>Фон по умолчанию, используемый во время выполнения потока. Может быть переопределено для каждого потока.</target>
 </trans-unit>
 <trans-unit id="sf16aa54bf77362e1">
   <source>Custom CSS</source>
@@ -4660,6 +5044,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s6171ded034da4e96">
   <source>Custom CSS to apply to pages when this brand is active.</source>
+  <target>Пользовательский CSS для применения к страницам, когда этот бренд активен.</target>
 </trans-unit>
 <trans-unit id="sd61a4f736ac0a98e">
   <source>External user settings</source>
@@ -4671,6 +5056,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s2643b2f95c0c38a0">
   <source>Select an application...</source>
+  <target>Выберите приложение...</target>
 </trans-unit>
 <trans-unit id="sac85801a25b7bb27">
   <source>When configured, external users will automatically be redirected to this application when not attempting to access a different application</source>
@@ -4694,6 +5080,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s5d4669050d36a5ab">
   <source>Select a recovery flow...</source>
+  <target>Выберите процесс восстановления...</target>
 </trans-unit>
 <trans-unit id="s836aa192b30c21da">
   <source>Unenrollment flow</source>
@@ -4701,6 +5088,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s796ab9d9a9131241">
   <source>Select an unenrollment flow...</source>
+  <target>Выберите процесс отмены регистрации...</target>
 </trans-unit>
 <trans-unit id="s081d3c4b47a6ff83">
   <source>If set, users are able to unenroll themselves using this flow. If no flow is set, option is not shown.</source>
@@ -4712,6 +5100,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s1fe26d2eb791caec">
   <source>Select a user settings flow...</source>
+  <target>Выберите поток настроек пользователя...</target>
 </trans-unit>
 <trans-unit id="s523160b433311521">
   <source>If set, users are able to configure details of their profile.</source>
@@ -4723,6 +5112,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s70d02f31fd256eff">
   <source>Select a device code flow...</source>
+  <target>Выберите поток кода устройства...</target>
 </trans-unit>
 <trans-unit id="s7b298427bdea81ae">
   <source>If set, the OAuth Device Code profile can be used, and the selected flow will be used to enter the code.</source>
@@ -4738,12 +5128,15 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s2c42bb3c6f5420d2">
   <source>Client Certificates</source>
+  <target>Клиентские сертификаты</target>
 </trans-unit>
 <trans-unit id="s95901716c0629274">
   <source>Available Certificates</source>
+  <target>Доступные сертификаты</target>
 </trans-unit>
 <trans-unit id="sdbf6b484fa1436b0">
   <source>Selected Certificates</source>
+  <target>Выбранные сертификаты</target>
 </trans-unit>
 <trans-unit id="s17260b71484b307f">
   <source>Set custom attributes using YAML or JSON. Any attributes set here will be inherited by users, if the request is handled by this brand.</source>
@@ -4751,6 +5144,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s4270ebcf645b9df5">
   <source>Search by domain or brand name...</source>
+  <target>Поиск по домену или названию бренда...</target>
 </trans-unit>
 <trans-unit id="s79fc990a2b58f27f">
   <source>Brands</source>
@@ -4835,9 +5229,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sf0d94539428a0900">
   <source>Search for a group by name…</source>
+  <target>Поиск группы по названию…</target>
 </trans-unit>
 <trans-unit id="s77ec9e27e9ae81b8">
   <source>Group Search</source>
+  <target>Групповой поиск</target>
 </trans-unit>
 <trans-unit id="s9f26843287bb592d">
   <source>Groups</source>
@@ -4857,6 +5253,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s79683026e49e4866">
   <source>View details of group "<x id="0" equiv-text="${item.name}"/>"</source>
+  <target>Посмотреть подробную информацию о группе "<x id="0" equiv-text="${item.name}"/>"</target>
 </trans-unit>
 <trans-unit id="s7c5774fad9d050ce">
   <source>Create group</source>
@@ -4864,9 +5261,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s66752390605b7d37">
   <source>Create and assign a group with the same name as the user.</source>
+  <target>Создайте и назначьте группу с тем же именем, что и у пользователя.</target>
 </trans-unit>
 <trans-unit id="s0137933e117f2092">
   <source>Whether the token will expire. Upon expiration, the token will be rotated.</source>
+  <target>Срок действия токена истечет. По истечении срока действия токен будет ротирован.</target>
 </trans-unit>
 <trans-unit id="s6b6e6eb037aef7da">
   <source>Use the username and password below to authenticate. The password can be retrieved later on the Tokens page.</source>
@@ -4878,21 +5277,27 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s1fd02f07e4fa3312">
   <source>Impersonating user...</source>
+  <target>Выдавая себя за пользователя...</target>
 </trans-unit>
 <trans-unit id="s12928f97c99f88db">
   <source>This may take a few seconds.</source>
+  <target>Это может занять несколько секунд.</target>
 </trans-unit>
 <trans-unit id="saa29a2ac03cd9d19">
   <source>Reason</source>
+  <target>Причина</target>
 </trans-unit>
 <trans-unit id="se9fd92a824994eba">
   <source>Reason for impersonating the user</source>
+  <target>Причина выдачи себя за пользователя</target>
 </trans-unit>
 <trans-unit id="sbc4f2320a13d4dfd">
   <source>A brief explanation of why you are impersonating the user. This will be included in audit logs.</source>
+  <target>Краткое объяснение того, почему вы выдаете себя за пользователя. Это будет включено в журналы аудита.</target>
 </trans-unit>
 <trans-unit id="s8563c5a14e9a42f2">
   <source>New Password</source>
+  <target>Новый пароль</target>
 </trans-unit>
 <trans-unit id="sc92d7cfb6ee1fec6">
   <source>Successfully updated password.</source>
@@ -4912,6 +5317,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s3d0a5ad9bdb617e2">
   <source>Open user selection dialog</source>
+  <target>Открыть диалог выбора пользователя</target>
 </trans-unit>
 <trans-unit id="s424f57afae0caac4">
   <source>Add users</source>
@@ -4959,6 +5365,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s547b687213f48489">
   <source>Update <x id="0" equiv-text="${formatUserDisplayName(user)}"/>'s password</source>
+  <target>Обновить пароль <x id="0" equiv-text="${formatUserDisplayName(user)}"/></target>
 </trans-unit>
 <trans-unit id="sce8d867ca5f35304">
   <source>Set password</source>
@@ -4978,6 +5385,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sac6c67e92bd30229">
   <source>Assign Additional Users</source>
+  <target>Назначение дополнительных пользователей</target>
 </trans-unit>
 <trans-unit id="s4c41f3f4c23e8eaa">
   <source>Warning: This group is configured with superuser access. Added users will have superuser access.</source>
@@ -4985,6 +5393,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s462975174949cfc0">
   <source>New User</source>
+  <target>Новый пользователь</target>
 </trans-unit>
 <trans-unit id="s824e0943a7104668">
   <source>This user will be added to the group "<x id="0" equiv-text="${this.targetGroup.name}"/>".</source>
@@ -5008,18 +5417,23 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sb26035b596566abf">
   <source>Unnamed</source>
+  <target>Безымянный</target>
 </trans-unit>
 <trans-unit id="s326ee20bba2564a0">
   <source>Collapse "<x id="0" equiv-text="${itemLabel}"/>"</source>
+  <target>Свернуть " <x id="0" equiv-text="${itemLabel}"/> "</target>
 </trans-unit>
 <trans-unit id="s27df1f36ba8e269f">
   <source>Expand "<x id="0" equiv-text="${itemLabel}"/>"</source>
+  <target>Развернуть "<x id="0" equiv-text="${itemLabel}"/>"</target>
 </trans-unit>
 <trans-unit id="sf2b5d3236e6f1ab3">
   <source>Select "<x id="0" equiv-text="${itemLabel}"/>"</source>
+  <target>Выберите «<x id="0" equiv-text="${itemLabel}"/>»</target>
 </trans-unit>
 <trans-unit id="sb7c2715df863a6ce">
   <source>Items of "<x id="0" equiv-text="${itemLabel}"/>"</source>
+  <target>Предметы "<x id="0" equiv-text="${itemLabel}"/>"</target>
 </trans-unit>
 <trans-unit id="sca7cfe2bef51b2a5">
   <source>Root</source>
@@ -5027,12 +5441,15 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s3ef09dfdd0568b6e">
   <source>Search by username, email, etc...</source>
+  <target>Поиск по имени пользователя, электронной почте и т. д.</target>
 </trans-unit>
 <trans-unit id="sd65f96914ccbeb76">
   <source>User Search</source>
+  <target>Поиск пользователей</target>
 </trans-unit>
 <trans-unit id="s1367dcd6e8749fcd">
   <source>No name set</source>
+  <target>Имя не установлено</target>
 </trans-unit>
 <trans-unit id="s895514dda9cb9c94">
   <source>Create recovery link</source>
@@ -5044,6 +5461,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s441f155311f1748a">
   <source>User paths</source>
+  <target>Пути пользователя</target>
 </trans-unit>
 <trans-unit id="sa982875b258fea07">
   <source>Successfully added user to group(s).</source>
@@ -5150,6 +5568,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="source-settings-list-item-label">
   <source>"<x id="0" equiv-text="${source.title}"/>" source</source>
+  <target>Источник "<x id="0" equiv-text="${source.title}"/>"</target>
 </trans-unit>
 <trans-unit id="s7968dbed9b106c29">
   <source>No services available.</source>
@@ -5157,6 +5576,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s20b2b040b332bb55">
   <source>Source Settings</source>
+  <target>Настройки источника</target>
 </trans-unit>
 <trans-unit id="sf05c700a1250824e">
   <source>Confirmed</source>
@@ -5176,6 +5596,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sbfee780fa0a2c83e">
   <source>Device type <x id="0" equiv-text="${device.verboseName}"/> cannot be deleted</source>
+  <target>Тип устройства <x id="0" equiv-text="${device.verboseName}"/> невозможно удалить.</target>
 </trans-unit>
 <trans-unit id="sa0b01f479f40c52d">
   <source>Device(s)</source>
@@ -5259,27 +5680,35 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s6ea6a64acb45dfdf">
   <source>Successfully updated initial permissions.</source>
+  <target>Первоначальные разрешения успешно обновлены.</target>
 </trans-unit>
 <trans-unit id="sfddf7896ab5938b6">
   <source>Successfully created initial permissions.</source>
+  <target>Первоначальные разрешения успешно созданы.</target>
 </trans-unit>
 <trans-unit id="s5c5f240cbb6d0bae">
   <source>When a user with the selected Role creates an object, the Initial Permissions will be applied to that object.</source>
+  <target>Когда пользователь с выбранной ролью создает объект, к этому объекту будут применены первоначальные разрешения.</target>
 </trans-unit>
 <trans-unit id="s93f04537efda1b24">
   <source>Available Permissions</source>
+  <target>Доступные разрешения</target>
 </trans-unit>
 <trans-unit id="s297bc57f9e494470">
   <source>Selected Permissions</source>
+  <target>Выбранные разрешения</target>
 </trans-unit>
 <trans-unit id="s0ea71d53764d781c">
   <source>Permissions to grant when a new object is created.</source>
+  <target>Разрешения, предоставляемые при создании нового объекта.</target>
 </trans-unit>
 <trans-unit id="s891cd64acabf23bf">
   <source>Initial Permissions</source>
+  <target>Начальные разрешения</target>
 </trans-unit>
 <trans-unit id="s06fc21a40f5d7de1">
   <source>Set initial permissions for newly created objects.</source>
+  <target>Установите начальные разрешения для вновь создаваемых объектов.</target>
 </trans-unit>
 <trans-unit id="s526e2c66bd51ff5f">
   <source>Role Info</source>
@@ -5287,6 +5716,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s7e796fe83982863f">
   <source>Role <x id="0" equiv-text="${this.targetRole.name}"/></source>
+  <target>Роль <x id="0" equiv-text="${this.targetRole.name}"/></target>
 </trans-unit>
 <trans-unit id="s7a322c89298dd27c">
   <source>Successfully updated invitation.</source>
@@ -5298,6 +5728,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s0433d667ea6eec1a">
   <source>The name of an invitation must be a slug: only lower case letters, numbers, and the hyphen are permitted here.</source>
+  <target>Имя приглашения должно быть кратким: здесь разрешены только строчные буквы, цифры и дефис.</target>
 </trans-unit>
 <trans-unit id="sfcebd18506f1e535">
   <source>Flow</source>
@@ -5593,6 +6024,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sd2b106933823b754">
   <source>When using a Duo MFA, Access or Beyond plan, an Admin API application can be created. This will allow authentik to import devices automatically.</source>
+  <target>При использовании плана Duo MFA, Access или Beyond можно создать приложение Admin API. Это позволит authentik автоматически импортировать устройства.</target>
 </trans-unit>
 <trans-unit id="s9a34d1520e320465">
   <source>Stage-specific settings</source>
@@ -5636,24 +6068,31 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sca2487321ec12bd6">
   <source>Email address the verification email will be sent from.</source>
+  <target>Адрес электронной почты, с которого будет отправлено письмо с подтверждением.</target>
 </trans-unit>
 <trans-unit id="s24a8fdfc73e8137f">
   <source>Stage used to configure an email-based authenticator.</source>
+  <target>Этап, используемый для настройки аутентификатора на основе электронной почты.</target>
 </trans-unit>
 <trans-unit id="sea0da186a814a212">
   <source>Use global connection settings</source>
+  <target>Использовать глобальные настройки подключения</target>
 </trans-unit>
 <trans-unit id="s7754fa56a4439de4">
   <source>When enabled, global email connection settings will be used and connection settings below will be ignored.</source>
+  <target>Если этот параметр включен, будут использоваться глобальные настройки подключения к электронной почте, а приведенные ниже настройки подключения будут игнорироваться.</target>
 </trans-unit>
 <trans-unit id="s7e2bcca51126ec9c">
   <source>Subject of the verification email.</source>
+  <target>Тема письма с подтверждением.</target>
 </trans-unit>
 <trans-unit id="sc12c90b1da0f3a47">
   <source>Token expiration</source>
+  <target>Срок действия токена</target>
 </trans-unit>
 <trans-unit id="sc264a82f9c710f14">
   <source>Time the token sent is valid (Format: hours=3,minutes=17,seconds=300).</source>
+  <target>Время, когда отправленный токен действителен (формат: часы=3,минуты=17,секунды=300).</target>
 </trans-unit>
 <trans-unit id="se47baf2fd16b9d2b">
   <source>Template</source>
@@ -5661,9 +6100,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s503217f10ebdc63e">
   <source>Loading templates...</source>
+  <target>Загрузка шаблонов...</target>
 </trans-unit>
 <trans-unit id="s6891d230751dd7bf">
   <source>Template used for the verification email.</source>
+  <target>Шаблон, используемый для письма с подтверждением.</target>
 </trans-unit>
 <trans-unit id="s3baf512851453712">
   <source>Twilio Account SID</source>
@@ -5739,6 +6180,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s3c619d54c995d4ab">
   <source>Modify the payload sent to the provider.</source>
+  <target>Измените полезную нагрузку, отправленную провайдеру.</target>
 </trans-unit>
 <trans-unit id="s0ae0072614320ae2">
   <source>Hash phone number</source>
@@ -5802,6 +6244,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s15986693bfc99fb7">
   <source>Email-based Authenticators</source>
+  <target>Аутентификаторы на основе электронной почты</target>
 </trans-unit>
 <trans-unit id="s0e15f678445dfc45">
   <source>Stage used to validate any authenticator. This stage should be used during authentication or authorization flows.</source>
@@ -5837,9 +6280,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s7bd456df0becbbff">
   <source>Available Stages</source>
+  <target>Доступные этапы</target>
 </trans-unit>
 <trans-unit id="sf80798d2f56b540b">
   <source>Selected Stages</source>
+  <target>Избранные этапы</target>
 </trans-unit>
 <trans-unit id="s6941a67f0038ba4c">
   <source>Stages used to configure Authenticator when user doesn't have any compatible devices. After this configuration Stage passes, the user is not prompted again.</source>
@@ -5927,9 +6372,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sbd65aeeb8a3b9bbc">
   <source>Maximum registration attempts</source>
+  <target>Максимальное количество попыток регистрации</target>
 </trans-unit>
 <trans-unit id="s8495753cb15e8d8e">
   <source>Maximum allowed registration attempts. When set to 0 attempts, attempts are not limited.</source>
+  <target>Максимально допустимое количество попыток регистрации. Если установлено значение 0 попыток, количество попыток не ограничивается.</target>
 </trans-unit>
 <trans-unit id="sa64fb483becc9c2c">
   <source>Device type restrictions</source>
@@ -5945,6 +6392,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s6f4f35a5a4b9b3cb">
   <source>Interactive</source>
+  <target>Интерактивный</target>
 </trans-unit>
 <trans-unit id="s1cd617e7bbe278d0">
   <source>Prompt for the user's consent. The consent can either be permanent or expire in a defined amount of time.</source>
@@ -5956,9 +6404,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s2e5226fcf269689b">
   <source>Consent given lasts indefinitely</source>
+  <target>Данное согласие действует бессрочно</target>
 </trans-unit>
 <trans-unit id="s7eff620292ed9349">
   <source>Consent expires</source>
+  <target>Срок действия согласия истекает</target>
 </trans-unit>
 <trans-unit id="s6f328f2d8382d998">
   <source>Consent expires in</source>
@@ -6006,12 +6456,15 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s32fc592c4a264edd">
   <source>Account Recovery Max Attempts</source>
+  <target>Максимальное количество попыток восстановления учетной записи</target>
 </trans-unit>
 <trans-unit id="s8341dba451980abe">
   <source>Account Recovery Cache Timeout</source>
+  <target>Тайм-аут кэша восстановления учетной записи</target>
 </trans-unit>
 <trans-unit id="sede4ad68849ce0c5">
   <source>The time window used to count recent account recovery attempts.</source>
+  <target>Временной интервал, используемый для подсчета недавних попыток восстановления учетной записи.</target>
 </trans-unit>
 <trans-unit id="sc7d071fb5cc1f6bf">
   <source>A selection is required</source>
@@ -6039,9 +6492,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s54154a8d64a3597b">
   <source>Captcha stage</source>
+  <target>Этап капчи</target>
 </trans-unit>
 <trans-unit id="s0c250af62ddbf801">
   <source>When set, adds functionality exactly like a Captcha stage, but baked into the Identification stage.</source>
+  <target>Если этот параметр установлен, добавляется функциональность, аналогичная этапу Captcha, но встроенная в этап идентификации.</target>
 </trans-unit>
 <trans-unit id="sd97d8d0906e6cc47">
   <source>Case insensitive matching</source>
@@ -6069,9 +6524,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s844baf19a6c4a9b4">
   <source>Enable "Remember me on this device"</source>
+  <target>Включите «Запомнить меня на этом устройстве»</target>
 </trans-unit>
 <trans-unit id="sfa72bca733f40692">
   <source>When enabled, the user can save their username in a cookie, allowing them to skip directly to entering their password.</source>
+  <target>Если эта функция включена, пользователь может сохранить свое имя пользователя в файле cookie, что позволяет ему сразу перейти к вводу пароля.</target>
 </trans-unit>
 <trans-unit id="s0295ce5d6f635d75">
   <source>Source settings</source>
@@ -6123,27 +6580,35 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s9300147e327fd8f6">
   <source>Client-certificate/mTLS authentication/enrollment.</source>
+  <target>Сертификат клиента/аутентификация/регистрация mTLS.</target>
 </trans-unit>
 <trans-unit id="sbf990ec848470f5c">
   <source>Certificate optional</source>
+  <target>Сертификат необязательно</target>
 </trans-unit>
 <trans-unit id="s72e2876e9409b9eb">
   <source>If no certificate was provided, this stage will succeed and continue to the next stage.</source>
+  <target>Если сертификат не был предоставлен, этот этап завершится успешно и перейдет к следующему этапу.</target>
 </trans-unit>
 <trans-unit id="se07d973901a6e6b9">
   <source>Certificate required</source>
+  <target>Требуется сертификат</target>
 </trans-unit>
 <trans-unit id="s664c47df020ee414">
   <source>If no certificate was provided, this stage will stop flow execution.</source>
+  <target>Если сертификат не был предоставлен, на этом этапе выполнение потока будет остановлено.</target>
 </trans-unit>
 <trans-unit id="sbe9da6dad795aa39">
   <source>Certificate authorities</source>
+  <target>Центры сертификации</target>
 </trans-unit>
 <trans-unit id="se3a6aa4f0ab7568e">
   <source>Configure the certificate authority client certificates are validated against. The certificate authority can also be configured on a brand, which allows for different certificate authorities for different domains.</source>
+  <target>Настройте центр сертификации, по которому проверяются сертификаты клиента. Центр сертификации также можно настроить для бренда, что позволяет использовать разные центры сертификации для разных доменов.</target>
 </trans-unit>
 <trans-unit id="sb8fdf5a09a969870">
   <source>Certificate attribute</source>
+  <target>Атрибут сертификата</target>
 </trans-unit>
 <trans-unit id="sd4ac926e4ebb1cd7">
   <source>Common Name</source>
@@ -6151,12 +6616,15 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s8069037a865037c9">
   <source>Configure the attribute of the certificate used to look for a user.</source>
+  <target>Настройте атрибут сертификата, используемый для поиска пользователя.</target>
 </trans-unit>
 <trans-unit id="sc185a8ad96f8eaa2">
   <source>User attribute</source>
+  <target>Атрибут пользователя</target>
 </trans-unit>
 <trans-unit id="s4f9860fefb8fbe01">
   <source>Configure the attribute of the user used to look for a user.</source>
+  <target>Настройте атрибут пользователя, используемый для поиска пользователя.</target>
 </trans-unit>
 <trans-unit id="sba42248f3f27955c">
   <source>User database + standard password</source>
@@ -6172,6 +6640,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s03e4044abe0b556c">
   <source>User database + Kerberos password</source>
+  <target>База данных пользователей + пароль Kerberos</target>
 </trans-unit>
 <trans-unit id="sdc30bddeda2f0225">
   <source>Validate the user's password against the selected backend(s).</source>
@@ -6187,6 +6656,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s69bc087c166b4177">
   <source>Flow used by an authenticated user to configure their password. If empty, user will not be able to change their password.</source>
+  <target>Поток, используемый прошедшим проверку подлинности пользователем для настройки своего пароля. Если поле пусто, пользователь не сможет изменить свой пароль.</target>
 </trans-unit>
 <trans-unit id="s77994108c886b965">
   <source>Failed attempts before cancel</source>
@@ -6202,6 +6672,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s2d5f69929bb7221d">
   <source><x id="0" equiv-text="${p.name}"/> ("<x id="1" equiv-text="${p.fieldKey}"/>", of type <x id="2" equiv-text="${p.type}"/>)</source>
+  <target><x id="0" equiv-text="${p.name}"/> ("<x id="1" equiv-text="${p.fieldKey}"/>", типа <x id="2" equiv-text="${p.type}"/>)</target>
 </trans-unit>
 <trans-unit id="s5170f9ef331949c0">
   <source>Show arbitrary input fields to the user, for example during enrollment. Data is saved in the flow context under the 'prompt_data' variable.</source>
@@ -6213,9 +6684,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sf651943c3ddff635">
   <source>Available Fields</source>
+  <target>Доступные поля</target>
 </trans-unit>
 <trans-unit id="s80ba9c5ebb7826a9">
   <source>Selected Fields</source>
+  <target>Выбранные поля</target>
 </trans-unit>
 <trans-unit id="s3b7b519444181264">
   <source>Validation Policies</source>
@@ -6235,6 +6708,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sad9d5481474d4f5b">
   <source>Static</source>
+  <target>Статический</target>
 </trans-unit>
 <trans-unit id="se87a96950464bc89">
   <source>Target URL</source>
@@ -6242,15 +6716,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s7f3097955b19736a">
   <source>Redirect the user to a static URL.</source>
+  <target>Перенаправьте пользователя на статический URL-адрес.</target>
 </trans-unit>
 <trans-unit id="s9bdee1c5130c8240">
   <source>Target Flow</source>
+  <target>Целевой поток</target>
 </trans-unit>
 <trans-unit id="sa5d1405b8d6529c7">
   <source>Redirect the user to a Flow.</source>
+  <target>Перенаправьте пользователя в поток.</target>
 </trans-unit>
 <trans-unit id="s7c9db337d14d42b3">
   <source>Keep flow context</source>
+  <target>Сохранять контекст потока</target>
 </trans-unit>
 <trans-unit id="s02160dc6adba3456">
   <source>Inject an OAuth or SAML Source into the flow execution. This allows for additional user verification, or to dynamically access different sources for different user identifiers (username, email address, etc).</source>
@@ -6298,9 +6776,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sa3ff409b84679db8">
   <source>Remember device</source>
+  <target>Запомнить устройство</target>
 </trans-unit>
 <trans-unit id="s3b123cba0bf03f29">
   <source>If set to a duration above 0, a cookie will be stored for the duration specified which will allow authentik to know if the user is signing in from a new device.</source>
+  <target>Если установлено значение продолжительности выше 0, файл cookie будет храниться в течение указанного времени, что позволит authentik узнать, входит ли пользователь в систему с нового устройства.</target>
 </trans-unit>
 <trans-unit id="s663ccbfdf27e8dd0">
   <source>Network binding</source>
@@ -6446,6 +6926,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s37e1bad4bf0e9241">
   <source>Evaluate policies before the Stage is presented to the user.</source>
+  <target>Оценивайте политики до того, как этап будет представлен пользователю.</target>
 </trans-unit>
 <trans-unit id="s0dc46deb8f181baf">
   <source>Invalid response behavior</source>
@@ -6502,9 +6983,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="sabf8a430d504f8c8">
   <source>Endpoint Google Chrome Device Trust is in preview.</source>
+  <target>Конечная точка Google Chrome Device Trust находится в предварительной версии.</target>
 </trans-unit>
 <trans-unit id="s336936629cdeb3e5">
   <source>Stage used to verify users' browsers using Google Chrome Device Trust. This stage can be used in authentication/authorization flows.</source>
+  <target>Этап, используемый для проверки браузеров пользователей с помощью Google Chrome Device Trust. Этот этап можно использовать в потоках аутентификации/авторизации.</target>
 </trans-unit>
 <trans-unit id="s85fe794c71b4ace8">
   <source>Google Verified Access API</source>
@@ -6556,6 +7039,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s0d7dea184036a74d">
   <source>Require no authentication</source>
+  <target>Не требовать аутентификации</target>
 </trans-unit>
 <trans-unit id="s66f533986ba6182c">
   <source>Require superuser</source>
@@ -6563,9 +7047,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s26c0a8789930b5fd">
   <source>Require being redirected from another flow</source>
+  <target>Требовать перенаправления из другого потока</target>
 </trans-unit>
 <trans-unit id="sbfaee8cfbf4e44e8">
   <source>Require Outpost (flow can only be executed from an outpost)</source>
+  <target>Требовать аванпост (поток может быть выполнен только с аванпоста)</target>
 </trans-unit>
 <trans-unit id="sfad9279cc42c6b61">
   <source>Required authentication level for this flow.</source>
@@ -6621,6 +7107,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s8b0e21adf383c8ba">
   <source>.yaml files, which can be found in the Example Flows documentation</source>
+  <target>Файлы .yaml, которые можно найти в документации по примерам потоков.</target>
 </trans-unit>
 <trans-unit id="sc816360d6f5a1eeb">
   <source>Flows describe a chain of Stages to authenticate, enroll or recover a user. Stages are chosen based on policies applied to them.</source>
@@ -6632,6 +7119,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s5d90aeadfcb34286">
   <source>Execute "<x id="0" equiv-text="${item.name}"/>"</source>
+  <target>Выполните "<x id="0" equiv-text="${item.name}"/>"</target>
 </trans-unit>
 <trans-unit id="sc4fdeccf14be5378">
   <source>Execute</source>
@@ -6639,6 +7127,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="saa25eac2952d918d">
   <source>Export "<x id="0" equiv-text="${item.name}"/>"</source>
+  <target>Экспортировать "<x id="0" equiv-text="${item.name}"/>"</target>
 </trans-unit>
 <trans-unit id="s293aa6a6446fb153">
   <source>Export</source>
@@ -6704,6 +7193,7 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s61e5043203e94d0a">
   <source>Execute "<x id="0" equiv-text="${this.flow.name}"/>" normally</source>
+  <target>Выполните «<x id="0" equiv-text="${this.flow.name}"/>» как обычно.</target>
 </trans-unit>
 <trans-unit id="s9ff3121d30f88d52">
   <source>Normal</source>
@@ -6711,15 +7201,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s02eb960c270a837e">
   <source>Execute "<x id="0" equiv-text="${this.flow.name}"/>" as current user</source>
+  <target>Выполните «<x id="0" equiv-text="${this.flow.name}"/>» от имени текущего пользователя.</target>
 </trans-unit>
 <trans-unit id="saf579a36a54c92e1">
   <source>Current user</source>
+  <target>Текущий пользователь</target>
 </trans-unit>
 <trans-unit id="sd149e44e50455923">
   <source>Execute "<x id="0" equiv-text="${this.flow.name}"/>" with inspector</source>
+  <target>Выполните «<x id="0" equiv-text="${this.flow.name}"/>» с помощью инспектора.</target>
 </trans-unit>
 <trans-unit id="s45c530a48bcf74ad">
   <source>Use inspector</source>
+  <target>Использовать инспектор</target>
 </trans-unit>
 <trans-unit id="se2c3cbf2ed1403f1">
   <source>Stage Bindings</source>
@@ -6792,15 +7286,19 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s04fbc36687266544">
   <source>Webhook Body Mapping</source>
+  <target>Сопоставление тела вебхука</target>
 </trans-unit>
 <trans-unit id="s149fd588c9f4b891">
   <source>Webhook Header Mapping</source>
+  <target>Сопоставление заголовков веб-перехватчиков</target>
 </trans-unit>
 <trans-unit id="sf1fc82d7ae3f4d81">
   <source>Email Subject Prefix</source>
+  <target>Префикс темы электронной почты</target>
 </trans-unit>
 <trans-unit id="s66401e0b2526acab">
   <source>Email Template</source>
+  <target>Шаблон электронной почты</target>
 </trans-unit>
 <trans-unit id="s819509c33a7534ac">
   <source>Notification Transports</source>
@@ -6824,9 +7322,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s2e9d5ea88f02ae68">
   <source>Select the group of users which the alerts are sent to. </source>
+  <target>Выберите группу пользователей, которым будут отправляться оповещения.</target>
 </trans-unit>
 <trans-unit id="s47966b2a708694e2">
   <source>Send notification to event user</source>
+  <target>Отправить уведомление пользователю события</target>
 </trans-unit>
 <trans-unit id="sffa171e11d4ae513">
   <source>Transports</source>
@@ -6834,9 +7334,11 @@ doesn't pass when either or both of the selected options are equal or above the 
 </trans-unit>
 <trans-unit id="s26733a6289ca6f1a">
   <source>Available Transports</source>
+  <target>Доступные транспорты</target>
 </trans-unit>
 <trans-unit id="sa65f772cfc5aa67e">
   <source>Selected Transports</source>
+  <target>Избранные транспорты</target>
 </trans-unit>
 <trans-unit id="s7b18721be331241e">
   <source>Select which transports should be used to notify the user. If none are selected, the notification will only be shown in the authentik UI.</source>
@@ -6948,6 +7450,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s354405ae02cb262d">
   <source>Last seen: <x id="0" equiv-text="${formatElapsedTime(lastSeen)}"/> (<x id="1" equiv-text="${lastSeen.toLocaleTimeString()}"/>)</source>
+  <target>Последний раз был на связи: <x id="0" equiv-text="${formatElapsedTime(lastSeen)}"/> ( <x id="1" equiv-text="${lastSeen.toLocaleTimeString()}"/> )</target>
 </trans-unit>
 <trans-unit id="s5e169e1bac20b4a6">
   <source>Outposts</source>
@@ -6998,6 +7501,7 @@ Bindings to groups/users are checked against the user of the event.</source>
   <source>Can be in the format of <x id="0" equiv-text="&lt;code&gt;"/>unix://<x id="1" equiv-text="&lt;/code&gt;"/> when connecting to a local
                             docker daemon, using <x id="2" equiv-text="&lt;code&gt;"/>ssh://<x id="3" equiv-text="&lt;/code&gt;"/> to connect via SSH, or
                             <x id="4" equiv-text="&lt;code&gt;"/>https://:2376<x id="5" equiv-text="&lt;/code&gt;"/> when connecting to a remote system.</source>
+  <target>Может быть в формате <x id="0" equiv-text="&lt;code&gt;"/> unix:// <x id="1" equiv-text="&lt;/code&gt;"/> при подключении к локальному демону Docker, используя <x id="2" equiv-text="&lt;code&gt;"/> ssh:// <x id="3" equiv-text="&lt;/code&gt;"/> для подключения через SSH или <x id="4" equiv-text="&lt;code&gt;"/> https://:2376 <x id="5" equiv-text="&lt;/code&gt;"/> при подключении к удаленной системе.</target>
 </trans-unit>
 <trans-unit id="saf1d289e3137c2ea">
   <source>CA which the endpoint's Certificate is verified against. Can be left empty for no validation.</source>
@@ -7146,6 +7650,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s8f36fb59c31d33eb">
   <source>Link Title</source>
+  <target>Название ссылки</target>
 </trans-unit>
 <trans-unit id="s634e2fd82c397576">
   <source>Successfully updated settings.</source>
@@ -7244,6 +7749,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 <trans-unit id="h3ac79dc5cc553329">
   <source>When using an external logging solution for archiving, this can be
                                 set to <x id="0" equiv-text="&lt;code&gt;"/>minutes=5<x id="1" equiv-text="&lt;/code&gt;"/>.</source>
+  <target>При использовании внешнего решения для ведения журналов для архивирования для этого параметра можно установить значение <x id="0" equiv-text="&lt;code&gt;"/> минут=5 <x id="1" equiv-text="&lt;/code&gt;"/> .</target>
 </trans-unit>
 <trans-unit id="s44536d20bb5c8257">
   <source>This setting only affects new Events, as the expiration is saved per-event.</source>
@@ -7251,15 +7757,19 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="se37ac6cf9c72f21a">
   <source>Reputation: lower limit</source>
+  <target>Репутация: нижний предел</target>
 </trans-unit>
 <trans-unit id="sa634ffa797037aac">
   <source>Reputation cannot decrease lower than this value. Zero or negative.</source>
+  <target>Репутация не может упасть ниже этого значения. Ноль или отрицательный.</target>
 </trans-unit>
 <trans-unit id="s862986ce8e70edd7">
   <source>Reputation: upper limit</source>
+  <target>Репутация: верхний предел</target>
 </trans-unit>
 <trans-unit id="sdd04913b3b46cf30">
   <source>Reputation cannot increase higher than this value. Zero or positive.</source>
+  <target>Репутация не может вырасти выше этого значения. Ноль или положительный.</target>
 </trans-unit>
 <trans-unit id="s57b52b60ed5e2bc7">
   <source>Footer links</source>
@@ -7267,6 +7777,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s92205c10ba1f0f4c">
   <source>This option configures the footer links on the flow executor pages. The URL is limited to web and mail addresses. If the name is left blank, the URL will be shown.</source>
+  <target>Этот параметр настраивает ссылки нижнего колонтитула на страницах исполнителя потока. URL-адрес ограничен веб-адресами и адресами электронной почты. Если имя оставить пустым, будет показан URL-адрес.</target>
 </trans-unit>
 <trans-unit id="s166b59f3cc5d8ec3">
   <source>GDPR compliance</source>
@@ -7286,9 +7797,11 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s29fab8887734192f">
   <source>Require reason for impersonation</source>
+  <target>Требовать причину выдачи себя за другое лицо</target>
 </trans-unit>
 <trans-unit id="sc24af6de78468cfa">
   <source>Require administrators to provide a reason for impersonating a user.</source>
+  <target>Требовать от администраторов указания причины выдачи себя за пользователя.</target>
 </trans-unit>
 <trans-unit id="s4888252cbd785175">
   <source>Default token duration</source>
@@ -7308,6 +7821,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s2de7890b100c4f4c">
   <source>Flags</source>
+  <target>Флаги</target>
 </trans-unit>
 <trans-unit id="s33f85f24c0f5f008">
   <source>Save</source>
@@ -7339,16 +7853,20 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sa556d7b744364dcf">
   <source>OCI URL</source>
+  <target>URL-адрес OCI</target>
 </trans-unit>
 <trans-unit id="h3b1f38bb34f8b1b6">
   <source> A valid OCI manifest URL, prefixed with the protocol
                                               e.g. <x id="0" equiv-text="&lt;code&gt;"/>oci://registry.domain.tld/path/to/manifest<x id="1" equiv-text="&lt;/code&gt;"/></source>
+  <target>Действительный URL-адрес манифеста OCI с префиксом протокола, например.  <x id="0" equiv-text="&lt;code&gt;"/> oci://registry.domain.tld/path/to/manifest <x id="1" equiv-text="&lt;/code&gt;"/></target>
 </trans-unit>
 <trans-unit id="sc19e397bee1e67f7">
   <source>Read more about</source>
+  <target>Подробнее о</target>
 </trans-unit>
 <trans-unit id="sa777a614e18a35cd">
   <source>OCI Support</source>
+  <target>Поддержка OCI</target>
 </trans-unit>
 <trans-unit id="sfae395b94a5a0040">
   <source>Blueprint</source>
@@ -7380,6 +7898,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s6f8d15b5494ac41a">
   <source>Apply "<x id="0" equiv-text="${item.name}"/>" blueprint</source>
+  <target>Примените план «<x id="0" equiv-text="${item.name}"/>»</target>
 </trans-unit>
 <trans-unit id="sb8f855b49234b81b">
   <source>Apply</source>
@@ -7403,12 +7922,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sd923f95605fed7b2">
   <source>Expired</source>
+  <target>Истекший</target>
 </trans-unit>
 <trans-unit id="s86959994f28077dc">
   <source>Expiring soon</source>
+  <target>Срок действия скоро истекает</target>
 </trans-unit>
 <trans-unit id="sc60a5fba70bf5a53">
   <source>Unlicensed</source>
+  <target>Нелицензионный</target>
 </trans-unit>
 <trans-unit id="s4f9880ce82953741">
   <source>Read Only</source>
@@ -7416,6 +7938,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s4220dda46d622211">
   <source>Valid</source>
+  <target>Действительный</target>
 </trans-unit>
 <trans-unit id="sdc94711a2eb66a45">
   <source>Current license status</source>
@@ -7447,9 +7970,11 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sde9a3f41977ec1f8">
   <source>Estimated user count one year from now based on <x id="0" equiv-text="${internalUsers}"/> current internal users and <x id="1" equiv-text="${forecastedInternalUsers}"/> forecasted internal users.</source>
+  <target>Предполагаемое количество пользователей через год основано на текущих внутренних пользователях <x id="0" equiv-text="${internalUsers}"/> и прогнозируемых внутренних пользователях <x id="1" equiv-text="${forecastedInternalUsers}"/>.</target>
 </trans-unit>
 <trans-unit id="s531571491deb239a">
   <source>Approximately</source>
+  <target>Примерно</target>
 </trans-unit>
 <trans-unit id="s4557b6b9da258643">
   <source>Forecast external users</source>
@@ -7457,6 +7982,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sf52479d6daa0a4a8">
   <source>Estimated user count one year from now based on <x id="0" equiv-text="${externalUsers}"/> current external users and <x id="1" equiv-text="${forecastedExternalUsers}"/> forecasted external users.</source>
+  <target>Предполагаемое количество пользователей через год основано на текущих внешних пользователях <x id="0" equiv-text="${externalUsers}"/> и прогнозируемых внешних пользователях <x id="1" equiv-text="${forecastedExternalUsers}"/>.</target>
 </trans-unit>
 <trans-unit id="sd22bd01bdf28c548">
   <source>Cumulative license expiry</source>
@@ -7464,6 +7990,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sc62e587718608e85">
   <source>No expiry</source>
+  <target>Нет срока действия</target>
 </trans-unit>
 <trans-unit id="s0dd031b58ed4017c">
   <source>Internal: <x id="0" equiv-text="${item.internalUsers}"/></source>
@@ -7495,6 +8022,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s35429c9dc2319aea">
   <source>Development</source>
+  <target>Разработка</target>
 </trans-unit>
 <trans-unit id="s5937938934a777ab">
   <source>UI Version</source>
@@ -7526,12 +8054,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sd51d6a39208696cc">
   <source>Collapse <x id="0" equiv-text="${this.label}"/></source>
+  <target>Свернуть <x id="0" equiv-text="${this.label}"/></target>
 </trans-unit>
 <trans-unit id="scce64bcfb0a73ad7">
   <source>Expand <x id="0" equiv-text="${this.label}"/></source>
+  <target>Развернуть <x id="0" equiv-text="${this.label}"/></target>
 </trans-unit>
 <trans-unit id="sfe1fb536cab6c0f5">
   <source><x id="0" equiv-text="${this.label}"/> navigation</source>
+  <target><x id="0" equiv-text="${this.label}"/> навигация</target>
 </trans-unit>
 <trans-unit id="s8849ece8c65e3a18">
   <source>Dashboards</source>
@@ -7539,6 +8070,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s0393ac07cf8a3097">
   <source>Endpoint Devices</source>
+  <target>Конечные устройства</target>
 </trans-unit>
 <trans-unit id="s4f1ad6b48a5df506">
   <source>Logs</source>
@@ -7602,9 +8134,11 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s1381314790b50b1f">
   <source>A newer version (<x id="0" equiv-text="${this.version.versionCurrent}"/>) of the UI is available.</source>
+  <target>Доступна более новая версия ( <x id="0" equiv-text="${this.version.versionCurrent}"/> ) пользовательского интерфейса.</target>
 </trans-unit>
 <trans-unit id="sf6707428adeba590">
   <source>API drawer</source>
+  <target>ящик API</target>
 </trans-unit>
 <trans-unit id="s32a3efa23718e713">
   <source>API Requests</source>
@@ -7616,12 +8150,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sf3b5b13c6b55eb4c">
   <source>Close API drawer</source>
+  <target>Закрыть панель API</target>
 </trans-unit>
 <trans-unit id="sfa991acd65f738bf">
   <source>View details for <x id="0" equiv-text="${label}"/></source>
+  <target>Посмотреть подробную информацию о <x id="0" equiv-text="${label}"/></target>
 </trans-unit>
 <trans-unit id="s5bb4026da28b7914">
   <source>Mark as read</source>
+  <target>Отметить как прочитанное</target>
 </trans-unit>
 <trans-unit id="s6e6e737601f44b2c">
   <source>Successfully cleared notifications</source>
@@ -7641,12 +8178,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sf1a3d030efd11f28">
   <source>Open about dialog</source>
+  <target>Открыть диалог о программе</target>
 </trans-unit>
 <trans-unit id="s95b96d7ead27527f">
   <source>Product name</source>
+  <target>Название продукта</target>
 </trans-unit>
 <trans-unit id="s68b6d404c3349b18">
   <source>Product version</source>
+  <target>Версия продукта</target>
 </trans-unit>
 <trans-unit id="s358e08de4fbebf51">
   <source>Version <x id="0" equiv-text="${this.version?.versionCurrent || &quot;&quot;}"/></source>
@@ -7654,6 +8194,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="se0d7715f3211d220">
   <source>Global navigation</source>
+  <target>Глобальная навигация</target>
 </trans-unit>
 <trans-unit id="s67ac11d47f1ce794">
   <source>WebAuthn requires this page to be accessed via HTTPS.</source>
@@ -7669,6 +8210,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sa4be93eb7f4e51e3">
   <source>Site links</source>
+  <target>Ссылки на сайты</target>
 </trans-unit>
 <trans-unit id="s6fe64b4625517333">
   <source>Powered by authentik</source>
@@ -7700,12 +8242,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sf376ae7e9ef41c1a">
   <source>Authenticating with Telegram...</source>
+  <target>Авторизация в Telegram...</target>
 </trans-unit>
 <trans-unit id="s76ea993fdc8503d8">
   <source>Click the button below to start.</source>
+  <target>Нажмите кнопку ниже, чтобы начать.</target>
 </trans-unit>
 <trans-unit id="s15d6fabebb4ef2d8">
   <source>User information</source>
+  <target>Информация о пользователе</target>
 </trans-unit>
 <trans-unit id="s9bd9ba84819493d4">
   <source>Something went wrong! Please try again later.</source>
@@ -7729,6 +8274,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sb69e43f2f6bd1b54">
   <source>Close flow inspector</source>
+  <target>Закрыть инспектор расхода</target>
 </trans-unit>
 <trans-unit id="s502884e1977b2c06">
   <source>Next stage</source>
@@ -7764,6 +8310,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s857cf5aa8955cf5c">
   <source>Flow inspector loading</source>
+  <target>Загрузка инспектора потока</target>
 </trans-unit>
 <trans-unit id="sa11e92683c5860c7">
   <source>Request has been denied.</source>
@@ -7787,6 +8334,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s8d6236ad153d42c0">
   <source>CAPTCHA challenge</source>
+  <target>Капча-вызов</target>
 </trans-unit>
 <trans-unit id="s30d6ff9e15e0a40a">
   <source>Verifying...</source>
@@ -7794,9 +8342,11 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s1c336c2d6cef77b3">
   <source>Remember me on this device</source>
+  <target>Запомнить меня на этом устройстве</target>
 </trans-unit>
 <trans-unit id="seb6ab868740e4e36">
   <source>Continue with <x id="0" equiv-text="${name}"/></source>
+  <target>Продолжить с <x id="0" equiv-text="${name}"/></target>
 </trans-unit>
 <trans-unit id="sc4eedb434536bdb4">
   <source>Need an account?</source>
@@ -7812,6 +8362,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s05a941e4b4bfca9f">
   <source>Additional actions</source>
+  <target>Дополнительные действия</target>
 </trans-unit>
 <trans-unit id="s6ecfc18dbfeedd76">
   <source>Select one of the options below to continue.</source>
@@ -7827,6 +8378,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s53dddf1733e26c98">
   <source>Login sources</source>
+  <target>Источники входа</target>
 </trans-unit>
 <trans-unit id="s85366fac18679f28">
   <source>Forgot password?</source>
@@ -7854,12 +8406,15 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sc091f75b942ec081">
   <source>QR-Code to setup a time-based one-time password</source>
+  <target>QR-код для установки одноразового пароля с привязкой ко времени</target>
 </trans-unit>
 <trans-unit id="s6db67c7681b8be6e">
   <source>Copy time-based one-time password configuration</source>
+  <target>Копирование конфигурации одноразового пароля на основе времени</target>
 </trans-unit>
 <trans-unit id="s43e859bf711e3599">
   <source>Copy TOTP Config</source>
+  <target>Скопировать конфигурацию TOTP</target>
 </trans-unit>
 <trans-unit id="s90064dd5c4dde2c6">
   <source>Please scan the QR code above using the Microsoft Authenticator, Google Authenticator, or other authenticator apps on your device, and enter the code the device displays below to finish setting up the MFA device.</source>
@@ -7867,15 +8422,19 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sa5562e0115ffbccd">
   <source>Time-based one-time password</source>
+  <target>Одноразовый пароль, основанный на времени</target>
 </trans-unit>
 <trans-unit id="s40f44c0d88807fd5">
   <source>TOTP Code</source>
+  <target>TOTP-код</target>
 </trans-unit>
 <trans-unit id="s95474cc8c73dd9c0">
   <source>Type your TOTP code...</source>
+  <target>Введите свой TOTP-код...</target>
 </trans-unit>
 <trans-unit id="s168d0c138b63286d">
   <source>Type your time-based one-time password code.</source>
+  <target>Введите код одноразового пароля, зависящий от времени.</target>
 </trans-unit>
 <trans-unit id="sc2ec367e3108fe65">
   <source>Duo activation QR code</source>
@@ -7927,6 +8486,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s98bb2ae796f1ceef">
   <source>Select another authentication method</source>
+  <target>Выберите другой метод аутентификации</target>
 </trans-unit>
 <trans-unit id="s844fea0bfb10a72a">
   <source>Authentication code</source>
@@ -7938,6 +8498,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s14e8ac4d377a1a99">
   <source>Type an authentication code...</source>
+  <target>Введите код аутентификации...</target>
 </trans-unit>
 <trans-unit id="s39002897db60bb28">
   <source>Sending Duo push notification...</source>
@@ -7977,6 +8538,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s8bb0a1b672b52954">
   <source>In case you lose access to your primary authenticators.</source>
+  <target>На случай, если вы потеряете доступ к своим основным аутентификаторам.</target>
 </trans-unit>
 <trans-unit id="s97f2dc19fa556a6a">
   <source>SMS</source>
@@ -7992,15 +8554,19 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s76d21e163887ddd1">
   <source>Unknown device</source>
+  <target>Неизвестное устройство</target>
 </trans-unit>
 <trans-unit id="sf0ceaf3116e31fd4">
   <source>An unknown device class was provided.</source>
+  <target>Был предоставлен неизвестный класс устройства.</target>
 </trans-unit>
 <trans-unit id="s610fced3957d0471">
   <source>Select an authentication method</source>
+  <target>Выберите метод аутентификации</target>
 </trans-unit>
 <trans-unit id="s958cedec1cb3fc52">
   <source>Select a configuration stage</source>
+  <target>Выберите этап настройки</target>
 </trans-unit>
 <trans-unit id="sac17f177f884e238">
   <source>Stay signed in?</source>
@@ -8012,6 +8578,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s23da7320dee28a60">
   <source>Device Code</source>
+  <target>Код устройства</target>
 </trans-unit>
 <trans-unit id="s3cd84e82e83e35ad">
   <source>Please enter your code</source>
@@ -8023,42 +8590,55 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sac88482c48453fc8">
   <source>You've logged out of <x id="0" equiv-text="${challenge.applicationName}"/>. You can go back to the overview to launch another application, or log out of your authentik account.</source>
+  <target>Вы вышли из <x id="0" equiv-text="${app.name}"/>. Можно вернуться к списку приложений или выйти из учётной записи authentik.</target>
 </trans-unit>
 <trans-unit id="s3108167b562674e2">
   <source>Go back to overview</source>
+  <target>К списку приложений</target>
 </trans-unit>
 <trans-unit id="sdb749e793de55478">
   <source>Log out of <x id="0" equiv-text="${challenge.brandName}"/></source>
+  <target>Выйти из <x id="0" equiv-text="${app.name}"/></target>
 </trans-unit>
 <trans-unit id="s521681ed1d5ff814">
   <source>Log back into <x id="0" equiv-text="${challenge.applicationName}"/></source>
+  <target>Войти снова в <x id="0" equiv-text="${app.name}"/></target>
 </trans-unit>
 <trans-unit id="s78869b8b2bc26d0d">
   <source>SAML Provider</source>
+  <target>SAML-провайдер</target>
 </trans-unit>
 <trans-unit id="sca83a1f9227f74b9">
   <source>SAML logout complete</source>
+  <target>Выход из SAML завершен</target>
 </trans-unit>
 <trans-unit id="s7b90eab7969ae056">
   <source>Redirecting to SAML provider: <x id="0" equiv-text="${providerName}"/></source>
+  <target>Перенаправление к поставщику SAML: <x id="0" equiv-text="${providerName}"/></target>
 </trans-unit>
 <trans-unit id="s3e6174b645d96835">
   <source>Posting logout request to SAML provider: <x id="0" equiv-text="${providerName}"/></source>
+  <target>Отправка запроса на выход поставщику SAML: <x id="0" equiv-text="${providerName}"/></target>
 </trans-unit>
 <trans-unit id="s0b1ffff8bedd6b8a">
   <source>Unknown Provider</source>
+  <target>Неизвестный поставщик</target>
 </trans-unit>
 <trans-unit id="s777e86d562523c85">
   <source>Logging out of providers...</source>
+  <target>Выход из провайдеров...</target>
 </trans-unit>
 <trans-unit id="s4980379bf8461c2d">
   <source>Single Logout</source>
+  <target>Единый выход</target>
 </trans-unit>
 <trans-unit id="s3736936aac1adc2e">
   <source>Open flow inspector</source>
+  <target>Инспектор открытого потока</target>
 </trans-unit>
 <trans-unit id="sa17ce23517e56461">
   <source>Authentication form</source>
+  <target>Форма аутентификации</target>
 </trans-unit>
 <trans-unit id="sb0821a9e92cac5eb">
   <source>Failed to register. Please try again.</source>
@@ -8086,6 +8666,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s123b7254b44dd148">
   <source>Waiting</source>
+  <target>Ожидающий</target>
 </trans-unit>
 <trans-unit id="s82a4e28ab5b56670">
   <source>Connected</source>
@@ -8113,15 +8694,19 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="sa00a53efc9c70de5">
   <source>Please wait while the content is loading</source>
+  <target>Пожалуйста, подождите, пока загружается контент</target>
 </trans-unit>
 <trans-unit id="s7ea73e0b3b45e385">
   <source>application</source>
+  <target>приложение</target>
 </trans-unit>
 <trans-unit id="s33b2f30214a2e99d">
   <source>Actions for "<x id="0" equiv-text="${applicationName}"/>"</source>
+  <target>Действия для "<x id="0" equiv-text="${applicationName}"/>"</target>
 </trans-unit>
 <trans-unit id="sfa660d9e563c346f">
   <source>Edit application...</source>
+  <target>Редактировать заявку...</target>
 </trans-unit>
 <trans-unit id="s3fb39fc45e840f78">
   <source>Refer to documentation</source>
@@ -8137,9 +8722,11 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s45915ee0293ce5d4">
   <source>Ungrouped</source>
+  <target>Разгруппировано</target>
 </trans-unit>
 <trans-unit id="s65b433c52c2ad8eb">
   <source>Search for an application by name...</source>
+  <target>Поиск приложения по названию...</target>
 </trans-unit>
 <trans-unit id="s4facec1106c91cf9">
   <source>Search returned no results.</source>
@@ -8147,9 +8734,11 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s91cfe4fac0957ee7">
   <source>Application list</source>
+  <target>Список приложений</target>
 </trans-unit>
 <trans-unit id="sf609e15e71559cd2">
   <source>Failed to fetch applications.</source>
+  <target>Не удалось загрузить приложения.</target>
 </trans-unit>
 <trans-unit id="s06c92148da82be0d">
   <source>Change your password</source>
@@ -8181,6 +8770,7 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s013620384af7c8b4">
   <source>Device type <x id="0" equiv-text="${device.verboseName}"/> cannot be edited</source>
+  <target>Тип устройства <x id="0" equiv-text="${device.verboseName}"/> редактировать нельзя.</target>
 </trans-unit>
 <trans-unit id="s6a406aecb2c0e5c5">
   <source>Enroll</source>
@@ -8188,9 +8778,11 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="s64de9eceb8172269">
   <source>Edit device</source>
+  <target>Изменить устройство</target>
 </trans-unit>
 <trans-unit id="s2e6c714bb95c18a3">
   <source>User settings</source>
+  <target>Пользовательские настройки</target>
 </trans-unit>
 <trans-unit id="s588796ee929a2e4c">
   <source>User details</source>
@@ -8214,3562 +8806,4730 @@ Bindings to groups/users are checked against the user of the event.</source>
 </trans-unit>
 <trans-unit id="ellipsis">
   <source>...</source>
+  <target>...</target>
   <note from="lit-localize">Truncation ellipsis</note>
 </trans-unit>
 <trans-unit id="s6cd96061d397f7b5">
   <source>Via <x id="0" equiv-text="${event.context.device.name}"/></source>
+  <target>Через <x id="0" equiv-text="${event.context.device.name}"/></target>
 </trans-unit>
 <trans-unit id="s8015ac3b47172dc8">
   <source>Select from uploaded files, or type a Font Awesome icon (fa://fa-icon-name) or URL.</source>
+  <target>Выберите из загруженных файлов или введите значок Font Awesome (fa://fa-icon-name) или URL-адрес.</target>
 </trans-unit>
 <trans-unit id="s87616130c08b117c">
   <source>This type is deprecated.</source>
+  <target>Этот тип устарел.</target>
 </trans-unit>
 <trans-unit id="s40f4c2223ce87751">
   <source>No connectors configured. Navigate to Connectors in the sidebar and first create a connector.</source>
+  <target>Разъемы не настроены. Перейдите к разделу «Соединители» на боковой панели и сначала создайте соединитель.</target>
 </trans-unit>
 <trans-unit id="s70c2cd89201ecca9">
   <source>Home directory</source>
+  <target>Домашний каталог</target>
 </trans-unit>
 <trans-unit id="sb171d638b8af660d">
   <source>Successfully updated agent connector.</source>
+  <target>Соединитель агента успешно обновлен.</target>
 </trans-unit>
 <trans-unit id="s81c9554908463f94">
   <source>Successfully created agent connector.</source>
+  <target>Соединитель агента успешно создан.</target>
 </trans-unit>
 <trans-unit id="s306dd51d3be07bc7">
   <source>Device compliance settings</source>
+  <target>Настройки соответствия устройства</target>
 </trans-unit>
 <trans-unit id="sc2966702517b7af5">
   <source>Challenge certificate</source>
+  <target>Сертификат вызова</target>
 </trans-unit>
 <trans-unit id="s051588c63fedab5f">
   <source>Challenge idle timeout</source>
+  <target>Вызов тайм-аута простоя</target>
 </trans-unit>
 <trans-unit id="s4c70d7629e29ac2d">
   <source>Duration the flow executor will wait before continuing without a response.</source>
+  <target>Продолжительность ожидания, в течение которого исполнитель потока продолжит работу без ответа.</target>
 </trans-unit>
 <trans-unit id="se3c7fb54006d9e98">
   <source>Trigger check-in on device</source>
+  <target>Запустить регистрацию на устройстве</target>
 </trans-unit>
 <trans-unit id="se0a747f4db08e87f">
   <source>Configure how devices connect with authentik and ingest external device data.</source>
+  <target>Настройте способ подключения устройств к authentik и приема данных внешнего устройства.</target>
 </trans-unit>
 <trans-unit id="s114f2b310ef163ff">
   <source>Stage which associates the currently used device with the current session.</source>
+  <target>Этап, который связывает используемое в данный момент устройство с текущим сеансом.</target>
 </trans-unit>
 <trans-unit id="s8290d08ab5a49ed0">
   <source>Connector</source>
+  <target>Разъем</target>
 </trans-unit>
 <trans-unit id="s5e8eefcbbeffd4d5">
   <source>Device optional</source>
+  <target>Устройство опционально</target>
 </trans-unit>
 <trans-unit id="s51b09bba5dcc19b0">
   <source>If no device was provided, this stage will succeed and continue to the next stage.</source>
+  <target>Если устройство не было предоставлено, этот этап завершится успешно и перейдет к следующему этапу.</target>
 </trans-unit>
 <trans-unit id="s5f58e358343a5514">
   <source>Device required</source>
+  <target>Требуется устройство</target>
 </trans-unit>
 <trans-unit id="s6df8326edea3b23d">
   <source>If no device was provided, this stage will stop flow execution.</source>
+  <target>Если устройство не было предоставлено, на этом этапе выполнение потока будет остановлено.</target>
 </trans-unit>
 <trans-unit id="s803ce7e1a2294d50">
   <source>Files</source>
+  <target>Файлы</target>
 </trans-unit>
 <trans-unit id="s42d82601762f5321">
   <source>Manage uploaded files.</source>
+  <target>Управление загруженными файлами.</target>
 </trans-unit>
 <trans-unit id="saad01178f02a6a23">
   <source>file</source>
+  <target>файл</target>
 </trans-unit>
 <trans-unit id="s69f800801812a5f0">
   <source>files</source>
+  <target>файлы</target>
 </trans-unit>
 <trans-unit id="s96668830629e0dfc">
   <source>Upload</source>
+  <target>Загрузить</target>
 </trans-unit>
 <trans-unit id="s95094b57684716a5">
   <source>Failed to validate device.</source>
+  <target>Не удалось проверить устройство.</target>
 </trans-unit>
 <trans-unit id="se99d25eb70c767ef">
   <source>Verifying your device...</source>
+  <target>Проверка вашего устройства...</target>
 </trans-unit>
 <trans-unit id="s5c85e53f1d3747d0">
   <source>Service Provider Config cache timeout</source>
+  <target>Тайм-аут кэша конфигурации поставщика услуг</target>
 </trans-unit>
 <trans-unit id="s5fca9f7853a54584">
   <source>Cache duration for ServiceProviderConfig responses. Set minutes=0 to disable caching.</source>
+  <target>Продолжительность кэширования ответов ServiceProviderConfig. Установите минуты = 0, чтобы отключить кеширование.</target>
 </trans-unit>
 <trans-unit id="s89a2859207d766fe">
   <source>JWTs signed by the selected providers can be used to authenticate to devices.</source>
+  <target>JWT, подписанные выбранными поставщиками, можно использовать для аутентификации на устройствах.</target>
 </trans-unit>
 <trans-unit id="s988e1dfd2b962e4f">
   <source>Score Configuration</source>
+  <target>Конфигурация оценки</target>
 </trans-unit>
 <trans-unit id="s83d396fed4b71e29">
   <source>This CAPTCHA provider does not support scoring. Score thresholds will be ignored.</source>
+  <target>Этот поставщик CAPTCHA не поддерживает оценку. Пороговые значения баллов будут игнорироваться.</target>
 </trans-unit>
 <trans-unit id="s5b29d7a77c92758e">
   <source>Score Minimum Threshold</source>
+  <target>Минимальный порог оценки</target>
 </trans-unit>
 <trans-unit id="sfb4f2529b0b36889">
   <source>Minimum required score to allow continuing. Lower scores indicate more suspicious behavior.</source>
+  <target>Минимально необходимый балл для продолжения обучения. Более низкие баллы указывают на более подозрительное поведение.</target>
 </trans-unit>
 <trans-unit id="sf578722c6d349838">
   <source>Score Maximum Threshold</source>
+  <target>Максимальный порог оценки</target>
 </trans-unit>
 <trans-unit id="s66fe9ce730db1f7b">
   <source>Maximum allowed score to allow continuing. Set to -1 to disable upper bound checking.</source>
+  <target>Максимально допустимое количество очков, позволяющее продолжить игру. Установите значение -1, чтобы отключить проверку верхней границы.</target>
 </trans-unit>
 <trans-unit id="s1f412e69817ebb7f">
   <source>Error on Invalid Score</source>
+  <target>Ошибка при неверном счете</target>
 </trans-unit>
 <trans-unit id="sbfc0f211f5f7c96f">
   <source>When enabled and the score is outside the threshold, the user will not be able to continue. When disabled, the user can continue and the score can be used in policies.</source>
+  <target>Если эта функция включена и оценка выходит за пределы порогового значения, пользователь не сможет продолжить. Если этот параметр отключен, пользователь может продолжить работу, а оценка может использоваться в политиках.</target>
 </trans-unit>
 <trans-unit id="s74982e57a1d8896c">
   <source>Advanced Settings</source>
+  <target>Расширенные настройки</target>
 </trans-unit>
 <trans-unit id="s27bfe23deaaf0c2f">
   <source>JavaScript URL</source>
+  <target>URL-адрес JavaScript</target>
 </trans-unit>
 <trans-unit id="s22f10cb634a6d1e5">
   <source>URL to fetch the CAPTCHA JavaScript library from. Automatically set based on provider selection but can be customized.</source>
+  <target>URL-адрес для получения библиотеки JavaScript CAPTCHA. Устанавливается автоматически в зависимости от выбора поставщика, но может быть настроен.</target>
 </trans-unit>
 <trans-unit id="s83c66d5a3edc1b03">
   <source>API Verification URL</source>
+  <target>URL-адрес проверки API</target>
 </trans-unit>
 <trans-unit id="s47028bbf2c2cce0c">
   <source>URL used to validate CAPTCHA response on the backend. Automatically set based on provider selection but can be customized.</source>
+  <target>URL-адрес, используемый для проверки ответа CAPTCHA на серверной стороне. Устанавливается автоматически в зависимости от выбора поставщика, но может быть настроен.</target>
 </trans-unit>
 <trans-unit id="s7fed8c29d9963f53">
   <source>This stage checks the user's current session against a CAPTCHA service to prevent automated abuse.</source>
+  <target>На этом этапе текущий сеанс пользователя проверяется с помощью службы CAPTCHA, чтобы предотвратить автоматическое злоупотребление.</target>
 </trans-unit>
 <trans-unit id="s9b8e5c6f87ca887e">
   <source>CAPTCHA Provider</source>
+  <target>Поставщик капчи</target>
 </trans-unit>
 <trans-unit id="sab1ddd059633b9aa">
   <source>Enable this if the CAPTCHA requires user interaction (clicking checkbox, solving puzzles, etc.). Required for reCAPTCHA v2, hCaptcha interactive mode, and Cloudflare Turnstile.</source>
+  <target>Включите это, если CAPTCHA требует взаимодействия с пользователем (нажатие флажка, решение головоломок и т. д.). Требуется для reCAPTCHA v2, интерактивного режима hCaptcha и турникета Cloudflare.</target>
 </trans-unit>
 <trans-unit id="s8d94e51441d0ce0c">
   <source>Flow Examples</source>
+  <target>Примеры потоков</target>
 </trans-unit>
 <trans-unit id="s49ae82ba527f8e01">
   <source>Type an outpost name...</source>
+  <target>Введите название аванпоста...</target>
 </trans-unit>
 <trans-unit id="s574ed5d3a52d45c8">
   <source>Outpost Name</source>
+  <target>Название аванпоста</target>
 </trans-unit>
 <trans-unit id="sc47f8ab6162bb2bb">
   <source>Outpost configuration</source>
+  <target>Конфигурация аванпоста</target>
 </trans-unit>
 <trans-unit id="s11a2ac9f2bd811d8">
   <source>Delete Object Permission</source>
+  <target>Разрешение на удаление объекта</target>
 </trans-unit>
 <trans-unit id="s78aa910bcb26034d">
   <source>Global and object permission</source>
+  <target>Глобальное и объектное разрешение</target>
 </trans-unit>
 <trans-unit id="sc8f73affccb6ae4d">
   <source>Global permission</source>
+  <target>Глобальное разрешение</target>
 </trans-unit>
 <trans-unit id="scf9ebad133d2d561">
   <source>Object permission</source>
+  <target>Разрешение объекта</target>
 </trans-unit>
 <trans-unit id="sa84d68ec57e21b0f">
   <source>Permissions on this object</source>
+  <target>Разрешения на этот объект</target>
 </trans-unit>
 <trans-unit id="s4d83e4891c19ff14">
   <source>Permissions assigned to this role affecting specific object instances.</source>
+  <target>Разрешения, назначенные этой роли, влияют на конкретные экземпляры объектов.</target>
 </trans-unit>
 <trans-unit id="s3e07daaacb10f38a">
   <source>Parents</source>
+  <target>Родители</target>
 </trans-unit>
 <trans-unit id="s74636eae90c1a208">
   <source>Available Groups</source>
+  <target>Доступные группы</target>
 </trans-unit>
 <trans-unit id="s66d795717763ca54">
   <source>Selected Groups</source>
+  <target>Выбранные группы</target>
 </trans-unit>
 <trans-unit id="sab46a062a503d9bb">
   <source>A group recursively inherits every role from its ancestors.</source>
+  <target>Группа рекурсивно наследует каждую роль от своих предков.</target>
 </trans-unit>
 <trans-unit id="sb75f1413fcfbd4bd">
   <source>User updated.</source>
+  <target>Пользователь обновлен.</target>
 </trans-unit>
 <trans-unit id="s13625030f6501a5f">
   <source>User created and added to group <x id="0" equiv-text="${this.targetGroup.name}"/></source>
+  <target>Пользователь создан и добавлен в группу <x id="0" equiv-text="${this.targetGroup.name}"/>.</target>
 </trans-unit>
 <trans-unit id="s31dc80daa773a5dc">
   <source>User created and added to role <x id="0" equiv-text="${this.targetRole.name}"/></source>
+  <target>Пользователь создан и добавлен в роль <x id="0" equiv-text="${this.targetRole.name}"/>.</target>
 </trans-unit>
 <trans-unit id="sd1d84a93a9a8dd44">
   <source>User created.</source>
+  <target>Пользователь создан.</target>
 </trans-unit>
 <trans-unit id="sc5f2f9b4dce504d6">
   <source>Successfully downloaded <x id="0" equiv-text="${this.config.filename}"/>!</source>
+  <target><x id="0" equiv-text="${this.config.filename}"/> успешно загружен!</target>
 </trans-unit>
 <trans-unit id="s2b6c1190a54a0932">
   <source>Show MDM configuration</source>
+  <target>Показать конфигурацию MDM</target>
 </trans-unit>
 <trans-unit id="sb4f4c6c72acfa253">
   <source>Hide MDM configuration</source>
+  <target>Скрыть конфигурацию MDM</target>
 </trans-unit>
 <trans-unit id="s4a7ec7687e560e6a">
   <source>Is Primary user</source>
+  <target>Является основным пользователем</target>
 </trans-unit>
 <trans-unit id="se14ede3bc78d9599">
   <source>Primary</source>
+  <target>Начальный</target>
 </trans-unit>
 <trans-unit id="sc67ff7b2278e81e4">
   <source>Remove User(s)</source>
+  <target>Удалить пользователя(ей)</target>
 </trans-unit>
 <trans-unit id="s76e10cbcb80c3a64">
   <source>Are you sure you want to remove the selected users from <x id="0" equiv-text="${targetLabel}"/>?</source>
+  <target>Вы уверены, что хотите удалить выбранных пользователей из <x id="0" equiv-text="${targetLabel}"/>?</target>
 </trans-unit>
 <trans-unit id="s85835da8c3bd6198">
   <source>Are you sure you want to remove the selected users?</source>
+  <target>Вы уверены, что хотите удалить выбранных пользователей?</target>
 </trans-unit>
 <trans-unit id="s86f283ed16448157">
   <source>This user will be added to the role "<x id="0" equiv-text="${this.targetRole.name}"/>".</source>
+  <target>Этот пользователь будет добавлен к роли «<x id="0" equiv-text="${this.targetRole.name}"/>».</target>
 </trans-unit>
 <trans-unit id="sed582fb69fd1eed8">
   <source>Successfully added user to role(s).</source>
+  <target>Пользователь успешно добавлен в роли.</target>
 </trans-unit>
 <trans-unit id="s78daaa3ef4325cac">
   <source>Roles to add</source>
+  <target>Роли для добавления</target>
 </trans-unit>
 <trans-unit id="sca5f586369a597a4">
   <source>Add role</source>
+  <target>Добавить роль</target>
 </trans-unit>
 <trans-unit id="sd8b8f59ad30971f7">
   <source>Remove from Role(s)</source>
+  <target>Удалить из роли(ей)</target>
 </trans-unit>
 <trans-unit id="s5fcb76c89d17698c">
   <source>Are you sure you want to remove user <x id="0" equiv-text="${this.targetUser?.username}"/> from the following roles?</source>
+  <target>Вы уверены, что хотите удалить пользователя <x id="0" equiv-text="${this.targetUser?.username}"/> из следующих ролей?</target>
 </trans-unit>
 <trans-unit id="s1d6a69c054342126">
   <source>Add to existing role</source>
+  <target>Добавить к существующей роли</target>
 </trans-unit>
 <trans-unit id="sbf5a46ac69b2ca56">
   <source>Add new role</source>
+  <target>Добавить новую роль</target>
 </trans-unit>
 <trans-unit id="s1af2337b6d11d4c6">
   <source>Data export ready</source>
+  <target>Экспорт данных готов</target>
 </trans-unit>
 <trans-unit id="sd0fcaa6952729a9a">
   <source>Data Exports</source>
+  <target>Экспорт данных</target>
 </trans-unit>
 <trans-unit id="s1d1d961d6f3550e5">
   <source>Manage past data exports.</source>
+  <target>Управляйте экспортом прошлых данных.</target>
 </trans-unit>
 <trans-unit id="s8cddef7d8dac7f87">
   <source>Data type</source>
+  <target>Тип данных</target>
 </trans-unit>
 <trans-unit id="s3783e647280eb968">
   <source>Requested by</source>
+  <target>По запросу</target>
 </trans-unit>
 <trans-unit id="s2d119c0d85bde088">
   <source>Creation date</source>
+  <target>Дата создания</target>
 </trans-unit>
 <trans-unit id="s5033dab8c17f05f2">
   <source>Completed</source>
+  <target>Завершенный</target>
 </trans-unit>
 <trans-unit id="s21c76a0f6cae7920">
   <source>Row actions</source>
+  <target>Действия со строками</target>
 </trans-unit>
 <trans-unit id="s97aa774d38013957">
   <source>Data export(s)</source>
+  <target>Экспорт(ы) данных</target>
 </trans-unit>
 <trans-unit id="s694b2e2c53d2d85d">
   <source>Query parameters</source>
+  <target>Параметры запроса</target>
 </trans-unit>
 <trans-unit id="s145aca905bbc68a4">
   <source>SAML metadata XML file to import provider settings from.</source>
+  <target>XML-файл метаданных SAML, из которого можно импортировать настройки поставщика.</target>
 </trans-unit>
 <trans-unit id="s0d748f6fb237da48">
   <source>Configure SAML Provider from Metadata</source>
+  <target>Настройка поставщика SAML из метаданных</target>
 </trans-unit>
 <trans-unit id="sb541f02499d73b4e">
   <source>Outgoing syncs will not be triggered.</source>
+  <target>Исходящая синхронизация не будет запущена.</target>
 </trans-unit>
 <trans-unit id="s967b3abf2608649a">
   <source>Immediate</source>
+  <target>Немедленный</target>
 </trans-unit>
 <trans-unit id="sba0b0ee7c8b8f04a">
   <source>Outgoing syncs will be triggered immediately for each object that is updated. This can create many background tasks and is therefore not recommended</source>
+  <target>Исходящая синхронизация будет запускаться немедленно для каждого обновляемого объекта. Это может создать множество фоновых задач, поэтому не рекомендуется.</target>
 </trans-unit>
 <trans-unit id="sd3dfc2a1c3647e77">
   <source>Deferred until end</source>
+  <target>Отложено до конца</target>
 </trans-unit>
 <trans-unit id="secd492de6e1ae305">
   <source>Outgoing syncs will be triggered at the end of the source synchronization.</source>
+  <target>Исходящая синхронизация будет запущена в конце исходной синхронизации.</target>
 </trans-unit>
 <trans-unit id="s0c476074a4fc4d95">
   <source>Outgoing sync trigger mode</source>
+  <target>Режим триггера исходящей синхронизации</target>
 </trans-unit>
 <trans-unit id="s4bb6f209647072f4">
   <source>Successfully connected source</source>
+  <target>Источник успешно подключен</target>
 </trans-unit>
 <trans-unit id="sf3ad0b5ebe730780">
   <source>Failed to connect source: <x id="0" equiv-text="${pluckErrorDetail(parsedError)}"/></source>
+  <target>Не удалось подключить источник: <x id="0" equiv-text="${pluckErrorDetail(parsedError)}"/>.</target>
 </trans-unit>
 <trans-unit id="sed44880a52f72a08">
   <source>Passkey settings</source>
+  <target>Настройки пароля</target>
 </trans-unit>
 <trans-unit id="sf65cb435d6ca1d01">
   <source>WebAuthn Authenticator Validation Stage</source>
+  <target>Этап проверки аутентификатора WebAuthn</target>
 </trans-unit>
 <trans-unit id="s05a4cbce470ede73">
   <source>When set, allows users to authenticate using passkeys directly from the browser's autofill dropdown without entering a username first.</source>
+  <target>Если этот параметр установлен, пользователи могут проходить аутентификацию с использованием ключей доступа непосредственно из раскрывающегося списка автозаполнения браузера без предварительного ввода имени пользователя.</target>
 </trans-unit>
 <trans-unit id="s51610dc462a5a034">
   <source>Pagination: default page size</source>
+  <target>Пагинация: размер страницы по умолчанию</target>
 </trans-unit>
 <trans-unit id="s05d8a93b0de05ad4">
   <source>Default page size for API requests not specifying a page size.</source>
+  <target>Размер страницы по умолчанию для запросов API, не указывающих размер страницы.</target>
 </trans-unit>
 <trans-unit id="s41dac4f4d7caffa7">
   <source>Pagination: maximum page size</source>
+  <target>Пагинация: максимальный размер страницы</target>
 </trans-unit>
 <trans-unit id="s567c5a6e42cc5036">
   <source>Maximum page size for API requests.</source>
+  <target>Максимальный размер страницы для запросов API.</target>
 </trans-unit>
 <trans-unit id="s9864bd5cd7bb4bd0">
   <source>Local connection</source>
+  <target>Локальное соединение</target>
 </trans-unit>
 <trans-unit id="s4a3f19ff6e510c37">
   <source>Requires Docker socket/Kubernetes Integration.</source>
+  <target>Требуется сокет Docker/интеграция Kubernetes.</target>
 </trans-unit>
 <trans-unit id="s5f6ad947b4824e40">
   <source>Next, download the configuration to deploy the authentik Agent via MDM</source>
+  <target>Затем загрузите конфигурацию для развертывания агента authentik через MDM.</target>
 </trans-unit>
 <trans-unit id="s523337424b694d5c">
   <source>Device Access Group</source>
+  <target>Группа доступа к устройствам</target>
 </trans-unit>
 <trans-unit id="s7642bf28cf8f476c">
   <source>Select a device access group to be added to upon enrollment.</source>
+  <target>Выберите группу доступа к устройствам, в которую будет добавлено после регистрации.</target>
 </trans-unit>
 <trans-unit id="h30bbf18fbf87fa57">
   <source>To create a data export, navigate to
                             <x id="0" equiv-text="&lt;a href=&quot;#/identity/users&quot;&gt;"/>Directory &gt; Users<x id="1" equiv-text="&lt;/a&gt;"/> or to
                             <x id="2" equiv-text="&lt;a href=&quot;#/events/log&quot;&gt;"/>Events &gt; Logs<x id="3" equiv-text="&lt;/a&gt;"/>.</source>
+  <target>Чтобы создать экспорт данных, перейдите в каталог <x id="0" equiv-text="&lt;a href=&quot;#/identity/users&quot;&gt;"/> &gt; Пользователи <x id="1" equiv-text="&lt;/a&gt;"/> или <x id="2" equiv-text="&lt;a href=&quot;#/events/log&quot;&gt;"/> События &gt; Журналы <x id="3" equiv-text="&lt;/a&gt;"/> .</target>
 </trans-unit>
 <trans-unit id="s54af3ec70642782c">
   <source>Choose the object permissions that you want the selected role to have on this object. These object permissions are in addition to any global permissions already within the role.</source>
+  <target>Выберите разрешения объекта, которые выбранная роль должна иметь для этого объекта. Эти разрешения объекта дополняют любые глобальные разрешения, уже имеющиеся в роли.</target>
 </trans-unit>
 <trans-unit id="sbcd108b66363075c">
   <source>Device access group</source>
+  <target>Группа доступа к устройствам</target>
 </trans-unit>
 <trans-unit id="s325acae04cdcac57">
   <source>Primary disk size</source>
+  <target>Размер основного диска</target>
 </trans-unit>
 <trans-unit id="sb4a957846c89fca1">
   <source>Primary disk usage</source>
+  <target>Использование основного диска</target>
 </trans-unit>
 <trans-unit id="s7b68229d885a34d3">
   <source>The start for user ID numbers, this number is added to the user ID to make sure that the numbers aren't too low for POSIX users. Default is 2000 to prevent collisions with local users.</source>
+  <target>Начало номеров идентификаторов пользователей. Это число добавляется к идентификатору пользователя, чтобы убедиться, что числа не слишком малы для пользователей POSIX. По умолчанию установлено значение 2000, чтобы предотвратить конфликты с локальными пользователями.</target>
 </trans-unit>
 <trans-unit id="s284f44964466ef38">
   <source>The start for group ID numbers, this number is added to a number generated from the groups' ID to make sure that the numbers aren't too low for POSIX groups. Default is 4000 to prevent collisions with local groups.</source>
+  <target>Начало номера идентификатора группы. Это число добавляется к числу, сгенерированному на основе идентификатора группы, чтобы убедиться, что числа не слишком малы для групп POSIX. По умолчанию — 4000, чтобы предотвратить конфликты с локальными группами.</target>
 </trans-unit>
 <trans-unit id="s01f8cd92a0204da2">
   <source>Data exports are not available as storage for reports is not configured.</source>
+  <target>Экспорт данных недоступен, так как не настроено хранилище для отчетов.</target>
 </trans-unit>
 <trans-unit id="s7afef158aada7389">
   <source><x id="0" equiv-text="${this.brand.brandingTitle}"/> will collect all objects with the specified parameters:</source>
+  <target><x id="0" equiv-text="${this.brand.brandingTitle}"/> соберет все объекты с указанными параметрами:</target>
 </trans-unit>
 <trans-unit id="sa8d2689c8fdfea22">
   <source>Successfully requested data export</source>
+  <target>Экспорт данных успешно запрошен.</target>
 </trans-unit>
 <trans-unit id="s7e2ef0e26e7f5e6f">
   <source>Failed to export data</source>
+  <target>Не удалось экспортировать данные</target>
 </trans-unit>
 <trans-unit id="sd69873a0783f8e39">
   <source>Export data</source>
+  <target>Экспортировать данные</target>
 </trans-unit>
 <trans-unit id="en-XA">
   <source>English (Pseudo-Accents)</source>
+  <target>Английский (псевдоакценты)</target>
 </trans-unit>
 <trans-unit id="sbb99d4ec27fbb263">
   <source>Finished</source>
+  <target>Законченный</target>
 </trans-unit>
 <trans-unit id="s3ec4da71c1a62754">
   <source>Queued</source>
+  <target>В очереди</target>
 </trans-unit>
 <trans-unit id="sd32298bb7d36024d">
   <source>Configured file backend does not support file management.</source>
+  <target>Настроенный файловый сервер не поддерживает управление файлами.</target>
 </trans-unit>
 <trans-unit id="s4f1e04b9b4cb96ae">
   <source>Please ensure the data folder is mounted or S3 storage is configured.</source>
+  <target>Убедитесь, что папка данных подключена или хранилище S3 настроено.</target>
 </trans-unit>
 <trans-unit id="s3a46b5964b3ecfac">
   <source>View details...</source>
+  <target>Посмотреть подробности...</target>
 </trans-unit>
 <trans-unit id="s6cbf6cd401ea3336">
   <source>Type a connector name...</source>
+  <target>Введите имя соединителя...</target>
 </trans-unit>
 <trans-unit id="s04be2edfb0d2218a">
   <source>Type a name for the token...</source>
+  <target>Введите имя токена...</target>
 </trans-unit>
 <trans-unit id="s5a7055a44dc83b1e">
   <source>Type a unique identifier...</source>
+  <target>Введите уникальный идентификатор...</target>
 </trans-unit>
 <trans-unit id="sdfe787aeeebbfbf1">
   <source>Type a token description...</source>
+  <target>Введите описание токена...</target>
 </trans-unit>
 <trans-unit id="sd7c52e2ce408c542">
   <source>Integrations synced in the last 12 hours.</source>
+  <target>Интеграции синхронизировались за последние 12 часов.</target>
 </trans-unit>
 <trans-unit id="table-loading-bar-label">
   <source>Loading <x id="0" equiv-text="${this.label ?? &quot;table&quot;}"/> data</source>
+  <target>Загрузка данных <x id="0" equiv-text="${this.label ?? &quot;table&quot;}"/></target>
   <note from="lit-localize">Label for progress bar shown when table data is loading</note>
 </trans-unit>
 <trans-unit id="sb6650552aaaf5da0">
   <source>Assigned Roles</source>
+  <target>Назначенные роли</target>
 </trans-unit>
 <trans-unit id="s5cbf3cbb4cf38b05">
   <source>All Roles</source>
+  <target>Все роли</target>
 </trans-unit>
 <trans-unit id="s6a850cd00064d6e6">
   <source>Inherited from parent group</source>
+  <target>Унаследовано от родительской группы</target>
 </trans-unit>
 <trans-unit id="sd9e3b91f8d62cb04">
   <source>Inherited from group</source>
+  <target>Унаследовано от группы</target>
 </trans-unit>
 <trans-unit id="s3d8c389ca77b97e1">
   <source>Inherited</source>
+  <target>Унаследовано</target>
 </trans-unit>
 <trans-unit id="drawer-toggle-button-api-requests">
   <source>Toggle API requests drawer</source>
+  <target>Переключить панель запросов API</target>
 </trans-unit>
 <trans-unit id="s355e4737a0286070">
   <source>API Drawer</source>
+  <target>API-ящик</target>
 </trans-unit>
 <trans-unit id="drawer-toggle-button-notifications">
   <source>Toggle notifications drawer</source>
+  <target>Переключить панель уведомлений</target>
 </trans-unit>
 <trans-unit id="drawer-invoker-tooltip-notifications">
   <source>Notification Drawer</source>
+  <target>ящик уведомлений</target>
 </trans-unit>
 <trans-unit id="s5fa7f18dcfc98131">
   <source>Failed to fetch notifications.</source>
+  <target>Не удалось получить уведомления.</target>
 </trans-unit>
 <trans-unit id="notification-drawer-clear-all">
   <source>Clear all notifications</source>
+  <target>Очистить все уведомления</target>
 </trans-unit>
 <trans-unit id="notification-drawer-close">
   <source>Close notification drawer</source>
+  <target>Закрыть панель уведомлений</target>
 </trans-unit>
 <trans-unit id="s54e4d61fc46a14be">
   <source>No MFA devices enrolled.</source>
+  <target>Устройства MFA не зарегистрированы.</target>
 </trans-unit>
 <trans-unit id="s227aacd5a7fc6f50">
   <source>User Tokens</source>
+  <target>Пользовательские токены</target>
 </trans-unit>
 <trans-unit id="sea858aeacf6ae9b0">
   <source>No User Tokens enrolled.</source>
+  <target>Никакие пользовательские токены не зарегистрированы.</target>
 </trans-unit>
 <trans-unit id="notification-unread-count">
   <source><x id="0" equiv-text="${unreadCount}"/> unread</source>
+  <target><x id="0" equiv-text="${unreadCount}"/> непрочитано</target>
   <note from="lit-localize">Indicates the number of unread notifications in the notification drawer</note>
 </trans-unit>
 <trans-unit id="s42636dae6e29892e">
   <source>Agent version: <x id="0" equiv-text="${vendorData.agent_version ?? &quot;-&quot;}"/></source>
+  <target>Версия агента: <x id="0" equiv-text="${vendorData.agent_version ?? &quot;-&quot;}"/></target>
 </trans-unit>
 <trans-unit id="s6dd24e14615f1369">
   <source>Warning: Flow imports are blueprint files, which may contain objects other than flows (such as users, policies, etc).</source>
+  <target>Предупреждение. Импорт потоков представляет собой файлы схемы, которые могут содержать объекты, отличные от потоков (например, пользователей, политики и т. д.).</target>
 </trans-unit>
 <trans-unit id="sa6cd3315b7c53ab7">
   <source>You should only import files from trusted sources and review blueprints before importing them.</source>
+  <target>Вам следует импортировать файлы только из надежных источников и просматривать чертежи перед их импортом.</target>
 </trans-unit>
 <trans-unit id="sd8309fdcb0478b0f">
   <source>The length of the individual generated tokens. Can be set to a maximum of 100 characters.</source>
+  <target>Длина отдельных сгенерированных токенов. Может быть установлено максимум 100 символов.</target>
 </trans-unit>
 <trans-unit id="s382600808211cf23">
   <source>Close sidebar</source>
+  <target>Закрыть боковую панель</target>
 </trans-unit>
 <trans-unit id="sce4fb29c933410a5">
   <source>Open sidebar</source>
+  <target>Открыть боковую панель</target>
 </trans-unit>
 <trans-unit id="s180feee6454499fa">
   <source>Certificate-Key Pair</source>
+  <target>Пара сертификат-ключ</target>
 </trans-unit>
 <trans-unit id="avatar.alt-text-for-user">
   <source>Avatar for <x id="0" equiv-text="${this.username}"/></source>
+  <target>Аватар для <x id="0" equiv-text="${this.username}"/></target>
 </trans-unit>
 <trans-unit id="avatar.alt-text">
   <source>User avatar</source>
+  <target>Аватар пользователя</target>
 </trans-unit>
 <trans-unit id="flow.navigation.go-back">
   <source>Go back</source>
+  <target>Возвращаться</target>
 </trans-unit>
 <trans-unit id="stage.authenticator.email.sent-to-address">
   <source>A verification token has been sent to your configured email address: <x id="0" equiv-text="${email}"/></source>
+  <target>Токен подтверждения был отправлен на указанный вами адрес электронной почты: <x id="0" equiv-text="${email}"/>.</target>
   <note from="lit-localize">Displayed when a verification token has been sent to the user's configured email address.</note>
 </trans-unit>
 <trans-unit id="stage.authenticator.email.sent">
   <source>A verification token has been sent to your email address.</source>
+  <target>Токен подтверждения был отправлен на ваш адрес электронной почты.</target>
   <note from="lit-localize">Displayed when a verification token has been sent to the user's email address.</note>
 </trans-unit>
 <trans-unit id="user.library.application-count-singular-with-query">
   <source><x id="0" equiv-text="${count}"/> application found for "<x id="1" equiv-text="${query}"/>"</source>
+  <target>Приложение <x id="0" equiv-text="${count}"/> найдено для " <x id="1" equiv-text="${query}"/> "</target>
 </trans-unit>
 <trans-unit id="user.library.application-count-plural-with-query">
   <source><x id="0" equiv-text="${count}"/> applications found for "<x id="1" equiv-text="${query}"/>"</source>
+  <target><x id="0" equiv-text="${count}"/> приложений найдено для " <x id="1" equiv-text="${query}"/> "</target>
 </trans-unit>
 <trans-unit id="user.library.application-count-singular">
   <source><x id="0" equiv-text="${count}"/> application available</source>
+  <target>Доступно приложение <x id="0" equiv-text="${count}"/></target>
 </trans-unit>
 <trans-unit id="user.library.application-count-plural">
   <source><x id="0" equiv-text="${count}"/> applications available</source>
+  <target>Доступно <x id="0" equiv-text="${count}"/> приложений</target>
 </trans-unit>
 <trans-unit id="user.library.search.type-to-filter-hint">
   <source>Type to filter applications</source>
+  <target>Введите текст для фильтрации приложений</target>
   <note from="lit-localize">Screen reader hint to inform the user they can filter the application list by typing</note>
 </trans-unit>
 <trans-unit id="user.library.search.enter-to-open-hint">
   <source>Press Enter to open <x id="0" equiv-text="${this.selectedApp.name}"/></source>
+  <target>Нажмите Enter, чтобы открыть <x id="0" equiv-text="${this.selectedApp.name}"/>.</target>
   <note from="lit-localize">Screen reader hint to inform the user they can open the selected application by pressing Enter</note>
 </trans-unit>
 <trans-unit id="user.library.application-count.enter-to-open-hint">
   <source>Press Enter to open <x id="0" equiv-text="${this.selectedApp.name}"/></source>
+  <target>Нажмите Enter, чтобы открыть <x id="0" equiv-text="${this.selectedApp.name}"/>.</target>
   <note from="lit-localize">Screen reader hint to inform the user they can open the selected application by pressing Enter</note>
 </trans-unit>
 <trans-unit id="library.application.card.aria-label">
   <source>Open "<x id="0" equiv-text="${application.name}"/>"</source>
+  <target>Открыть "<x id="0" equiv-text="${application.name}"/>"</target>
   <note from="lit-localize">Screen reader label for the application card</note>
 </trans-unit>
 <trans-unit id="sc1e9c9bab6765c74">
   <source>Active Sessions</source>
+  <target>Активные сессии</target>
 </trans-unit>
 <trans-unit id="s83991563e9d607ac">
   <source>Successfully revoked <x id="0" equiv-text="${this.revokedCount}"/> session(s) for <x id="1" equiv-text="${this.users.length}"/> user(s)</source>
+  <target>Сеансы <x id="0" equiv-text="${this.revokedCount}"/> успешно отозваны для пользователей <x id="1" equiv-text="${this.users.length}"/>.</target>
 </trans-unit>
 <trans-unit id="s4b004192e4d6ab2e">
   <source>Failed to revoke sessions: <x id="0" equiv-text="${e.toString()}"/></source>
+  <target>Не удалось отменить сеансы: <x id="0" equiv-text="${e.toString()}"/>.</target>
 </trans-unit>
 <trans-unit id="sb458ffb37cbde768">
   <source>Revoke Sessions</source>
+  <target>Отменить сеансы</target>
 </trans-unit>
 <trans-unit id="s1bd2d0f088b75b92">
   <source>Are you sure you want to revoke all sessions for <x id="0" equiv-text="${this.users.length}"/> user(s)?</source>
+  <target>Вы уверены, что хотите отменить все сеансы для пользователей <x id="0" equiv-text="${this.users.length}"/>?</target>
 </trans-unit>
 <trans-unit id="s5c5e74eabcb9eba1">
   <source>This will force the selected users to re-authenticate on all their devices.</source>
+  <target>Это заставит выбранных пользователей повторно пройти аутентификацию на всех своих устройствах.</target>
 </trans-unit>
 <trans-unit id="scd909e0bc55fc548">
   <source>Security key</source>
+  <target>Ключ безопасности</target>
 </trans-unit>
 <trans-unit id="sd0de938d9c37ad5f">
   <source>Use a Passkey or security key to prove your identity.</source>
+  <target>Используйте пароль или ключ безопасности, чтобы подтвердить свою личность.</target>
 </trans-unit>
 <trans-unit id="s856c15d3387d1ac7">
   <source>Include additional data in Audit logs</source>
+  <target>Включение дополнительных данных в журналы аудита</target>
 </trans-unit>
 <trans-unit id="sf432a1157155369f">
   <source>When enabled, additional data about objects added/removed is saved in the audit log. May reduce performance in certain requests.</source>
+  <target>При включении дополнительные данные о добавленных/удаленных объектах сохраняются в журнале аудита. Может снизить производительность при выполнении некоторых запросов.</target>
 </trans-unit>
 <trans-unit id="s6173e24ed3ba956e">
   <source>Successfully updated Fleet connector.</source>
+  <target>Соединитель флота успешно обновлен.</target>
 </trans-unit>
 <trans-unit id="sc9b84fdc2119ed1f">
   <source>Successfully created Fleet connector.</source>
+  <target>Соединитель флота успешно создан.</target>
 </trans-unit>
 <trans-unit id="sc8a067f02f4cf520">
   <source>Fleet settings</source>
+  <target>Настройки флота</target>
 </trans-unit>
 <trans-unit id="sd5434d21a084c48f">
   <source>Fleet Server URL</source>
+  <target>URL-адрес сервера флота</target>
 </trans-unit>
 <trans-unit id="s10320a36724d7e1a">
   <source>Fleet API Token</source>
+  <target>Токен API флота</target>
 </trans-unit>
 <trans-unit id="s4f0d6329461ac269">
   <source>Map users</source>
+  <target>Пользователи карты</target>
 </trans-unit>
 <trans-unit id="s0770384b6d1e7075">
   <source>When enabled, users detected by Fleet will be mapped in authentik, granting them access to the device.</source>
+  <target>Если этот параметр включен, пользователи, обнаруженные Fleet, будут сопоставлены в authentik, предоставляя им доступ к устройству.</target>
 </trans-unit>
 <trans-unit id="s140417fe6bad13ab">
   <source>Map teams to device access group</source>
+  <target>Сопоставьте команды с группой доступа к устройствам</target>
 </trans-unit>
 <trans-unit id="sa8383f7f7ff1a62e">
   <source>When enabled, Fleet teams will be mapped to Device access groups. Missing device access groups are automatically created. Devices assigned to a different group are not re-assigned</source>
+  <target>Если этот параметр включен, команды парка будут сопоставлены с группами доступа к устройствам. Группы доступа к отсутствующим устройствам создаются автоматически. Устройства, отнесенные к другой группе, не переназначаются</target>
 </trans-unit>
 <trans-unit id="sfec0c302ab140e30">
   <source>Software</source>
+  <target>Программное обеспечение</target>
 </trans-unit>
 <trans-unit id="sf4cea728c240ee6b">
   <source>Paste your license key...</source>
+  <target>Вставьте лицензионный ключ...</target>
 </trans-unit>
 <trans-unit id="s5f404525692ee652">
   <source>You can select from popular providers with preset configurations or choose a custom setup to specify your own endpoints and keys.</source>
+  <target>Вы можете выбрать одного из популярных поставщиков с предустановленными конфигурациями или выбрать пользовательскую настройку, указав собственные конечные точки и ключи.</target>
 </trans-unit>
 <trans-unit id="sb275cc802634f93d">
   <source>Paste your CAPTCHA public key...</source>
+  <target>Вставьте открытый ключ CAPTCHA...</target>
 </trans-unit>
 <trans-unit id="s69a0bed6319d085a">
   <source>Secret Key</source>
+  <target>Секретный ключ</target>
 </trans-unit>
 <trans-unit id="s4cbbb47ef050cd0e">
   <source>Paste your CAPTCHA secret key...</source>
+  <target>Вставьте секретный ключ CAPTCHA...</target>
 </trans-unit>
 <trans-unit id="s896c7fc0f9277a74">
   <source>Stage Name</source>
+  <target>Сценическое имя</target>
 </trans-unit>
 <trans-unit id="s1baea28d44c34fef">
   <source>Type a stage name...</source>
+  <target>Введите сценический псевдоним...</target>
 </trans-unit>
 <trans-unit id="sdd8bef43fcac336d">
   <source>The unique name used internally to identify the stage.</source>
+  <target>Уникальное имя, используемое внутри для идентификации сцены.</target>
 </trans-unit>
 <trans-unit id="captcha.providers.recaptcha-v2">
   <source>Google reCAPTCHA v2</source>
+  <target>Google reCAPTCHA v2</target>
 </trans-unit>
 <trans-unit id="captcha.providers.recaptcha.admin-console">
   <source>reCAPTCHA admin console</source>
+  <target>консоль администратора reCAPTCHA</target>
 </trans-unit>
 <trans-unit id="captcha.providers.recaptcha-v3">
   <source>Google reCAPTCHA v3</source>
+  <target>Google reCAPTCHA v3</target>
 </trans-unit>
 <trans-unit id="captcha.providers.recaptcha.api-key-source">
   <source>reCAPTCHA admin console</source>
+  <target>консоль администратора reCAPTCHA</target>
 </trans-unit>
 <trans-unit id="captcha.providers.recaptcha-enterprise">
   <source>Google reCAPTCHA Enterprise</source>
+  <target>Google reCAPTCHA для предприятий</target>
 </trans-unit>
 <trans-unit id="captcha.providers.recaptcha-enterprise.api-key-source">
   <source>Google Cloud Console</source>
+  <target>Облачная консоль Google</target>
 </trans-unit>
 <trans-unit id="captcha.providers.hcaptcha">
   <source>hCaptcha</source>
+  <target>hCaptcha</target>
 </trans-unit>
 <trans-unit id="captcha.providers.hcaptcha.api-key-source">
   <source>hCaptcha dashboard</source>
+  <target>Панель управления hCaptcha</target>
 </trans-unit>
 <trans-unit id="captcha.providers.turnstile">
   <source>Cloudflare Turnstile</source>
+  <target>Облачный турникет</target>
 </trans-unit>
 <trans-unit id="captcha.providers.turnstile.api-key-source">
   <source>Cloudflare dashboard</source>
+  <target>Панель управления Cloudflare</target>
 </trans-unit>
 <trans-unit id="captcha.providers.custom">
   <source>Custom</source>
+  <target>Обычай</target>
 </trans-unit>
 <trans-unit id="s3fdf499bd9e14a92">
   <source>Type an email address...</source>
+  <target>Введите адрес электронной почты...</target>
 </trans-unit>
 <trans-unit id="captcha.public-key.description">
   <source>The public key is used by authentik to render the CAPTCHA widget.</source>
+  <target>Открытый ключ используется authentik для отображения виджета CAPTCHA.</target>
   <note from="lit-localize">Description for CAPTCHA public key field.</note>
 </trans-unit>
 <trans-unit id="captcha.secret-key.description">
   <source>The secret key allows communication between authentik and the CAPTCHA provider to validate user responses.</source>
+  <target>Секретный ключ обеспечивает связь между authentik и провайдером CAPTCHA для проверки ответов пользователя.</target>
   <note from="lit-localize">Description for CAPTCHA secret key field.</note>
 </trans-unit>
 <trans-unit id="ak-secret-text-input.actions.modify">
   <source>Modify</source>
+  <target>Изменить</target>
   <note from="lit-localize">Help text for secret input field to indicate that clicking will allow changing the value.</note>
 </trans-unit>
 <trans-unit id="captcha.provider-link">
   <source>API keys can be obtained from the
                                         <x id="0" equiv-text="${html `&lt;a&#10;                                                target=&quot;_blank&quot;&#10;                                                rel=&quot;noopener noreferrer&quot;&#10;                                                href=${keyURL}&#10;                                                &gt;${formatAPISource()}&lt;/a&#10;                                            &gt;.`}"/></source>
+  <target>Ключи API можно получить на сайте <x id="0" equiv-text="${html `&lt;a&#10;                                                target=&quot;_blank&quot;&#10;                                                rel=&quot;noopener noreferrer&quot;&#10;                                                href=${keyURL}&#10;                                                &gt;${formatAPISource()}&lt;/a&#10;                                            &gt;.`}"/>.</target>
   <note from="lit-localize">Supplementary help text with link to provider dashboard.</note>
 </trans-unit>
 <trans-unit id="s3934affe32f6a454">
   <source><x id="0" equiv-text="${availableCount}"/> item marked to add.</source>
+  <target><x id="0" equiv-text="${availableCount}"/> элемент помечен для добавления.</target>
 </trans-unit>
 <trans-unit id="s8b68948382758d57">
   <source><x id="0" equiv-text="${availableCount}"/> items marked to add.</source>
+  <target><x id="0" equiv-text="${availableCount}"/> элементов отмечено для добавления.</target>
 </trans-unit>
 <trans-unit id="s3a482e34c3713e41">
   <source><x id="0" equiv-text="${selectedTotal}"/> item selected.</source>
+  <target>Выбран элемент <x id="0" equiv-text="${selectedTotal}"/>.</target>
 </trans-unit>
 <trans-unit id="s726a7342e18dc660">
   <source><x id="0" equiv-text="${selectedTotal}"/> items selected.</source>
+  <target>Выбрано <x id="0" equiv-text="${selectedTotal}"/> элементов.</target>
 </trans-unit>
 <trans-unit id="s403a360d48a11d5f">
   <source><x id="0" equiv-text="${selectedCount}"/> item marked to remove.</source>
+  <target><x id="0" equiv-text="${selectedCount}"/> элемент помечен для удаления.</target>
 </trans-unit>
 <trans-unit id="s2e92b61847f32e72">
   <source><x id="0" equiv-text="${selectedCount}"/> items marked to remove.</source>
+  <target><x id="0" equiv-text="${selectedCount}"/> элементов отмечено для удаления.</target>
 </trans-unit>
 <trans-unit id="sa5d4a82c5daae3de">
   <source>Reply URL</source>
+  <target>URL-адрес ответа</target>
 </trans-unit>
 <trans-unit id="s513e09d45feee5dd">
   <source>Update WS-Federation Provider</source>
+  <target>Обновление поставщика WS-Federation</target>
 </trans-unit>
 <trans-unit id="s02d3bec9a0ff82bd">
   <source>WS-Federation Configuration</source>
+  <target>Конфигурация WS-Federation</target>
 </trans-unit>
 <trans-unit id="s7eeab4c954cfed12">
   <source>WS-Federation URL</source>
+  <target>URL-адрес WS-федерации</target>
 </trans-unit>
 <trans-unit id="sb001338b056bf9d5">
   <source>Realm (wtrealm)</source>
+  <target>Царство (wtrealm)</target>
 </trans-unit>
 <trans-unit id="s7ac77ffc2d88bc94">
   <source>WS-Federation Metadata</source>
+  <target>Метаданные WS-Federation</target>
 </trans-unit>
 <trans-unit id="s36b4b8f51a90009a">
   <source>Example WS-Federation attributes</source>
+  <target>Пример атрибутов WS-Federation</target>
 </trans-unit>
 <trans-unit id="scde666c4a777dd66">
   <source>Group Filter</source>
+  <target>Групповой фильтр</target>
 </trans-unit>
 <trans-unit id="s5bbedc6d1d078553">
   <source>Groups to be synced. If empty, all groups will be synced.</source>
+  <target>Группы для синхронизации. Если пусто, все группы будут синхронизированы.</target>
 </trans-unit>
 <trans-unit id="s93aad5cd9b47f65f">
   <source>Custom Attributes</source>
+  <target>Пользовательские атрибуты</target>
 </trans-unit>
 <trans-unit id="s254696510e45f3bb">
   <source>No custom attributes defined.</source>
+  <target>Пользовательские атрибуты не определены.</target>
 </trans-unit>
 <trans-unit id="sb94beab52540d2b7">
   <source>The CAPTCHA challenge failed to load.</source>
+  <target>Не удалось загрузить запрос CAPTCHA.</target>
 </trans-unit>
 <trans-unit id="s217a96c47caaf73d">
   <source>Could not find a suitable CAPTCHA provider.</source>
+  <target>Не удалось найти подходящего поставщика CAPTCHA.</target>
 </trans-unit>
 <trans-unit id="sdf2794b96386c868">
   <source>Copy time-based one-time password secret</source>
+  <target>Копировать секретный одноразовый пароль, основанный на времени</target>
 </trans-unit>
 <trans-unit id="sc78d16417878afd0">
   <source>Copy Secret</source>
+  <target>Копировать секрет</target>
 </trans-unit>
 <trans-unit id="s2df814c26d5c5e56">
   <source>ED25519</source>
+  <target>ЭД25519</target>
 </trans-unit>
 <trans-unit id="sa31350da8b357fa4">
   <source>ED448</source>
+  <target>ЭД448</target>
 </trans-unit>
 <trans-unit id="s088efc814570fa2c">
   <source>Enrollment Token</source>
+  <target>Токен регистрации</target>
 </trans-unit>
 <trans-unit id="s0ce6e3aa4e7c81a0">
   <source>New Token</source>
+  <target>Новый токен</target>
 </trans-unit>
 <trans-unit id="s1bb47213a314465b">
   <source>Create link</source>
+  <target>Создать ссылку</target>
 </trans-unit>
 <trans-unit id="s68be8f284274370a">
   <source>Recovery link</source>
+  <target>Ссылка для восстановления</target>
 </trans-unit>
 <trans-unit id="s2e318e4a2934eef9">
   <source>Successfully queued email.</source>
+  <target>Электронная почта успешно поставлена ​​в очередь.</target>
 </trans-unit>
 <trans-unit id="s9121335709cfac7a">
   <source>Token duration</source>
+  <target>Срок действия токена</target>
 </trans-unit>
 <trans-unit id="s4530f2951a6633e2">
   <source>If a recovery token already exists, its duration is updated.</source>
+  <target>Если токен восстановления уже существует, его продолжительность обновляется.</target>
 </trans-unit>
 <trans-unit id="clipboard.write.success.message.entity">
   <source><x id="0" equiv-text="${entityLabel}"/> copied to clipboard.</source>
+  <target><x id="0" equiv-text="${entityLabel}"/> скопирован в буфер обмена.</target>
 </trans-unit>
 <trans-unit id="clipboard.write.success.generic">
   <source>Copied to clipboard.</source>
+  <target>Скопировано в буфер обмена.</target>
 </trans-unit>
 <trans-unit id="clipboard.write.failure.description">
   <source>Clipboard not available. Please copy the value manually.</source>
+  <target>Буфер обмена недоступен. Пожалуйста, скопируйте значение вручную.</target>
 </trans-unit>
 <trans-unit id="se7385f882e2b8b7d">
   <source>An unknown error occurred while retrieving the token.</source>
+  <target>При получении токена произошла неизвестная ошибка.</target>
 </trans-unit>
 <trans-unit id="totp.config">
   <source>TOTP Config</source>
+  <target>Конфигурация TOTP</target>
 </trans-unit>
 <trans-unit id="totp.config.clipboard.description">
   <source>Paste this URL into your authenticator app to set up a time-based one-time password.</source>
+  <target>Вставьте этот URL-адрес в свое приложение для аутентификации, чтобы настроить одноразовый пароль, зависящий от времени.</target>
 </trans-unit>
 <trans-unit id="totp.secret">
   <source>TOTP Secret</source>
+  <target>Секрет TOTP</target>
 </trans-unit>
 <trans-unit id="totp.secret.clipboard.description">
   <source>Paste this secret into your authenticator app to set up a time-based one-time password.</source>
+  <target>Вставьте этот секрет в свое приложение для аутентификации, чтобы настроить одноразовый пароль, зависящий от времени.</target>
 </trans-unit>
 <trans-unit id="s2157b29f47940266">
   <source>Type a unique identifier for this token...</source>
+  <target>Введите уникальный идентификатор для этого токена...</target>
 </trans-unit>
 <trans-unit id="s0950c703759a8746">
   <source>Type a description for this token...</source>
+  <target>Введите описание для этого токена...</target>
 </trans-unit>
 <trans-unit id="sd02d96c6930f31db">
   <source>Create App Password</source>
+  <target>Создать пароль приложения</target>
 </trans-unit>
 <trans-unit id="scf325f1039d7c82f">
   <source>New App Password</source>
+  <target>Новый пароль приложения</target>
 </trans-unit>
 <trans-unit id="saa02cc40143c291e">
   <source>Sidebar left (frame background)</source>
+  <target>Боковая панель слева (фон рамки)</target>
 </trans-unit>
 <trans-unit id="s7606cffc63e1b0a1">
   <source>Sidebar right (frame background)</source>
+  <target>Боковая панель справа (фон рамки)</target>
 </trans-unit>
 <trans-unit id="s92e22f9319fdb85d">
   <source>Configuration warning</source>
+  <target>Предупреждение о конфигурации</target>
 </trans-unit>
 <trans-unit id="s304ca1e922bd3278">
   <source>Lifecycle Rules</source>
+  <target>Правила жизненного цикла</target>
 </trans-unit>
 <trans-unit id="scd223a9aac742fcf">
   <source>Lifecycle</source>
+  <target>Жизненный цикл</target>
 </trans-unit>
 <trans-unit id="sa9ebf2b039449d6c">
   <source>Object Lifecycle Management is in preview.</source>
+  <target>Управление жизненным циклом объектов находится в предварительной версии.</target>
 </trans-unit>
 <trans-unit id="s2b858c5186f8f2fd">
   <source>Select a group...</source>
+  <target>Выберите группу...</target>
 </trans-unit>
 <trans-unit id="s5e0fb3d421bb57cc">
   <source>Select a role...</source>
+  <target>Выберите роль...</target>
 </trans-unit>
 <trans-unit id="s8e5d1a84bd559a27">
   <source>Select an object...</source>
+  <target>Выберите объект...</target>
 </trans-unit>
 <trans-unit id="s69e44328a5b45aa2">
   <source>Rule Name</source>
+  <target>Имя правила</target>
 </trans-unit>
 <trans-unit id="se319064a2f20deba">
   <source>Type a name for this lifecycle rule...</source>
+  <target>Введите имя для этого правила жизненного цикла...</target>
 </trans-unit>
 <trans-unit id="sb46d3613edb66558">
   <source>Interval</source>
+  <target>Интервал</target>
 </trans-unit>
 <trans-unit id="s19feda58eae87c66">
   <source>The interval between opening new reviews for matching objects.</source>
+  <target>Интервал между открытием новых отзывов на совпадающие объекты.</target>
 </trans-unit>
 <trans-unit id="s760c656016171d08">
   <source>Grace period</source>
+  <target>Льготный период</target>
 </trans-unit>
 <trans-unit id="s48a53c24fbbc8444">
   <source>The duration of time before an open review is considered overdue.</source>
+  <target>Срок до начала открытого рассмотрения считается просроченным.</target>
 </trans-unit>
 <trans-unit id="s1b5d2f91633b74d6">
   <source>Reviewer groups</source>
+  <target>Группы рецензентов</target>
 </trans-unit>
 <trans-unit id="s693370c05900a1c6">
   <source>Number of users from the selected reviewer groups that must approve the review.</source>
+  <target>Количество пользователей из выбранных групп рецензентов, которые должны одобрить отзыв.</target>
 </trans-unit>
 <trans-unit id="s74906f78877111cb">
   <source>Reviewers</source>
+  <target>Рецензенты</target>
 </trans-unit>
 <trans-unit id="sb42871a38d8b61ee">
   <source>Object type</source>
+  <target>Тип объекта</target>
 </trans-unit>
 <trans-unit id="sd530d226f68ec351">
   <source>When set, the rule will apply to the selected individual object. Otherwise, the rule applies to all objects of the selected type.</source>
+  <target>Если установлено, правило будет применяться к выбранному отдельному объекту. В противном случае правило применяется ко всем объектам выбранного типа.</target>
 </trans-unit>
 <trans-unit id="sea85769d2d8f3ea8">
   <source>Available Users</source>
+  <target>Доступные пользователи</target>
 </trans-unit>
 <trans-unit id="s6251a3b1bbd7b124">
   <source>Selected Users</source>
+  <target>Выбранные пользователи</target>
 </trans-unit>
 <trans-unit id="s3899116cda378dcb">
   <source>A review will require approval from each of the users selected here in addition to group members as per above settings.</source>
+  <target>Для проверки потребуется одобрение каждого из выбранных здесь пользователей, а также членов группы в соответствии с приведенными выше настройками.</target>
 </trans-unit>
 <trans-unit id="s56511df6b44ad5cc">
   <source>Notification transports</source>
+  <target>Транспортировка уведомлений</target>
 </trans-unit>
 <trans-unit id="s6273aa020677fe75">
   <source>Select which transports should be used to notify the user.</source>
+  <target>Выберите, какие транспорты следует использовать для уведомления пользователя.</target>
 </trans-unit>
 <trans-unit id="s78e31a199ca08cd9">
   <source>Object Lifecycle Rules</source>
+  <target>Правила жизненного цикла объекта</target>
 </trans-unit>
 <trans-unit id="s24cc4e5aa6446401">
   <source>Schedule periodic reviews for objects in authentik.</source>
+  <target>Запланируйте периодические проверки объектов в Authentik.</target>
 </trans-unit>
 <trans-unit id="s468f705986fff045">
   <source>Lifecycle rule(s)</source>
+  <target>Правила жизненного цикла</target>
 </trans-unit>
 <trans-unit id="s9279704dfc98cdf9">
   <source>No reviews yet.</source>
+  <target>Пока нет отзывов.</target>
 </trans-unit>
 <trans-unit id="s08400d94769ba771">
   <source>Reviewed on</source>
+  <target>Проверено на</target>
 </trans-unit>
 <trans-unit id="sb89da38bc0c0b3fa">
   <source>Reviewer</source>
+  <target>Рецензент</target>
 </trans-unit>
 <trans-unit id="s6686fcc6d2c8f0bd">
   <source>Note</source>
+  <target>Примечание</target>
 </trans-unit>
 <trans-unit id="s5754eb43287dd6e5">
   <source>No review iteration found for this object.</source>
+  <target>Для этого объекта не найдено ни одной итерации проверки.</target>
 </trans-unit>
 <trans-unit id="s68ea8ed25680242f">
   <source>At least <x id="0" equiv-text="${minReviewers}"/> user from this group: <x id="1" equiv-text="${groupList}"/>.</source>
+  <target>По крайней мере <x id="0" equiv-text="${minReviewers}"/> пользователь из этой группы: <x id="1" equiv-text="${groupList}"/>.</target>
 </trans-unit>
 <trans-unit id="sd9e03fcf99724085">
   <source>At least <x id="0" equiv-text="${minReviewers}"/> user from these groups: <x id="1" equiv-text="${groupList}"/>.</source>
+  <target>По крайней мере <x id="0" equiv-text="${minReviewers}"/> пользователь из этих групп: <x id="1" equiv-text="${groupList}"/>.</target>
 </trans-unit>
 <trans-unit id="sbbaa87f8826a0756">
   <source>At least <x id="0" equiv-text="${minReviewers}"/> users from this group: <x id="1" equiv-text="${groupList}"/>.</source>
+  <target>Минимум <x id="0" equiv-text="${minReviewers}"/> пользователей из этой группы: <x id="1" equiv-text="${groupList}"/>.</target>
 </trans-unit>
 <trans-unit id="s79ef398b6e3e2c44">
   <source>At least <x id="0" equiv-text="${minReviewers}"/> users from these groups: <x id="1" equiv-text="${groupList}"/>.</source>
+  <target>Как минимум <x id="0" equiv-text="${minReviewers}"/> пользователей из этих групп: <x id="1" equiv-text="${groupList}"/> .</target>
 </trans-unit>
 <trans-unit id="s33d20c1a2e0bf773">
   <source>Review opened on</source>
+  <target>Обзор открыт</target>
 </trans-unit>
 <trans-unit id="s5e053bb69bf930b7">
   <source>Grace period till</source>
+  <target>Льготный период до</target>
 </trans-unit>
 <trans-unit id="s310b639f39d731b0">
   <source>Next review date</source>
+  <target>Дата следующей проверки</target>
 </trans-unit>
 <trans-unit id="s3daaf5e7f16e2c52">
   <source>Latest review for this object</source>
+  <target>Последний отзыв об этом объекте</target>
 </trans-unit>
 <trans-unit id="s3be348f8aeeb6a64">
   <source>Review state</source>
+  <target>Состояние проверки</target>
 </trans-unit>
 <trans-unit id="s30c9ff051aa083b0">
   <source>Required reviewers</source>
+  <target>Требуются рецензенты</target>
 </trans-unit>
 <trans-unit id="s7f3437809d931336">
   <source>Reviews</source>
+  <target>Отзывы</target>
 </trans-unit>
 <trans-unit id="sc33f0df01dc32300">
   <source>Review Notes</source>
+  <target>Обзор примечаний</target>
 </trans-unit>
 <trans-unit id="s86316abdd9054708">
   <source>Type optional notes to include in this review...</source>
+  <target>Введите дополнительные примечания для включения в этот обзор...</target>
 </trans-unit>
 <trans-unit id="s2430fb91fa928ae0">
   <source>Open Reviews</source>
+  <target>Открыть обзоры</target>
 </trans-unit>
 <trans-unit id="s35d1f3a355ed1084">
   <source>See all currently open reviews.</source>
+  <target>Просмотреть все открытые на данный момент обзоры.</target>
 </trans-unit>
 <trans-unit id="s71230441c759c9b1">
   <source>Only show reviews where I am a reviewer</source>
+  <target>Показывать только те отзывы, в которых я являюсь рецензентом</target>
 </trans-unit>
 <trans-unit id="sce6a3502c71baa60">
   <source>Opened</source>
+  <target>Открыто</target>
 </trans-unit>
 <trans-unit id="sea8d30456c79058a">
   <source>Grace period ends</source>
+  <target>Льготный период заканчивается</target>
 </trans-unit>
 <trans-unit id="se6203ef69ff63548">
   <source>Pending review</source>
+  <target>Ожидает рассмотрения</target>
 </trans-unit>
 <trans-unit id="sb89d8d8bc0c08e98">
   <source>Reviewed</source>
+  <target>Рассмотрено</target>
 </trans-unit>
 <trans-unit id="sc68080ce046320cb">
   <source>Overdue</source>
+  <target>Просрочено</target>
 </trans-unit>
 <trans-unit id="sa30c4d3b566b6b1a">
   <source>Canceled</source>
+  <target>Отменено</target>
 </trans-unit>
 <trans-unit id="s804ab712b1add3d3">
   <source>An unknown error occurred while submitting the form.</source>
+  <target>При отправке формы произошла неизвестная ошибка.</target>
 </trans-unit>
 <trans-unit id="s78adb00480380ad9">
   <source>Sign logout response</source>
+  <target>Подписать ответ на выход</target>
 </trans-unit>
 <trans-unit id="s7faa5610b9493a92">
   <source>When enabled, SAML logout responses will be signed.</source>
+  <target>Если этот параметр включен, ответы на выход из системы SAML будут подписаны.</target>
 </trans-unit>
 <trans-unit id="saa088a2d0f90d5a9">
   <source>Posting logout response to SAML provider: <x id="0" equiv-text="${providerName}"/></source>
+  <target>Отправка ответа о выходе поставщику SAML: <x id="0" equiv-text="${providerName}"/></target>
 </trans-unit>
 <trans-unit id="h903c2b1c21bb9fc7">
   <source>If checked, approving a review will require at least that many users from
                         <x id="0" equiv-text="&lt;em&gt;"/>each<x id="1" equiv-text="&lt;/em&gt;"/> of the selected groups. When disabled, the value is a total
                         across all groups.</source>
+  <target>Если этот флажок установлен, для одобрения отзыва потребуется как минимум столько же пользователей из
+                        <x id="0" equiv-text="&lt;em&gt;"/>each<x id="1" equiv-text="&lt;/em&gt;"/> из выбранных групп. Если этот параметр отключен, значение представляет собой общее значение.
+                        по всем группам.</target>
 </trans-unit>
 <trans-unit id="s776d93092ad9ce90">
   <source>Review initiated</source>
+  <target>Проверка начата</target>
 </trans-unit>
 <trans-unit id="sad46bcad1a343b51">
   <source>Review overdue</source>
+  <target>Обзор просрочен</target>
 </trans-unit>
 <trans-unit id="s59d168d966cecbaf">
   <source>Review attested</source>
+  <target>Обзор подтвержден</target>
 </trans-unit>
 <trans-unit id="s5158b7f014cecefc">
   <source>Review completed</source>
+  <target>Проверка завершена</target>
 </trans-unit>
 <trans-unit id="s9a2a2fda9cfa1ddc">
   <source>Copy Link</source>
+  <target>Копировать ссылку</target>
 </trans-unit>
 <trans-unit id="s57adf424d57c8a0f">
   <source>Send</source>
+  <target>Отправлять</target>
 </trans-unit>
 <trans-unit id="s28128d03244fa1ca">
   <source>Send Invitation via Email</source>
+  <target>Отправить приглашение по электронной почте</target>
 </trans-unit>
 <trans-unit id="s1ed9fed1a5e85d63">
   <source>Send via Email</source>
+  <target>Отправить по электронной почте</target>
 </trans-unit>
 <trans-unit id="safcbc1ba006eba57">
   <source>Please enter at least one email address</source>
+  <target>Пожалуйста, введите хотя бы один адрес электронной почты</target>
 </trans-unit>
 <trans-unit id="s0f957a7b0725a6dd">
   <source>Invitation emails queued for sending to <x id="0" equiv-text="${addresses.length}"/> recipient(s). Check the System Tasks for more information.</source>
+  <target>Письма с приглашениями поставлены в очередь для отправки получателям <x id="0" equiv-text="${addresses.length}"/>. Проверьте системные задачи для получения дополнительной информации.</target>
 </trans-unit>
 <trans-unit id="s27c34847aec88ec6">
   <source>Failed to queue invitation emails: <x id="0" equiv-text="${error}"/></source>
+  <target>Не удалось поставить в очередь приглашения по электронной почте: <x id="0" equiv-text="${error}"/>.</target>
 </trans-unit>
 <trans-unit id="s8b97ea84af17c029">
   <source>Never</source>
+  <target>Никогда</target>
 </trans-unit>
 <trans-unit id="s6e0b6a18cc59fd56">
   <source>No flow set</source>
+  <target>Нет настройки расхода</target>
 </trans-unit>
 <trans-unit id="sac428aa7c586a35a">
   <source>One email address per line, or comma/semicolon separated. Each recipient will receive a separate email with an invitation link.</source>
+  <target>Один адрес электронной почты в строке или через запятую/точку с запятой. Каждый получатель получит отдельное электронное письмо со ссылкой-приглашением.</target>
 </trans-unit>
 <trans-unit id="s090f2d07b5a6aee3">
   <source>CC</source>
+  <target>СС</target>
 </trans-unit>
 <trans-unit id="s7f39ec207409ff19">
   <source>A comma-separated list of addresses to receive copies of the invitation. Recipients will receive the full list of other addresses in this list.</source>
+  <target>Разделенный запятыми список адресов для получения копий приглашения. Получатели получат полный список других адресов в этом списке.</target>
 </trans-unit>
 <trans-unit id="s15db6d19b09a16c3">
   <source>BCC</source>
+  <target>BCC</target>
 </trans-unit>
 <trans-unit id="sf4021c7b40b6f54e">
   <source>A comma-separated list of addresses to receive copies of the invitation. Recipients will not receive the addresses of other recipients.</source>
+  <target>Разделенный запятыми список адресов для получения копий приглашения. Получатели не получат адреса других получателей.</target>
 </trans-unit>
 <trans-unit id="s7c37f1acb9f97ea3">
   <source>Select the email template to use for sending invitations.</source>
+  <target>Выберите шаблон электронной почты, который будет использоваться для отправки приглашений.</target>
 </trans-unit>
 <trans-unit id="sdd2ea73c24b40d5d">
   <source>Site footer</source>
+  <target>Нижний колонтитул сайта</target>
 </trans-unit>
 <trans-unit id="sf910cca0f06bbc31">
   <source>Enter the email address or username associated with your account.</source>
+  <target>Введите адрес электронной почты или имя пользователя, связанное с вашей учётной записью.</target>
 </trans-unit>
 <trans-unit id="s6e858c4c4c3b6b76">
   <source>You're about to be redirected to the following URL.</source>
+  <target>Вы будете перенаправлены на следующий URL-адрес.</target>
 </trans-unit>
 <trans-unit id="sd5d2b94a1ccba1a9">
   <source>Log in to continue to <x id="0" equiv-text="${prelude}"/>.</source>
+  <target>Войдите в систему, чтобы продолжить работу с <x id="0" equiv-text="${prelude}"/>.</target>
 </trans-unit>
 <trans-unit id="s2ffabdbe85465503">
   <source>Continuous Login</source>
+  <target>Непрерывный вход</target>
 </trans-unit>
 <trans-unit id="s4677fce6df625313">
   <source>Successfully updated Google Chrome connector.</source>
+  <target>Коннектор Google Chrome успешно обновлен.</target>
 </trans-unit>
 <trans-unit id="s0192d4ea977c63ea">
   <source>Successfully created Google Chrome connector.</source>
+  <target>Коннектор Google Chrome успешно создан.</target>
 </trans-unit>
 <trans-unit id="s3a0fd9fb78a811d7">
   <source>Google settings</source>
+  <target>настройки Google</target>
 </trans-unit>
 <trans-unit id="s6f67870f6f799d64">
   <source>Webhook Certificate Authority</source>
+  <target>Центр сертификации вебхука</target>
 </trans-unit>
 <trans-unit id="se9be959bed7985e2">
   <source>Keypair used to validate the certificate of the webhook endpoint. When not configured, the standard CA bundle is used.</source>
+  <target>Пара ключей, используемая для проверки сертификата конечной точки веб-перехватчика. Если он не настроен, используется стандартный пакет CA.</target>
 </trans-unit>
 <trans-unit id="s5b6d39d39a26028b">
   <source>Security key (e.g. YubiKey)</source>
+  <target>Ключ безопасности (например, YubiKey)</target>
 </trans-unit>
 <trans-unit id="s78928f6dae3d3de6">
   <source>Client device (e.g. Touch ID, Windows Hello)</source>
+  <target>Клиентское устройство (например, Touch ID, Windows Hello)</target>
 </trans-unit>
 <trans-unit id="s72e4f5f795106bee">
   <source>Hybrid (e.g. QR code, phone)</source>
+  <target>Гибридный (например, QR-код, телефон)</target>
 </trans-unit>
 <trans-unit id="sf3c49b8e683a2869">
   <source>WebAuthn Hints</source>
+  <target>Советы по WebAuthn</target>
 </trans-unit>
 <trans-unit id="s5fc675da5f02f4c6">
   <source>Available Hints</source>
+  <target>Доступные подсказки</target>
 </trans-unit>
 <trans-unit id="sca3b9ac876bfd642">
   <source>Selected Hints</source>
+  <target>Избранные подсказки</target>
 </trans-unit>
 <trans-unit id="se29f57b668fb7a1b">
   <source>Optional hints to guide the browser in prioritizing the preferred authenticator type. Order matters - the first hint has highest priority. These are advisory and may be ignored by browsers.</source>
+  <target>Дополнительные подсказки, которые помогут браузеру определить приоритет предпочтительного типа аутентификатора. Порядок имеет значение: первая подсказка имеет наивысший приоритет. Они носят рекомендательный характер и могут быть проигнорированы браузерами.</target>
 </trans-unit>
 <trans-unit id="sb67b82120563c611">
   <source>Hints</source>
+  <target>Подсказки</target>
 </trans-unit>
 <trans-unit id="sa422ad938ad8da19">
   <source>Optional hints to guide the browser in prioritizing the preferred authenticator type during registration. Order matters - the first hint has highest priority. These are advisory and may be ignored by browsers.</source>
+  <target>Дополнительные подсказки, которые помогут браузеру определить приоритет предпочтительного типа аутентификатора во время регистрации. Порядок имеет значение: первая подсказка имеет наивысший приоритет. Они носят рекомендательный характер и могут быть проигнорированы браузерами.</target>
 </trans-unit>
 <trans-unit id="sdbd03c084031f5c1">
   <source>Filtering</source>
+  <target>Фильтрация</target>
 </trans-unit>
 <trans-unit id="s9e6f66c5246f0e8e">
   <source>See documentation for path rules and theme-aware names.</source>
+  <target>Правила пути и имена с учетом тем см. в документации.</target>
 </trans-unit>
 <trans-unit id="sc0fccaeebcecbc47">
   <source>No assertion was returned by the authenticator</source>
+  <target>Аутентификатор не вернул никаких утверждений</target>
 </trans-unit>
 <trans-unit id="s77e1bdd20d7457b3">
   <source>Authentication was cancelled or timed out</source>
+  <target>Аутентификация отменена или истекло время ожидания</target>
 </trans-unit>
 <trans-unit id="sbc8f730711f5a0a1">
   <source>Registration was cancelled or timed out. Please try again.</source>
+  <target>Регистрация отменена или время ожидания истекло. Пожалуйста, попробуйте еще раз.</target>
 </trans-unit>
 <trans-unit id="s881c608e3be28a20">
   <source>An error occurred while creating the credential. Please try again.</source>
+  <target>Произошла ошибка при создании учетных данных. Пожалуйста, попробуйте еще раз.</target>
 </trans-unit>
 <trans-unit id="sc0cb70cfd086d048">
   <source>Server validation of credential failed</source>
+  <target>Проверка учетных данных на сервере не удалась</target>
 </trans-unit>
 <trans-unit id="s80490368baf07290">
   <source>Upon successful authentication, re-start authentication in other open tabs.</source>
+  <target>После успешной аутентификации перезапустите аутентификацию в других открытых вкладках.</target>
 </trans-unit>
 <trans-unit id="sb5db04b10b00f6fd">
   <source>About authentik</source>
+  <target>О аутентике</target>
 </trans-unit>
 <trans-unit id="sb02534c5edb664cc">
   <source>Create a new application...</source>
+  <target>Создать новое приложение...</target>
 </trans-unit>
 <trans-unit id="s292c8dcdd327ec74">
   <source>Username or email address...</source>
+  <target>Имя пользователя или адрес электронной почты...</target>
 </trans-unit>
 <trans-unit id="sa16713eb1eae6a97">
   <source>Type an optional publisher name...</source>
+  <target>Введите необязательное имя издателя...</target>
 </trans-unit>
 <trans-unit id="s1c030a6ae5c6f468">
   <source>Type an optional description...</source>
+  <target>Введите дополнительное описание...</target>
 </trans-unit>
 <trans-unit id="s0cb0cee97f520223">
   <source>New Application</source>
+  <target>Новое приложение</target>
 </trans-unit>
 <trans-unit id="s41d4dd186ab1e7bc">
   <source>Opens the new application wizard, which will guide you through creating a new application with an existing provider.</source>
+  <target>Открывает мастер создания нового приложения, который поможет вам создать новое приложение с использованием существующего поставщика.</target>
 </trans-unit>
 <trans-unit id="sf9c86f02a5609e71">
   <source>Opens the new application form, which will guide you through creating a new application with an existing provider.</source>
+  <target>Открывает новую форму заявки, которая поможет вам создать новую заявку у существующего поставщика.</target>
 </trans-unit>
 <trans-unit id="s7f1579146577efc4">
   <source>Clear Cache</source>
+  <target>Очистить кэш</target>
 </trans-unit>
 <trans-unit id="sea15e8e7527354c0">
   <source>Search for a provider...</source>
+  <target>Ищите провайдера...</target>
 </trans-unit>
 <trans-unit id="sdfe21d69a2da53f4">
   <source>e.g. my-application</source>
+  <target>например мое приложение</target>
 </trans-unit>
 <trans-unit id="sfafe0cba4a679e37">
   <source>Select Groups</source>
+  <target>Выберите группы</target>
 </trans-unit>
 <trans-unit id="seb21141e9ea652e1">
   <source>New Group User</source>
+  <target>Новый пользователь группы</target>
 </trans-unit>
 <trans-unit id="s5e57c4018429afd2">
   <source>New Role User</source>
+  <target>Новый пользователь роли</target>
 </trans-unit>
 <trans-unit id="s16b0129acc7b8890">
   <source>Add Existing User</source>
+  <target>Добавить существующего пользователя</target>
 </trans-unit>
 <trans-unit id="s28d2576a2c70d761">
   <source>Add New User</source>
+  <target>Добавить нового пользователя</target>
 </trans-unit>
 <trans-unit id="s8f0c6a3cf392a085">
   <source>New Group User...</source>
+  <target>Новый пользователь группы...</target>
 </trans-unit>
 <trans-unit id="s1119e082608d3500">
   <source>New Role User...</source>
+  <target>Новая роль пользователя...</target>
 </trans-unit>
 <trans-unit id="s5d2f015311362871">
   <source>New Service Account...</source>
+  <target>Новая учетная запись службы...</target>
 </trans-unit>
 <trans-unit id="s001ec7d4c24a3bdb">
   <source>Start Export</source>
+  <target>Начать экспорт</target>
 </trans-unit>
 <trans-unit id="sb6f2cee2b9e63d7c">
   <source>Assign Additional Roles</source>
+  <target>Назначьте дополнительные роли</target>
 </trans-unit>
 <trans-unit id="sf071697e794cca20">
   <source>Role Name</source>
+  <target>Имя роли</target>
 </trans-unit>
 <trans-unit id="s84f375c5cd7a9d00">
   <source>Type a name for this role...</source>
+  <target>Введите имя для этой роли...</target>
 </trans-unit>
 <trans-unit id="s7ed2bed74a846fd0">
   <source>This name will be used to identify the role within authentik.</source>
+  <target>Это имя будет использоваться для идентификации роли в authentik.</target>
 </trans-unit>
 <trans-unit id="s99059109387c0163">
   <source>Service Account</source>
+  <target>Сервисный аккаунт</target>
 </trans-unit>
 <trans-unit id="s807682aafab5ce30">
   <source>Service Accounts</source>
+  <target>Сервисные аккаунты</target>
 </trans-unit>
 <trans-unit id="sd518c86e47fc6f89">
   <source>Impersonate User</source>
+  <target>Выдавать себя за пользователя</target>
 </trans-unit>
 <trans-unit id="s05fc6161cadbe078">
   <source>Impersonate <x id="0" equiv-text="${displayName}"/></source>
+  <target>Выдать себя за <x id="0" equiv-text="${displayName}"/></target>
 </trans-unit>
 <trans-unit id="s7db9a3a41143c7e4">
   <source>Set Password</source>
+  <target>Установить пароль</target>
 </trans-unit>
 <trans-unit id="sd29ddaadcc30d22c">
   <source>User "<x id="0" equiv-text="${query}"/>"</source>
+  <target>Пользователь "<x id="0" equiv-text="${query}"/>"</target>
 </trans-unit>
 <trans-unit id="s220bcce27242e1e9">
   <source>search</source>
+  <target>поиск</target>
 </trans-unit>
 <trans-unit id="saad72478f030a91a">
   <source>find</source>
+  <target>находить</target>
 </trans-unit>
 <trans-unit id="s1809b50e79923494">
   <source>Search the docs for "<x id="0" equiv-text="${query}"/>"</source>
+  <target>Искать в документации «<x id="0" equiv-text="${query}"/>»</target>
 </trans-unit>
 <trans-unit id="command-palette.suffix.view-docs">
   <source>New Tab</source>
+  <target>Новая вкладка</target>
 </trans-unit>
 <trans-unit id="s4b305030ec421c71">
   <source>Command palette</source>
+  <target>Палитра команд</target>
 </trans-unit>
 <trans-unit id="s2fd7fd218bbb7504">
   <source>No commands</source>
+  <target>Нет команд</target>
 </trans-unit>
 <trans-unit id="command-palette.no-matching-commands">
   <source>No matching commands.</source>
+  <target>Нет подходящих команд.</target>
 </trans-unit>
 <trans-unit id="command-palette.no-commands">
   <source>No commands are currently available.</source>
+  <target>В настоящее время нет доступных команд.</target>
 </trans-unit>
 <trans-unit id="s2304324999452371">
   <source>Fetching users...</source>
+  <target>Получение пользователей...</target>
 </trans-unit>
 <trans-unit id="sd1362bc0288193e9">
   <source>No matching users</source>
+  <target>Подходящие пользователи не найдены</target>
 </trans-unit>
 <trans-unit id="command-palette.no-matching-users">
   <source>No matching users.</source>
+  <target>Подходящие пользователи не найдены.</target>
 </trans-unit>
 <trans-unit id="command-palette.prefix.jump-to">
   <source>Jump to</source>
+  <target>Перейти к</target>
 </trans-unit>
 <trans-unit id="command-palette.prefix.search-for">
   <source>Search for</source>
+  <target>Искать</target>
 </trans-unit>
 <trans-unit id="command-palette.prefix.open">
   <source>Open</source>
+  <target>Открыть</target>
 </trans-unit>
 <trans-unit id="command-palette.prefix.view">
   <source>View</source>
+  <target>Вид</target>
 </trans-unit>
 <trans-unit id="command-palette.suffix.new-tab">
   <source>New Tab</source>
+  <target>Новая вкладка</target>
 </trans-unit>
 <trans-unit id="command-palette.suffix.peek">
   <source>Peek</source>
+  <target>Пик</target>
 </trans-unit>
 <trans-unit id="s233f78792e4de7ba">
   <source>Integrations</source>
+  <target>Интеграции</target>
 </trans-unit>
 <trans-unit id="s74cb3d66f6a668e1">
   <source>Documentation</source>
+  <target>Документация</target>
 </trans-unit>
 <trans-unit id="sdf1d745af5aa858f">
   <source>Release notes</source>
+  <target>Примечания к выпуску</target>
 </trans-unit>
 <trans-unit id="command-palette.suffix.new-in">
   <source>New in <x id="0" equiv-text="${import.meta.env.AK_VERSION}"/></source>
+  <target>Новое в <x id="0" equiv-text="${import.meta.env.AK_VERSION}"/></target>
 </trans-unit>
 <trans-unit id="sc55abaab70a70bfc">
   <source>authentik</source>
+  <target>аутентик</target>
 </trans-unit>
 <trans-unit id="command-palette.about-authentik">
   <source>About authentik</source>
+  <target>О аутентике</target>
 </trans-unit>
 <trans-unit id="s62278f512692e037">
   <source>Session</source>
+  <target>Сессия</target>
 </trans-unit>
 <trans-unit id="command-palette.prefix.navigate">
   <source>Navigate to</source>
+  <target>Перейдите к</target>
 </trans-unit>
 <trans-unit id="sf866305516492af0">
   <source>Interface</source>
+  <target>Интерфейс</target>
 </trans-unit>
 <trans-unit id="command-palette.label.api-requests-drawer">
   <source>API requests drawer</source>
+  <target>ящик API-запросов</target>
 </trans-unit>
 <trans-unit id="command-palette.prefix.toggle">
   <source>Toggle</source>
+  <target>Переключить</target>
 </trans-unit>
 <trans-unit id="command-palette.label.notifications-drawer">
   <source>Notifications drawer</source>
+  <target>Панель уведомлений</target>
 </trans-unit>
 <trans-unit id="command-palette.prefix.reloads-page">
   <source>Reloads page</source>
+  <target>Перезагружает страницу</target>
 </trans-unit>
 <trans-unit id="s35ed5cf95b0c7262">
   <source>authentik information</source>
+  <target>достоверная информация</target>
 </trans-unit>
 <trans-unit id="s55402a876309f95b">
   <source>Landmark: <x id="0" equiv-text="${capitalCase(this.pageIdentifier)}"/></source>
+  <target>Ориентир: <x id="0" equiv-text="${capitalCase(this.pageIdentifier)}"/></target>
 </trans-unit>
 <trans-unit id="command-palette.switch-to-tab">
   <source>Switch to tab</source>
+  <target>Переключиться на вкладку</target>
 </trans-unit>
 <trans-unit id="s031945e67717bf79">
   <source>Save Changes</source>
+  <target>Сохранить изменения</target>
 </trans-unit>
 <trans-unit id="s934c5d00f93dda66">
   <source>Resend Email</source>
+  <target>Повторно отправить электронное письмо</target>
 </trans-unit>
 <trans-unit id="command-palette-trigger-label">
   <source>Open Command Palette</source>
+  <target>Открыть палитру команд</target>
   <note from="lit-localize">Label for the button that opens the command palette</note>
 </trans-unit>
 <trans-unit id="command-palette-placeholder">
   <source>Type a command...</source>
+  <target>Введите команду...</target>
   <note from="lit-localize">Label for the command palette input</note>
 </trans-unit>
 <trans-unit id="command-palette-placeholder-extended">
   <source>What are you looking for?</source>
+  <target>Что Вы ищете?</target>
   <note from="lit-localize">Placeholder for the command palette input</note>
 </trans-unit>
 <trans-unit id="command-palette-placeholder-user-search">
   <source>Type a username or email address...</source>
+  <target>Введите имя пользователя или адрес электронной почты...</target>
   <note from="lit-localize">Placeholder for the user search command in the admin interface</note>
 </trans-unit>
 <trans-unit id="model-form.headline">
   <source><x id="0" equiv-text="${modifier} ${noun}"/></source>
+  <target><x id="0" equiv-text="${modifier} ${noun}"/></target>
   <note from="lit-localize">The headline for a form that creates or updates a model instance.</note>
 </trans-unit>
 <trans-unit id="command-palette-trigger-tooltip">
   <source>Open Command Palette</source>
+  <target>Открыть палитру команд</target>
   <note from="lit-localize">Tooltip for the button that opens the command palette</note>
 </trans-unit>
 <trans-unit id="sca1fb5dc2d7901fc">
   <source>Configure WS-Federation Provider</source>
+  <target>Настроить провайдер WS-Federation</target>
 </trans-unit>
 <trans-unit id="s5cfb19cfce5f69b1">
   <source>Outpost</source>
+  <target>Застава</target>
 </trans-unit>
 <trans-unit id="s67910ccb738e5fa5">
   <source>No instances running.</source>
+  <target>Нет запущенных экземпляров.</target>
 </trans-unit>
 <trans-unit id="s06763f4bb18a1897">
   <source>New Outpost</source>
+  <target>Новый outpost</target>
 </trans-unit>
 <trans-unit id="s80ec46e704f8c452">
   <source>No providers configured.</source>
+  <target>Поставщики не настроены.</target>
 </trans-unit>
 <trans-unit id="s3397d8bb9edb5637">
   <source>Outpost Info</source>
+  <target>Информация о заставе</target>
 </trans-unit>
 <trans-unit id="sbaf0a7c417e388af">
   <source>Health</source>
+  <target>Здоровье</target>
 </trans-unit>
 <trans-unit id="sa721e91eca44711f">
   <source>Configured providers</source>
+  <target>Настроенные провайдеры</target>
 </trans-unit>
 <trans-unit id="s5f751a332b377ca3">
   <source>Detailed health (data is cached so may be out of date)</source>
+  <target>Подробное состояние (данные кэшируются и могут быть устаревшими)</target>
 </trans-unit>
 <trans-unit id="s253a70947aa0a82c">
   <source>Webex</source>
+  <target>Вебекс</target>
 </trans-unit>
 <trans-unit id="sc574714bff5b18ea">
   <source>Altered behavior for usage with Cisco Webex.</source>
+  <target>Изменённое поведение для использования с Cisco Webex.</target>
 </trans-unit>
 <trans-unit id="s2293b71fd35fee2a">
   <source>Statistics</source>
+  <target>Статистика</target>
 </trans-unit>
 <trans-unit id="s7d2825bd304dbc49">
   <source>Authorizations (24 hours)</source>
+  <target>Авторизации (24 часа)</target>
 </trans-unit>
 <trans-unit id="s5b91d2ea77a5ba86">
   <source>Authorizations (7 days)</source>
+  <target>Авторизации (7 дней)</target>
 </trans-unit>
 <trans-unit id="s03b42cb6a95eddfb">
   <source>Authorizations (1 month)</source>
+  <target>Разрешения (1 месяц)</target>
 </trans-unit>
 <trans-unit id="sce00b83d404f4037">
   <source>Successfully imported blueprint.</source>
+  <target>Чертеж успешно импортирован.</target>
 </trans-unit>
 <trans-unit id="s8e2a8ba956a87d80">
   <source>File upload</source>
+  <target>Загрузка файла</target>
 </trans-unit>
 <trans-unit id="s82ad1b952d1637ec">
   <source>Warning: Blueprint files may contain objects such as users, policies and expression.</source>
+  <target>Предупреждение. Файлы Blueprint могут содержать такие объекты, как пользователи, политики и выражения.</target>
 </trans-unit>
 <trans-unit id="sabe892a3d6cb0df0">
   <source>Force authentication</source>
+  <target>Принудительная аутентификация</target>
 </trans-unit>
 <trans-unit id="sa79a733d1d6ea7ca">
   <source>When enabled, the IdP is requested to force re-authentication of the user, even if the user has an existing session.</source>
+  <target>Если этот параметр включен, IdP запрашивается для принудительной повторной аутентификации пользователя, даже если у пользователя есть существующий сеанс.</target>
 </trans-unit>
 <trans-unit id="sd70c33ce20f4221f">
   <source><x id="0" equiv-text="${healthyCount}"/>/<x id="1" equiv-text="${totalCount}"/> instances are healthy.</source>
+  <target>Экземпляры <x id="0" equiv-text="${healthyCount}"/>/<x id="1" equiv-text="${totalCount}"/> исправны.</target>
 </trans-unit>
 <trans-unit id="sc1006ec5976bf600">
   <source>Federated OAuth2/OpenID Providers</source>
+  <target>Федеративные поставщики OAuth2/OpenID</target>
 </trans-unit>
 <trans-unit id="s2063a9d17c280fe5">
   <source>Info</source>
+  <target>Информация</target>
 </trans-unit>
 <trans-unit id="s83cb0a6bd0b57d0c">
   <source>Verify Push stream endpoints' certificate</source>
+  <target>Проверка сертификата конечных точек push-потока</target>
 </trans-unit>
 <trans-unit id="s2044fd89e1e779ff">
   <source>Stream(s)</source>
+  <target>Поток(и)</target>
 </trans-unit>
 <trans-unit id="sdbfc37eb5da37686">
   <source>Delivery method</source>
+  <target>Способ доставки</target>
 </trans-unit>
 <trans-unit id="sf39364d7836810a6">
   <source>Delivery Method</source>
+  <target>Способ доставки</target>
 </trans-unit>
 <trans-unit id="s96b1fe1a2884509e">
   <source>Pull</source>
+  <target>Тянуть</target>
 </trans-unit>
 <trans-unit id="s970d041a28d1067d">
   <source>Push</source>
+  <target>Толкать</target>
 </trans-unit>
 <trans-unit id="s0eaba83c8b21236b">
   <source>post logout</source>
+  <target>опубликовать выход из системы</target>
 </trans-unit>
 <trans-unit id="sff974ce1fd18159e">
   <source>authorization</source>
+  <target>авторизация</target>
 </trans-unit>
 <trans-unit id="s399592d27c549c96">
   <source>Valid redirect URIs after a successful authorization or invalidation flow. Also specify any origins here for Implicit flows. Use the type dropdown to designate URIs for authorization or post-logout redirection.</source>
+  <target>Допустимые URI перенаправления после успешной авторизации или аннулирования потока. Также укажите здесь источники для неявных потоков. Используйте раскрывающийся список типов, чтобы назначить URI для авторизации или перенаправления после выхода из системы.</target>
 </trans-unit>
 <trans-unit id="s272aa39ee16e3fe7">
   <source>If no explicit authorization redirect URIs are specified, the first successfully used authorization redirect URI will be saved.</source>
+  <target>Если явные URI перенаправления авторизации не указаны, будет сохранен первый успешно использованный URI перенаправления авторизации.</target>
 </trans-unit>
 <trans-unit id="s49cafb32ed1d0d2b">
   <source>Post Logout</source>
+  <target>Опубликовать выход из системы</target>
 </trans-unit>
 <trans-unit id="s0e1a87cb82be68ac">
   <source>No connectivity status available.</source>
+  <target>Статус подключения недоступен.</target>
 </trans-unit>
 <trans-unit id="sf053496846861a89">
   <source>LDAP Group(s)</source>
+  <target>Группа(ы) LDAP</target>
 </trans-unit>
 <trans-unit id="s08d22cb65d51ec12">
   <source>Connect Group</source>
+  <target>Группа Connect</target>
 </trans-unit>
 <trans-unit id="s0e54649b37607548">
   <source>Successfully connected user.</source>
+  <target>Пользователь успешно подключен.</target>
 </trans-unit>
 <trans-unit id="sf5c3def20e22e0ac">
   <source>The unique identifier of this object in LDAP, the value of the '<x id="0" equiv-text="${this.source?.objectUniquenessField}"/>' attribute.</source>
+  <target>Уникальный идентификатор этого объекта в LDAP, значение атрибута <x id="0" equiv-text="${this.source?.objectUniquenessField}"/>.</target>
 </trans-unit>
 <trans-unit id="s6e982a7b2b65c859">
   <source>LDAP User(s)</source>
+  <target>Пользователи LDAP</target>
 </trans-unit>
 <trans-unit id="s37d7a0b00f4f6378">
   <source>Connect User</source>
+  <target>Подключить пользователя</target>
 </trans-unit>
 <trans-unit id="s21c15246d76b2910">
   <source>Object Identifier (<x id="0" equiv-text="${this.source?.objectUniquenessField}"/>)</source>
+  <target>Идентификатор объекта (<x id="0" equiv-text="${this.source?.objectUniquenessField}"/>)</target>
 </trans-unit>
 <trans-unit id="sa0e1c48bdd7086f7">
   <source>Synced Users</source>
+  <target>Синхронизированные пользователи</target>
 </trans-unit>
 <trans-unit id="s444676dba7492f41">
   <source>Synced Groups</source>
+  <target>Синхронизированные группы</target>
 </trans-unit>
 <trans-unit id="s1967faf9ed8d3504">
   <source>Avatar</source>
+  <target>Аватар</target>
 </trans-unit>
 <trans-unit id="s870f7b2f8c27e219">
   <source>Save changes</source>
+  <target>Сохранить изменения</target>
 </trans-unit>
 <trans-unit id="s4d80f6e1da39d26e">
   <source>Edit Settings</source>
+  <target>Изменить настройки</target>
 </trans-unit>
 <trans-unit id="s1f02775c374b659a">
   <source>Server Version</source>
+  <target>Версия сервера</target>
 </trans-unit>
 <trans-unit id="s16e5e5a4c64523c6">
   <source>Applications search</source>
+  <target>Поиск приложений</target>
 </trans-unit>
 <trans-unit id="sf8057578c1d38b31">
   <source>Search for application by name, group or provider...</source>
+  <target>Поиск приложения по имени, группе или провайдеру...</target>
 </trans-unit>
 <trans-unit id="sb18de48205b43ea1">
   <source>New Application options</source>
+  <target>Новые возможности приложения</target>
 </trans-unit>
 <trans-unit id="sea74880d1b9b5d2e">
   <source>Select a <x id="0" equiv-text="${title}"/>...</source>
+  <target>Выберите <x id="0" equiv-text="${title}"/>...</target>
 </trans-unit>
 <trans-unit id="s6d46b842e227be57">
   <source>Application Details</source>
+  <target>Детали приложения</target>
 </trans-unit>
 <trans-unit id="sda5e30fff0fb8622">
   <source>Provider Details</source>
+  <target>Сведения о провайдере</target>
 </trans-unit>
 <trans-unit id="s39291e42ae3e80aa">
   <source>Flow Blueprint</source>
+  <target>План потока</target>
 </trans-unit>
 <trans-unit id="s5f5f444e1434f0bb">
   <source>Flow Blueprints</source>
+  <target>Чертежи потоков</target>
 </trans-unit>
 <trans-unit id="sc1e7f77a6c720bcd">
   <source>Select a blueprint...</source>
+  <target>Выберите чертеж...</target>
 </trans-unit>
 <trans-unit id="sa8e7b3205641c888">
   <source>Search for a blueprint by name or path...</source>
+  <target>Поиск чертежа по имени или пути...</target>
 </trans-unit>
 <trans-unit id="s4d9f501d9e0474b1">
   <source>Type a name for this certificate...</source>
+  <target>Введите имя для этого сертификата...</target>
 </trans-unit>
 <trans-unit id="s229a13babcd2de4e">
   <source>e.g. mydomain.com, *.mydomain.com, mydomain.local</source>
+  <target>например мойдомен.com, *.mydomain.com, мойдомен.локальный</target>
 </trans-unit>
 <trans-unit id="sa40227ee04d48241">
   <source>Import Existing</source>
+  <target>Импортировать существующие</target>
 </trans-unit>
 <trans-unit id="sb238ddbba442c653">
   <source>Certificate Name</source>
+  <target>Имя сертификата</target>
 </trans-unit>
 <trans-unit id="se85985f43267d91d">
   <source>Type a name for this certificate-key pair...</source>
+  <target>Введите имя для этой пары сертификат-ключ...</target>
 </trans-unit>
 <trans-unit id="sb694bfc9c4f22707">
   <source>Search for a certificate or key name...</source>
+  <target>Поиск сертификата или имени ключа...</target>
 </trans-unit>
 <trans-unit id="s6fa221d26b4fb3a5">
   <source>Select a device access group...</source>
+  <target>Выберите группу доступа к устройству...</target>
 </trans-unit>
 <trans-unit id="sd3f8ab3f31961ff0">
   <source>No enrollment tokens found for this connector.</source>
+  <target>Для этого соединителя не найдены токены регистрации.</target>
 </trans-unit>
 <trans-unit id="sfb36e6e2c9c181d0">
   <source>Search for an enrollment token...</source>
+  <target>Найдите токен регистрации...</target>
 </trans-unit>
 <trans-unit id="s623334df0e007742">
   <source>Search connectors by name or type...</source>
+  <target>Поиск разъемов по названию или типу...</target>
 </trans-unit>
 <trans-unit id="s77405bfeaefa5df7">
   <source>Endpoint Connector</source>
+  <target>Коннектор конечной точки</target>
 </trans-unit>
 <trans-unit id="s9cb9d5c3536ce74c">
   <source>Endpoint Connectors</source>
+  <target>Коннекторы конечных точек</target>
 </trans-unit>
 <trans-unit id="s728b14f2c1fc517e">
   <source>Provide your Fleet API token...</source>
+  <target>Предоставьте свой токен API флота...</target>
 </trans-unit>
 <trans-unit id="s165414a623ee26dd">
   <source>Device Access Groups</source>
+  <target>Группы доступа к устройствам</target>
 </trans-unit>
 <trans-unit id="s01c5aed3727459af">
   <source>Search device groups by name...</source>
+  <target>Поиск групп устройств по имени...</target>
 </trans-unit>
 <trans-unit id="s672828ee2d469660">
   <source>Search devices by name, OS, or group...</source>
+  <target>Поиск устройств по имени, ОС или группе...</target>
 </trans-unit>
 <trans-unit id="s6206abae11837d59">
   <source>Enterprise License</source>
+  <target>Лицензия Enterprise</target>
 </trans-unit>
 <trans-unit id="s14d2e2c7c26dae5e">
   <source>Enterprise Licenses</source>
+  <target>Лицензии Enterprise</target>
 </trans-unit>
 <trans-unit id="s80966d6e3357ecac">
   <source>Search for a license by name...</source>
+  <target>Поиск лицензии по имени...</target>
 </trans-unit>
 <trans-unit id="sa1c74b747fb31ef4">
   <source>Notification Rule</source>
+  <target>Правило уведомления</target>
 </trans-unit>
 <trans-unit id="s3af6eb77fe01e40a">
   <source>Type a name for this rule...</source>
+  <target>Введите имя для этого правила...</target>
 </trans-unit>
 <trans-unit id="sdfd9e4c0a1431229">
   <source>Search for a notification rule by name, severity or group...</source>
+  <target>Поиск правила уведомления по имени, важности или группе...</target>
 </trans-unit>
 <trans-unit id="s9aed43e97f406ad7">
   <source>Notification Transport</source>
+  <target>Транспорт уведомлений</target>
 </trans-unit>
 <trans-unit id="s55e734a8740e4fb5">
   <source>Transport Name</source>
+  <target>Имя транспорта</target>
 </trans-unit>
 <trans-unit id="s741d1ae8f09b3933">
   <source>Type a name for this transport...</source>
+  <target>Введите имя для этого транспорта...</target>
 </trans-unit>
 <trans-unit id="s30e1f89ebb15a641">
   <source>Search for a notification transport by name or mode...</source>
+  <target>Поиск транспорта уведомлений по имени или режиму...</target>
 </trans-unit>
 <trans-unit id="s56723699a26ba7a9">
   <source>Search for a file by name...</source>
+  <target>Поиск файла по имени...</target>
 </trans-unit>
 <trans-unit id="s8262b0e4fe70ebcc">
   <source>Flow Name</source>
+  <target>Имя потока</target>
 </trans-unit>
 <trans-unit id="saff2b1ef8e947a4c">
   <source>Type a name for this flow...</source>
+  <target>Введите имя для этого потока...</target>
 </trans-unit>
 <trans-unit id="s655ef5bc26480d03">
   <source>Type a title for this flow...</source>
+  <target>Введите заголовок для этого потока...</target>
 </trans-unit>
 <trans-unit id="s1b09d58f0940916a">
   <source>e.g. my-flow</source>
+  <target>например, my-flow</target>
 </trans-unit>
 <trans-unit id="s3e6d52672f8055a9">
   <source>Select a designation...</source>
+  <target>Выберите назначение...</target>
 </trans-unit>
 <trans-unit id="se215571219af3e03">
   <source>Search for a flow by name or identifier...</source>
+  <target>Поиск потока по имени или идентификатору...</target>
 </trans-unit>
 <trans-unit id="s05868889177f29b8">
   <source>Stage Binding</source>
+  <target>Привязка этапа</target>
 </trans-unit>
 <trans-unit id="s2a3b8135c930d806">
   <source>Select a stage...</source>
+  <target>Выберите этап...</target>
 </trans-unit>
 <trans-unit id="s7890253cbc3a0f11">
   <source>Select one or more users to assign...</source>
+  <target>Выберите одного или нескольких пользователей, которых хотите назначить...</target>
 </trans-unit>
 <trans-unit id="sd436da52569717db">
   <source>Lifecycle Rule</source>
+  <target>Правило жизненного цикла</target>
 </trans-unit>
 <trans-unit id="s6e89acb429653073">
   <source>Search for a lifecycle rule by name or target...</source>
+  <target>Поиск правила жизненного цикла по имени или цели...</target>
 </trans-unit>
 <trans-unit id="sfc53e352afbca881">
   <source>Review</source>
+  <target>Обзор</target>
 </trans-unit>
 <trans-unit id="sddd96d7a8c730493">
   <source>Outpost Integration</source>
+  <target>Интеграция outpost</target>
 </trans-unit>
 <trans-unit id="seeaf3a5c5dda2b0d">
   <source>Search outposts by name, type or assigned integration...</source>
+  <target>Поиск outpost по имени, типу или назначенной интеграции...</target>
 </trans-unit>
 <trans-unit id="s627fcb2e3b756726">
   <source>Search for an outpost integration by name, type or assigned integration...</source>
+  <target>Поиск интеграции outpost по имени, типу или назначенной интеграции...</target>
 </trans-unit>
 <trans-unit id="s3d50d9689caaf646">
   <source>Open the wizard to create a new service connection.</source>
+  <target>Откройте мастер для создания нового подключения к службе.</target>
 </trans-unit>
 <trans-unit id="s6614cd5f6913ff3d">
   <source>New Outpost Integration</source>
+  <target>Новая интеграция outpost</target>
 </trans-unit>
 <trans-unit id="s0a6b1b964ef82473">
   <source>Open the wizard to create a new policy.</source>
+  <target>Откройте мастер для создания новой политики.</target>
 </trans-unit>
 <trans-unit id="s6325a4d09680bd6e">
   <source>Policy Name</source>
+  <target>Имя политики</target>
 </trans-unit>
 <trans-unit id="s9c114121ce05dde7">
   <source>Type a policy name...</source>
+  <target>Введите имя политики...</target>
 </trans-unit>
 <trans-unit id="sbedcbd307e07665a">
   <source>Policy Binding</source>
+  <target>Привязка политики</target>
 </trans-unit>
 <trans-unit id="sa7eca7691191ed58">
   <source>Search for a policy by name or type...</source>
+  <target>Найдите политику по названию или типу...</target>
 </trans-unit>
 <trans-unit id="s978ae8e1a90ee465">
   <source>New Policy</source>
+  <target>Новая политика</target>
 </trans-unit>
 <trans-unit id="s219823757f2e37a4">
   <source>Search for a reputation by identifier or IP...</source>
+  <target>Поиск репутации по идентификатору или IP...</target>
 </trans-unit>
 <trans-unit id="sc58c4b5e2d20ac26">
   <source>Property Mapping</source>
+  <target>Сопоставление свойств</target>
 </trans-unit>
 <trans-unit id="s161a4a481f0881bc">
   <source>Mapping Name</source>
+  <target>Имя сопоставления</target>
 </trans-unit>
 <trans-unit id="s4ce907c7a282926a">
   <source>Type a name for this mapping...</source>
+  <target>Введите имя для этого сопоставления...</target>
 </trans-unit>
 <trans-unit id="s9f8835681a5fbd87">
   <source>Search for a property mapping by name or type...</source>
+  <target>Поиск сопоставления свойств по имени или типу...</target>
 </trans-unit>
 <trans-unit id="sef1dc39187dfbc50">
   <source>New Property Mapping</source>
+  <target>Новое сопоставление свойств</target>
 </trans-unit>
 <trans-unit id="s4997e567d26705e6">
   <source>Run Test</source>
+  <target>Запустить тест</target>
 </trans-unit>
 <trans-unit id="sa2e6bc991ced226e">
   <source>Example Context Data</source>
+  <target>Пример контекстных данных</target>
 </trans-unit>
 <trans-unit id="se4e493631651cffd">
   <source>Select a user...</source>
+  <target>Выберите пользователя...</target>
 </trans-unit>
 <trans-unit id="s10253f888d117051">
   <source>Bind Mode</source>
+  <target>Режим bind</target>
 </trans-unit>
 <trans-unit id="se3d652b2eefb9eb4">
   <source>Search Mode</source>
+  <target>Режим поиска</target>
 </trans-unit>
 <trans-unit id="s2691c2b23685e486">
   <source>Bind Flow</source>
+  <target>Поток bind</target>
 </trans-unit>
 <trans-unit id="s033071f6ae08afd7">
   <source>Unbind Flow</source>
+  <target>Поток unbind</target>
 </trans-unit>
 <trans-unit id="sa2967eeed56fd6e0">
   <source>TLS Server Name</source>
+  <target>Имя сервера TLS</target>
 </trans-unit>
 <trans-unit id="s1ead555caa1a2006">
   <source>UID Start Number</source>
+  <target>Начальный номер UID</target>
 </trans-unit>
 <trans-unit id="s1756bb69542d9db4">
   <source>GID Start Number</source>
+  <target>Начальный номер GID</target>
 </trans-unit>
 <trans-unit id="s8d85c6a707771cb6">
   <source>Authorization Flow</source>
+  <target>Поток авторизации</target>
 </trans-unit>
 <trans-unit id="sf36c94b3dd7dec9a">
   <source>Client Type</source>
+  <target>Тип клиента</target>
 </trans-unit>
 <trans-unit id="se5c0444127d1b66f">
   <source>Authentication Flow</source>
+  <target>Поток аутентификации</target>
 </trans-unit>
 <trans-unit id="s0b58e50282384c23">
   <source>Invalidation Flow</source>
+  <target>Поток инвалидации</target>
 </trans-unit>
 <trans-unit id="scba3dc0c14daa5da">
   <source>Access Code Validity</source>
+  <target>Срок действия кода доступа</target>
 </trans-unit>
 <trans-unit id="s0d88c641cac72430">
   <source>Access Token Validity</source>
+  <target>Срок действия access token</target>
 </trans-unit>
 <trans-unit id="s2de57d3c2a118199">
   <source>Refresh Token Validity</source>
+  <target>Срок действия refresh token</target>
 </trans-unit>
 <trans-unit id="s92c4633a05e01db6">
   <source>Refresh Token Threshold</source>
+  <target>Порог refresh token</target>
 </trans-unit>
 <trans-unit id="s514c283c447dbcca">
   <source>Subject Mode</source>
+  <target>Тематический режим</target>
 </trans-unit>
 <trans-unit id="s584808e53254531c">
   <source>Search for provider by name, type or assigned application...</source>
+  <target>Поиск провайдера по имени, типу или назначенному приложению...</target>
 </trans-unit>
 <trans-unit id="sd8d09a02b5e34dda">
   <source>RAC Endpoint</source>
+  <target>Конечная точка RAC</target>
 </trans-unit>
 <trans-unit id="s4dc35b9b113cf62b">
   <source>RAC Endpoints</source>
+  <target>Конечные точки RAC</target>
 </trans-unit>
 <trans-unit id="s0be5af2db3c680cf">
   <source>Endpoint Name</source>
+  <target>Имя конечной точки</target>
 </trans-unit>
 <trans-unit id="sdaad41bf21e8e5f3">
   <source>Type a name for this endpoint...</source>
+  <target>Введите имя для этой конечной точки...</target>
 </trans-unit>
 <trans-unit id="sa6793a484bd8399b">
   <source>e.g. myserver.example.com, 10.0.0.1:22</source>
+  <target>например, myserver.example.com, 10.0.0.1:22</target>
 </trans-unit>
 <trans-unit id="s43f123e73d3882cb">
   <source>Create an endpoint to get started.</source>
+  <target>Создайте конечную точку, чтобы начать.</target>
 </trans-unit>
 <trans-unit id="s0af49e3fd32c92a3">
   <source>Search for an endpoint by name or host...</source>
+  <target>Поиск конечной точки по имени или хосту...</target>
 </trans-unit>
 <trans-unit id="s7fb4ba3dfb89c749">
   <source>Initial Permission Name</source>
+  <target>Имя начального разрешения</target>
 </trans-unit>
 <trans-unit id="s3652c81a5ffc1615">
   <source>Type a name for these initial permissions...</source>
+  <target>Введите имя для этих начальных разрешений...</target>
 </trans-unit>
 <trans-unit id="s6bc2e91a41be13ec">
   <source>Search for initial permissions by name...</source>
+  <target>Поиск начальных разрешений по имени...</target>
 </trans-unit>
 <trans-unit id="sd54afd99dfe64651">
   <source>Create an initial permission to get started.</source>
+  <target>Создайте начальное разрешение, чтобы начать.</target>
 </trans-unit>
 <trans-unit id="s32a0d2b9937d43b7">
   <source>Role Object Permission</source>
+  <target>Объектное разрешение роли</target>
 </trans-unit>
 <trans-unit id="s8489d5559dda260c">
   <source>Role Object Permissions</source>
+  <target>Объектные разрешения роли</target>
 </trans-unit>
 <trans-unit id="se84477a0cb9d8781">
   <source>Object Permission</source>
+  <target>Объектное разрешение</target>
 </trans-unit>
 <trans-unit id="s49df3839fcae0036">
   <source>Object Permissions</source>
+  <target>Разрешения объекта</target>
 </trans-unit>
 <trans-unit id="s8b0432eecbd8b034">
   <source>Update</source>
+  <target>Обновить</target>
 </trans-unit>
 <trans-unit id="sa6f726a43ec55a63">
   <source>Search for a role...</source>
+  <target>Поиск роли...</target>
 </trans-unit>
 <trans-unit id="sa22daca100d87eeb">
   <source>Source Name</source>
+  <target>Имя источника</target>
 </trans-unit>
 <trans-unit id="s7536c9f915bbaa8b">
   <source>Type a name for this source...</source>
+  <target>Введите имя для этого источника...</target>
 </trans-unit>
 <trans-unit id="sc0579421a31c3623">
   <source>e.g. my-kerberos-source</source>
+  <target>например, my-kerberos-source</target>
 </trans-unit>
 <trans-unit id="s4a0c13d21efc7415">
   <source>e.g. my-oauth-source</source>
+  <target>например, my-oauth-source</target>
 </trans-unit>
 <trans-unit id="s4886f075eef75a43">
   <source>e.g. my-plex-source</source>
+  <target>например мой-плекс-источник</target>
 </trans-unit>
 <trans-unit id="s2fb85f1a1bb48d57">
   <source>e.g. my-saml-source</source>
+  <target>например, my-saml-source</target>
 </trans-unit>
 <trans-unit id="s5332fcfe64df14ec">
   <source>e.g. my-scim-source</source>
+  <target>например, my-scim-source</target>
 </trans-unit>
 <trans-unit id="s160e6d2ad16970b4">
   <source>Search for a source...</source>
+  <target>Поиск источника...</target>
 </trans-unit>
 <trans-unit id="s276e897069177571">
   <source>e.g. my-telegram-source</source>
+  <target>например, my-telegram-source</target>
 </trans-unit>
 <trans-unit id="sc27c88533d7bc7d3">
   <source>Duo Device</source>
+  <target>Устройство Duo</target>
 </trans-unit>
 <trans-unit id="sf5634571795434e0">
   <source>Duo Devices</source>
+  <target>Устройства Duo</target>
 </trans-unit>
 <trans-unit id="sa6c276b7373d4084">
   <source>Importing</source>
+  <target>Импорт</target>
 </trans-unit>
 <trans-unit id="sf52d3890bf1fe2cb">
   <source>Type the Duo user ID for this device...</source>
+  <target>Введите ID пользователя Duo для этого устройства...</target>
 </trans-unit>
 <trans-unit id="s65466b58996b7efe">
   <source>Invitation</source>
+  <target>Приглашение</target>
 </trans-unit>
 <trans-unit id="s5bbad639c6a30561">
   <source>Invitation Name</source>
+  <target>Имя приглашения</target>
 </trans-unit>
 <trans-unit id="s4df6774172fa6602">
   <source>Search for an invitation by name...</source>
+  <target>Искать приглашение по имени...</target>
 </trans-unit>
 <trans-unit id="s54393bfa280ea55b">
   <source>Prompt</source>
+  <target>Быстрый</target>
 </trans-unit>
 <trans-unit id="s8aeb9bdd78a93bda">
   <source>Search for a prompt by name, field or type...</source>
+  <target>Поиск подсказки по имени, полю или типу...</target>
 </trans-unit>
 <trans-unit id="sde53bdf1d16d16ed">
   <source>Search for a stage name, type, or flow...</source>
+  <target>Поиск этапа по имени, типу или потоку...</target>
 </trans-unit>
 <trans-unit id="se34b4778849d4de2">
   <source>User creation mode</source>
+  <target>Режим создания пользователя</target>
 </trans-unit>
 <trans-unit id="s33150140b9f2b929">
   <source>Search for a token identifier, user, or intent...</source>
+  <target>Поиск токена по идентификатору, пользователю или назначению...</target>
 </trans-unit>
 <trans-unit id="s7dfd1961c568811b">
   <source>Review Credentials</source>
+  <target>Проверить учётные данные</target>
 </trans-unit>
 <trans-unit id="s92ac22a1f991b620">
   <source>Type a username for the service account...</source>
+  <target>Введите имя пользователя для сервисной учётной записи...</target>
 </trans-unit>
 <trans-unit id="sb80ecfb61d2fecc3">
   <source>Internal User</source>
+  <target>Внутренний пользователь</target>
 </trans-unit>
 <trans-unit id="sf117a273986f2f10">
   <source>Internal Users</source>
+  <target>Внутренние пользователи</target>
 </trans-unit>
 <trans-unit id="s6047fb3310b62771">
   <source>External User</source>
+  <target>Внешний пользователь</target>
 </trans-unit>
 <trans-unit id="s5076d9c565844866">
   <source>External Users</source>
+  <target>Внешние пользователи</target>
 </trans-unit>
 <trans-unit id="sa6e658c0b41f0dfc">
   <source>Type a username for the internal user...</source>
+  <target>Введите имя пользователя для внутреннего пользователя...</target>
 </trans-unit>
 <trans-unit id="sce17d331ba351972">
   <source>Type a username for the external user...</source>
+  <target>Введите имя пользователя для внешнего пользователя...</target>
 </trans-unit>
 <trans-unit id="s32f0badba04157d2">
   <source>Open the new user wizard</source>
+  <target>Открыть мастер создания пользователя</target>
 </trans-unit>
 <trans-unit id="s1dcda4e80fd2fc17">
   <source>Select email stage...</source>
+  <target>Выберите этап email...</target>
 </trans-unit>
 <trans-unit id="clipboard.progress.message.entity">
   <source>Copying <x id="0" equiv-text="${entityLabel}"/>...</source>
+  <target>Копирование <x id="0" equiv-text="${entityLabel}"/>...</target>
 </trans-unit>
 <trans-unit id="clipboard.progress.generic">
   <source>Copying to clipboard...</source>
+  <target>Копирование в буфер обмена...</target>
 </trans-unit>
 <trans-unit id="s2d0afb31093af141">
   <source>e.g. my-slug</source>
+  <target>например, my-slug</target>
 </trans-unit>
 <trans-unit id="form.create-submit">
   <source>Create <x id="0" equiv-text="${verboseName}"/></source>
+  <target>Создать <x id="0" equiv-text="${verboseName}"/></target>
 </trans-unit>
 <trans-unit id="form.create-submit-no-entity">
   <source>Create</source>
+  <target>Создать</target>
 </trans-unit>
 <trans-unit id="sdccd8f78d52d3a87">
   <source>Copy to clipboard</source>
+  <target>Скопировать в буфер обмена</target>
 </trans-unit>
 <trans-unit id="s757a4c2248c0b9da">
   <source>Entity</source>
+  <target>Сущность</target>
 </trans-unit>
 <trans-unit id="entity.edit.named">
   <source>Edit "<x id="0" equiv-text="${itemName}"/>" <x id="1" equiv-text="${noun}"/></source>
+  <target>Изменить " <x id="0" equiv-text="${itemName}"/> " <x id="1" equiv-text="${noun}"/></target>
 </trans-unit>
 <trans-unit id="entity.edit">
   <source>Edit <x id="0" equiv-text="${noun}"/></source>
+  <target>Изменить <x id="0" equiv-text="${noun}"/></target>
 </trans-unit>
 <trans-unit id="permissions.modal-invoker.named">
   <source>Open "<x id="0" equiv-text="${itemName}"/>" permissions</source>
+  <target>Открыть разрешения «<x id="0" equiv-text="${itemName}"/>»</target>
 </trans-unit>
 <trans-unit id="permissions.modal-invoker">
   <source>Open permissions</source>
+  <target>Открыть разрешения</target>
 </trans-unit>
 <trans-unit id="s3741f519c32ac391">
   <source>New</source>
+  <target>Создать</target>
 </trans-unit>
 <trans-unit id="invoker.label.modifier-noun">
   <source><x id="0" equiv-text="${createLabel} ${verboseName}"/></source>
+  <target><x id="0" equiv-text="${createLabel} ${verboseName}"/></target>
 </trans-unit>
 <trans-unit id="form.new-entity">
   <source>New</source>
+  <target>Создать</target>
 </trans-unit>
 <trans-unit id="form.submit.verb.create">
   <source>Create</source>
+  <target>Создать</target>
 </trans-unit>
 <trans-unit id="form.submit.verb.creating">
   <source>Creating</source>
+  <target>Создание</target>
 </trans-unit>
 <trans-unit id="form.submit.verb-entity">
   <source><x id="0" equiv-text="${verb} ${noun}"/></source>
+  <target><x id="0" equiv-text="${verb} ${noun}"/></target>
 </trans-unit>
 <trans-unit id="form.modifier.edit">
   <source>Edit</source>
+  <target>Редактировать</target>
 </trans-unit>
 <trans-unit id="form.submit.save-changes">
   <source>Save Changes</source>
+  <target>Сохранить изменения</target>
 </trans-unit>
 <trans-unit id="form.submit.saving-changes">
   <source>Saving Changes...</source>
+  <target>Сохранение изменений...</target>
 </trans-unit>
 <trans-unit id="se0bf7f662ec09302">
   <source>An error occurred while loading <x id="0" equiv-text="${this.verboseName}"/>.</source>
+  <target>При загрузке <x id="0" equiv-text="${this.verboseName}"/> произошла ошибка.</target>
 </trans-unit>
 <trans-unit id="s4fd2fe9adfd426e9">
   <source>Select an option...</source>
+  <target>Выберите вариант...</target>
 </trans-unit>
 <trans-unit id="s195ea6447a6b5486">
   <source>Cancel wizard</source>
+  <target>Отменить мастер</target>
 </trans-unit>
 <trans-unit id="s7ac4bf2be4d16ce4">
   <source>Search for an endpoint by name...</source>
+  <target>Поиск конечной точки по имени...</target>
 </trans-unit>
 <trans-unit id="sacc17a59268b8cf3">
   <source>No endpoints found for this application.</source>
+  <target>Для этого приложения конечные точки не найдены.</target>
 </trans-unit>
 <trans-unit id="sa769d10eac7fbdb7">
   <source>Launch Endpoint</source>
+  <target>Запустить конечную точку</target>
 </trans-unit>
 <trans-unit id="wizard.ariaLabel.default">
   <source>Wizard</source>
+  <target>Мастер</target>
   <note from="lit-localize">ARIA label for the creation wizard when no entity singular is provided.</note>
 </trans-unit>
 <trans-unit id="wizard.header.default">
   <source>Create New Entity</source>
+  <target>Создать новую сущность</target>
   <note from="lit-localize">Header for the creation wizard when no entity singular is provided.</note>
 </trans-unit>
 <trans-unit id="form.submitting">
   <source><x id="0" equiv-text="${submittingVerb} ${verboseName}"/>...</source>
+  <target><x id="0" equiv-text="${submittingVerb} ${verboseName}"/> ...</target>
   <note from="lit-localize">The message shown while a form is being submitted.</note>
 </trans-unit>
 <trans-unit id="sc74b7675f65c3e23">
   <source>Query</source>
+  <target>Запрос</target>
 </trans-unit>
 <trans-unit id="s6e8a8fbb24dfafb6">
   <source>Event query using the AKQL syntax.</source>
+  <target>Запрос событий с использованием синтаксиса AKQL.</target>
 </trans-unit>
 <trans-unit id="s4970e93737e5a3de">
   <source>See documentation for examples.</source>
+  <target>См. документацию для примеров.</target>
 </trans-unit>
 <trans-unit id="s13c123f97668a70b">
   <source>Access</source>
+  <target>Доступ</target>
 </trans-unit>
 <trans-unit id="s29d3b9fb142caed1">
   <source>Checking</source>
+  <target>Проверка</target>
 </trans-unit>
 <trans-unit id="s7716f6051e0040ee">
   <source>with New Provider...</source>
+  <target>с новым провайдером...</target>
 </trans-unit>
 <trans-unit id="s389abd73a230985b">
   <source>with Existing Provider...</source>
+  <target>с существующим провайдером...</target>
 </trans-unit>
 <trans-unit id="sf57dea661d832af7">
   <source>Select one or more backchannel providers...</source>
+  <target>Выберите одного или нескольких поставщиков обратных каналов...</target>
 </trans-unit>
 <trans-unit id="s0b0a02a4470de153">
   <source>Device</source>
+  <target>Устройство</target>
 </trans-unit>
 <trans-unit id="s6b2172efc35f9fc5">
   <source>Select one or more groups...</source>
+  <target>Выберите одну или несколько групп...</target>
 </trans-unit>
 <trans-unit id="s58649ae52329bd18">
   <source>Select one or more roles...</source>
+  <target>Выберите одну или несколько ролей...</target>
 </trans-unit>
 <trans-unit id="se1f93749f9f86133">
   <source>Select one or more permissions...</source>
+  <target>Выберите одно или несколько разрешений...</target>
 </trans-unit>
 <trans-unit id="s4607a8246d0d6265">
   <source>Avatar for <x id="0" equiv-text="${displayName}"/></source>
+  <target>Аватар для <x id="0" equiv-text="${displayName}"/></target>
 </trans-unit>
 <trans-unit id="sae2df5261700b49f">
   <source>Username: <x id="0" equiv-text="${item.username}"/></source>
+  <target>Имя пользователя: <x id="0" equiv-text="${item.username}"/></target>
 </trans-unit>
 <trans-unit id="s889d1719c28a4328">
   <source>Display name: <x id="0" equiv-text="${displayName || msg(&quot;No name set&quot;)}"/></source>
+  <target>Отображаемое имя: <x id="0" equiv-text="${displayName || msg(&quot;No name set&quot;)}"/></target>
 </trans-unit>
 <trans-unit id="s3c12d23036471dfc">
   <source>Dialog content</source>
+  <target>Содержимое диалога</target>
 </trans-unit>
 <trans-unit id="s83fc3142af4bc45f">
   <source>Require Flow token (flow can only be executed from a generated recovery link)</source>
+  <target>Требовать токен потока (поток можно выполнить только по сгенерированной ссылке восстановления)</target>
 </trans-unit>
 <trans-unit id="sb41bc87dec355a91">
   <source>Select the type of policy you want to create.</source>
+  <target>Выберите тип политики, которую хотите создать.</target>
 </trans-unit>
 <trans-unit id="sea431948ed259f17">
   <source>Bind Existing...</source>
+  <target>Привязать существующий...</target>
 </trans-unit>
 <trans-unit id="s6cd8c9a536fe9778">
   <source>Select a type to bind an existing object instead of creating a new one.</source>
+  <target>Выберите тип, чтобы привязать существующий объект вместо создания нового.</target>
 </trans-unit>
 <trans-unit id="s7ca1155850af5440">
   <source>Bind a user</source>
+  <target>Привязать пользователя</target>
 </trans-unit>
 <trans-unit id="s5d4ac457eb786153">
   <source>Statically bind an existing user.</source>
+  <target>Статически привязать существующего пользователя.</target>
 </trans-unit>
 <trans-unit id="s55a97843ee3327da">
   <source>Bind a group</source>
+  <target>Привязать группу</target>
 </trans-unit>
 <trans-unit id="s9759d2c08dac5743">
   <source>Statically bind an existing group.</source>
+  <target>Статически привязать существующую группу.</target>
 </trans-unit>
 <trans-unit id="sca7f18bb58977958">
   <source>Bind an existing policy</source>
+  <target>Привязать существующую политику</target>
 </trans-unit>
 <trans-unit id="sad707c5789636382">
   <source>Bind an existing policy.</source>
+  <target>Привязать существующую политику.</target>
 </trans-unit>
 <trans-unit id="s2b9ad6a5bc47ea5d">
   <source>Create or bind...</source>
+  <target>Создать или привязать...</target>
 </trans-unit>
 <trans-unit id="s0bc6ba00a01970db">
   <source>Select the type of stage you want to create.</source>
+  <target>Выберите тип этапа, который хотите создать.</target>
 </trans-unit>
 <trans-unit id="s17740986a2eb4322">
   <source>Existing Stage</source>
+  <target>Существующий этап</target>
 </trans-unit>
 <trans-unit id="saf2e473d40ad27c5">
   <source>Bind an existing stage to this flow.</source>
+  <target>Привязать существующий этап к этому потоку.</target>
 </trans-unit>
 <trans-unit id="s2483be7a0f8aa9aa">
   <source>Deactivating...</source>
+  <target>Деактивация...</target>
 </trans-unit>
 <trans-unit id="s29c097ef085ee657">
   <source>Activating...</source>
+  <target>Активация...</target>
 </trans-unit>
 <trans-unit id="s88e4a2cee2cad378">
   <source>Unknown user</source>
+  <target>Неизвестный пользователь</target>
 </trans-unit>
 <trans-unit id="form.headline.deactivation">
   <source>Review <x id="0" equiv-text="${this.verboseName}"/> Deactivation</source>
+  <target>Обзор деактивации <x id="0" equiv-text="${this.verboseName}"/></target>
 </trans-unit>
 <trans-unit id="form.headline.activation">
   <source>Review <x id="0" equiv-text="${this.verboseName}"/> Activation</source>
+  <target>Проверить активацию <x id="0" equiv-text="${this.verboseName}"/></target>
 </trans-unit>
 <trans-unit id="sa2ddb53b55f7432b">
   <source>Objects</source>
+  <target>Объекты</target>
 </trans-unit>
 <trans-unit id="s35fc18677970b01f">
   <source>Related object</source>
+  <target>Связанный объект</target>
 </trans-unit>
 <trans-unit id="used-by.consequence.cascade-many">
   <source>Connection will be deleted</source>
+  <target>Подключение будет удалено</target>
 </trans-unit>
 <trans-unit id="used-by.consequence.set-default">
   <source>Reference will be reset to default value</source>
+  <target>Ссылка будет сброшена к значению по умолчанию</target>
 </trans-unit>
 <trans-unit id="used-by.consequence.set-null">
   <source>Reference will be set to an empty value</source>
+  <target>Ссылка будет установлена в пустое значение</target>
 </trans-unit>
 <trans-unit id="used-by.consequence.left-dangling">
   <source><x id="0" equiv-text="${verboseName}"/> will be left dangling (may cause errors)</source>
+  <target><x id="0" equiv-text="${verboseName}"/> останется висеть (может вызвать ошибки)</target>
 </trans-unit>
 <trans-unit id="used-by.consequence.unknown-default-open-api">
   <source><x id="0" equiv-text="${verboseName}"/> has an unknown relationship (check logs)</source>
+  <target>У <x id="0" equiv-text="${verboseName}"/> неизвестная связь (проверьте журналы)</target>
 </trans-unit>
 <trans-unit id="used-by.consequence.unrecognized">
   <source><x id="0" equiv-text="${verboseName}"/> has an unrecognized relationship (check logs)</source>
+  <target>У <x id="0" equiv-text="${verboseName}"/> нераспознанная связь (проверьте журналы)</target>
 </trans-unit>
 <trans-unit id="s539942ab7cc7210e">
   <source>Failed to delete <x id="0" equiv-text="${this.objectLabel}"/></source>
+  <target>Не удалось удалить <x id="0" equiv-text="${this.objectLabel}"/>.</target>
 </trans-unit>
 <trans-unit id="sc420894701de5ea3">
   <source>Modify</source>
+  <target>Изменить</target>
 </trans-unit>
 <trans-unit id="s002c306b920f1e95">
   <source>Modifying</source>
+  <target>Модификация</target>
 </trans-unit>
 <trans-unit id="s37293a6cacedffe2">
   <source>Unnamed object</source>
+  <target>Безымянный объект</target>
 </trans-unit>
 <trans-unit id="usedBy.description">
   <source>List of objects that are associated with this <x id="0" equiv-text="${verboseName}"/>.</source>
+  <target>Список объектов, связанных с этим <x id="0" equiv-text="${verboseName}"/>.</target>
 </trans-unit>
 <trans-unit id="s2f93abbfddb3830d">
   <source>Object Name</source>
+  <target>Имя объекта</target>
 </trans-unit>
 <trans-unit id="scdb4a00d50beb88a">
   <source>Consequence</source>
+  <target>Последствие</target>
 </trans-unit>
 <trans-unit id="form-group.default-label">
   <source>Details</source>
+  <target>Подробности</target>
 </trans-unit>
 <trans-unit id="used-by.consequence.cascade">
   <source><x id="0" equiv-text="${relationName}"/> will be deleted</source>
+  <target><x id="0" equiv-text="${relationName}"/> будет удален</target>
   <note from="lit-localize">Consequence of deletion, when the related object will also be deleted. The name of the related object will be included, in the format 'Related object will be deleted'.</note>
 </trans-unit>
 <trans-unit id="user.display.unknownUser">
   <source>Unknown user</source>
+  <target>Неизвестный пользователь</target>
   <note from="lit-localize">Placeholder for an unknown user, in the format 'Unknown user'.</note>
 </trans-unit>
 <trans-unit id="usedBy.count.other">
   <source><x id="0" equiv-text="${verboseName}"/> is associated with <x id="1" equiv-text="${usedByList.length}"/> objects.</source>
+  <target><x id="0" equiv-text="${verboseName}"/> связан с <x id="1" equiv-text="${usedByList.length}"/> объектами.</target>
   <note from="lit-localize">Plural: N objects use this entity.</note>
 </trans-unit>
 <trans-unit id="usedBy.count.one">
   <source><x id="0" equiv-text="${verboseName}"/> is associated with one object.</source>
+  <target><x id="0" equiv-text="${verboseName}"/> связан с одним объектом.</target>
   <note from="lit-localize">Singular: exactly one object uses this entity.</note>
 </trans-unit>
 <trans-unit id="table.empty">
   <source>No <x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> found.</source>
+  <target><x id="0" equiv-text="${verboseNamePlural.toLocaleLowerCase(this.activeLanguageTag)}"/> не найден.</target>
   <note from="lit-localize">The message to show when a table has no content. The placeholder {0} is replaced with the pluralized name of the type of entity being shown in the table.</note>
 </trans-unit>
 <trans-unit id="user.display.nameInParens">
   <source>(<x id="0" equiv-text="${name}"/>)</source>
+  <target>( <x id="0" equiv-text="${name}"/> )</target>
   <note from="lit-localize">The user's name in parentheses, used when the name is different from the username</note>
 </trans-unit>
 <trans-unit id="used-by-list-item">
   <source><x id="0" equiv-text="${formattedName}"/> (<x id="1" equiv-text="${consequence}"/>)</source>
+  <target><x id="0" equiv-text="${formattedName}"/> ( <x id="1" equiv-text="${consequence}"/> )</target>
   <note from="lit-localize">Used in list item, showing the name of the object and the consequence of deletion.</note>
 </trans-unit>
 <trans-unit id="usedBy.count.zero">
   <source><x id="0" equiv-text="${verboseName}"/> is not associated with any objects.</source>
+  <target><x id="0" equiv-text="${verboseName}"/> не связан ни с какими объектами.</target>
   <note from="lit-localize">Zero: no objects use this entity.</note>
 </trans-unit>
 <trans-unit id="s78a13f8f08d3a317">
   <source>Authorization Code</source>
+  <target>Код авторизации</target>
 </trans-unit>
 <trans-unit id="s9765a1c7821ec626">
   <source>Implicit</source>
+  <target>Скрытый</target>
 </trans-unit>
 <trans-unit id="s6032372e5812d743">
   <source>Hybrid</source>
+  <target>Гибридный</target>
 </trans-unit>
 <trans-unit id="s4c21579d264ff019">
   <source>Refresh token</source>
+  <target>Обновить токен</target>
 </trans-unit>
 <trans-unit id="sec04243bf971ba5c">
   <source>Client credentials</source>
+  <target>Учетные данные клиента</target>
 </trans-unit>
 <trans-unit id="sf6625f1c093feb17">
   <source>Device-code</source>
+  <target>Код устройства</target>
 </trans-unit>
 <trans-unit id="sccb6f4a3d1fb9434">
   <source>Grant Types</source>
+  <target>Типы грантов</target>
 </trans-unit>
 <trans-unit id="s89c63fb4a8cb6d2b">
   <source>Grant types this provider may use.</source>
+  <target>Типы грантов, которые может использовать этот поставщик.</target>
 </trans-unit>
 <trans-unit id="s86a9472dc09ecf48">
   <source>vCenter</source>
+  <target>vCenter</target>
 </trans-unit>
 <trans-unit id="s71724d2ff6637203">
   <source>Altered behavior for usage with VMware vCenter.</source>
+  <target>Изменено поведение при использовании с VMware vCenter.</target>
 </trans-unit>
 <trans-unit id="s2ea2e39e4b470249">
   <source>EntityID/Issuer override</source>
+  <target>Переопределение EntityID/эмитента</target>
 </trans-unit>
 <trans-unit id="sf7aba95a8c43b7b1">
   <source>Sets a custom EntityID/Issuer to override the authentik generated default.</source>
+  <target>Устанавливает пользовательский EntityID/Issuer для переопределения значения по умолчанию, созданного authentik.</target>
 </trans-unit>
 <trans-unit id="sa3a27a128ad87f31">
   <source>Passwords</source>
+  <target>Пароли</target>
 </trans-unit>
 <trans-unit id="s16d13ea527d7fe6b">
   <source>Setting</source>
+  <target>Параметр</target>
 </trans-unit>
 <trans-unit id="sfef81bb4077a56fd">
   <source>Type a new password...</source>
+  <target>Введите новый пароль...</target>
 </trans-unit>
 <trans-unit id="sf9ec917e3e986bc1">
   <source>When enabled, your username will be remembered on this device for future logins.</source>
+  <target>Если эта функция включена, ваше имя пользователя будет запомнено на этом устройстве для будущих входов в систему.</target>
 </trans-unit>
 <trans-unit id="form.submitting.no-entity">
   <source><x id="0" equiv-text="${submittingVerb}"/>...</source>
+  <target><x id="0" equiv-text="${submittingVerb}"/> ...</target>
   <note from="lit-localize">The message shown while a form is being submitted, when no entity name is provided.</note>
 </trans-unit>
 <trans-unit id="sddfad4253602f965">
   <source>Account lockdown flow</source>
+  <target>Порядок блокировки аккаунта</target>
 </trans-unit>
 <trans-unit id="sda9155d390bca7b4">
   <source>Select an account lockdown flow...</source>
+  <target>Выберите порядок блокировки учетной записи...</target>
 </trans-unit>
 <trans-unit id="s77321fadb314f860">
   <source>Flow used when a user triggers account lockdown (e.g. in case of compromise). Should contain an Account Lockdown stage.</source>
+  <target>Поток, используемый, когда пользователь инициирует блокировку учетной записи (например, в случае компрометации). Должен содержать этап блокировки учетной записи.</target>
 </trans-unit>
 <trans-unit id="sf4ccddbac7b6ec31">
   <source>Account lockdown flows should require authentication so they can only be started from a signed-in session.</source>
+  <target>Потоки блокировки учетной записи должны требовать аутентификации, чтобы их можно было запустить только из сеанса, вошедшего в систему.</target>
 </trans-unit>
 <trans-unit id="sc9e81e2f575bcf24">
   <source>If no group is selected and 'Send notification to event user' is disabled, the rule is disabled.</source>
+  <target>Если группа не выбрана и параметр «Отправить уведомление пользователю о событии» отключен, правило отключено.</target>
 </trans-unit>
 <trans-unit id="sd30f00ff2135589c">
   <source>When enabled, notification will be sent to the user that triggered the event in addition to any users in the group above. The event user will always be the first user, to send a notification only to the event user enabled 'Send once' in the notification transport.</source>
+  <target>Если эта функция включена, уведомление будет отправлено пользователю, который инициировал событие, а также всем пользователям в указанной выше группе. Пользователь события всегда будет первым пользователем, отправляющим уведомление только пользователю события, для которого включена опция «Отправить один раз» в транспорте уведомлений.</target>
 </trans-unit>
 <trans-unit id="s1c0267488c33401b">
   <source>Minimum reviewers</source>
+  <target>Минимальное количество рецензентов</target>
 </trans-unit>
 <trans-unit id="sa80395e2be5324e4">
   <source>Minimum reviewers is per-group</source>
+  <target>Минимальное количество рецензентов указано для каждой группы.</target>
 </trans-unit>
 <trans-unit id="se18d75eda2628862">
   <source>The following reviews apply to this object:</source>
+  <target>К данному объекту относятся следующие отзывы:</target>
 </trans-unit>
 <trans-unit id="sea618ff863cfa3da">
   <source>This object has no reviews yet.</source>
+  <target>У этого объекта пока нет отзывов.</target>
 </trans-unit>
 <trans-unit id="sea74bf2b70c27113">
   <source>Rule</source>
+  <target>Правило</target>
 </trans-unit>
 <trans-unit id="s5ba577d0cda2bad2">
   <source>This stage executes account lockdown actions on a target user. Configure which actions to perform when this stage runs.</source>
+  <target>На этом этапе выполняются действия по блокировке учетной записи целевого пользователя. Настройте, какие действия выполнять при запуске этого этапа.</target>
 </trans-unit>
 <trans-unit id="sc2908875e6774352">
   <source>Type a name for this stage...</source>
+  <target>Введите имя для этого этапа...</target>
 </trans-unit>
 <trans-unit id="scf443deca2f466b6">
   <source>Deactivate user</source>
+  <target>Деактивировать пользователя</target>
 </trans-unit>
 <trans-unit id="s2abd586c2258eae4">
   <source>Deactivate the user account (set is_active to False).</source>
+  <target>Деактивируйте учетную запись пользователя (установите для is_active значение False).</target>
 </trans-unit>
 <trans-unit id="s89db6a525bb42303">
   <source>Set unusable password</source>
+  <target>Установить неиспользуемый пароль</target>
 </trans-unit>
 <trans-unit id="s52dc7e97dfbb99dd">
   <source>Set an unusable password for the user.</source>
+  <target>Установите непригодный пароль для пользователя.</target>
 </trans-unit>
 <trans-unit id="sb144fbff5de59af3">
   <source>Delete sessions</source>
+  <target>Удалить сеансы</target>
 </trans-unit>
 <trans-unit id="s20fb386bfce5e225">
   <source>Delete all active sessions for the user.</source>
+  <target>Удалить все активные сеансы пользователя.</target>
 </trans-unit>
 <trans-unit id="s6216c07f360073f7">
   <source>Revoke tokens</source>
+  <target>Отозвать токены</target>
 </trans-unit>
 <trans-unit id="s334ebfb3605630b0">
   <source>Revoke all tokens for the user (API, app password, recovery, verification).</source>
+  <target>Отозвать все токены пользователя (API, пароль приложения, восстановление, верификация).</target>
 </trans-unit>
 <trans-unit id="sdd3dfdd51bfbcd21">
   <source>Self-service completion</source>
+  <target>Завершение самообслуживания</target>
 </trans-unit>
 <trans-unit id="s0ef55fed99322c71">
   <source>Configure what happens after a user locks their own account. Since all sessions are deleted, the user cannot continue in the current flow and will be redirected to a separate completion flow.</source>
+  <target>Настройте, что произойдет после того, как пользователь заблокирует свою учетную запись. Поскольку все сеансы будут удалены, пользователь не сможет продолжить текущий поток и будет перенаправлен в отдельный поток завершения.</target>
 </trans-unit>
 <trans-unit id="sa42bdb7e1f7c8b75">
   <source>Completion flow</source>
+  <target>Ход завершения</target>
 </trans-unit>
 <trans-unit id="sf8f0cfd7ce5e081a">
   <source>Select a completion flow...</source>
+  <target>Выберите поток завершения...</target>
 </trans-unit>
 <trans-unit id="s7f8967e8077f2734">
   <source>Flow to redirect users to after self-service lockdown. This flow must not require authentication since the user's session is deleted.</source>
+  <target>Поток для перенаправления пользователей после блокировки самообслуживания. Этот поток не должен требовать аутентификации, поскольку сеанс пользователя удален.</target>
 </trans-unit>
 <trans-unit id="se84707d40ed8f349">
   <source>Alert (Info): Static alert box with info styling</source>
+  <target>Оповещение (информация): статическое окно оповещения со стилем информации.</target>
 </trans-unit>
 <trans-unit id="sb919fcbc8720c669">
   <source>Alert (Warning): Static alert box with warning styling</source>
+  <target>Предупреждение: статический блок предупреждения с оформлением warning</target>
 </trans-unit>
 <trans-unit id="sa50b13d36ee4f763">
   <source>Alert (Danger): Static alert box with danger styling</source>
+  <target>Оповещение (опасность): статическое окно предупреждения со стилем опасности.</target>
 </trans-unit>
 <trans-unit id="s1c23a9eed1a415df">
   <source>Warning: You are about to delete user <x id="0" equiv-text="${shouldShowWarning.username}"/>, but you are currently logged in as this user. Proceed at your own risk.</source>
+  <target>Внимание: вы собираетесь удалить пользователя <x id="0" equiv-text="${shouldShowWarning.username}"/> , но в настоящее время вы вошли в систему как этот пользователь. Действуйте на свой страх и риск.</target>
 </trans-unit>
 <trans-unit id="s11064f3323dac957">
   <source>Account Lockdown</source>
+  <target>Блокировка учётной записи</target>
 </trans-unit>
 <trans-unit id="s01a8d45397ec133b">
   <source>Security</source>
+  <target>Безопасность</target>
 </trans-unit>
 <trans-unit id="s5a1cd1f7b7a43204">
   <source>If you suspect your account has been compromised, you can immediately lock it to prevent unauthorized access.</source>
+  <target>Если вы подозреваете, что ваша учетная запись была взломана, вы можете немедленно заблокировать ее, чтобы предотвратить несанкционированный доступ.</target>
 </trans-unit>
 <trans-unit id="s36535ff645fd37f7">
   <source>Lock my account</source>
+  <target>Заблокировать мою учетную запись</target>
 </trans-unit>
 <trans-unit id="s7abbf11fd03b3c12">
   <source>Bind existing group/user</source>
+  <target>Привязать существующую группу/пользователя</target>
 </trans-unit>
 <trans-unit id="s33bfd42437266a1f">
   <source>Leave empty to skip certificate validation, or select a certificate/keypair containing the LDAP server CA chain to validate the remote certificate.</source>
+  <target>Оставьте пустым, чтобы пропустить проверку сертификата, или выберите сертификат/пару ключей, содержащую цепочку ЦС сервера LDAP, для проверки удаленного сертификата.</target>
 </trans-unit>
 <trans-unit id="sdcd1a9744efdbd7e">
   <source>Choose Policy Type</source>
+  <target>Выберите тип политики</target>
 </trans-unit>
 <trans-unit id="saa5ed8446baaba70">
   <source>Negate Result</source>
+  <target>Отрицать результат</target>
 </trans-unit>
 <trans-unit id="s5387aa645962312a">
   <source>Failure Result</source>
+  <target>Результат при неудаче</target>
 </trans-unit>
 <trans-unit id="sea62de98f2e25e03">
   <source>Device Classes</source>
+  <target>Классы устройств</target>
 </trans-unit>
 <trans-unit id="s41938ae69656ef53">
   <source>User Fields</source>
+  <target>Поля пользователя</target>
 </trans-unit>
 <trans-unit id="sc98037ccab57d329">
   <source>No preference: the browser may offer any available authenticator</source>
+  <target>Нет предпочтений: браузер может предложить любой доступный аутентификатор.</target>
 </trans-unit>
 <trans-unit id="s4611c85865abcba9">
   <source>Platform: a non-removable authenticator built into the device, such as Touch ID, Face ID, or Windows Hello</source>
+  <target>Платформа: встроенный в устройство несъемный аутентификатор, например Touch ID, Face ID или Windows Hello.</target>
 </trans-unit>
 <trans-unit id="s0003d0e3fcdacabc">
   <source>Cross-platform: a roaming authenticator, such as a YubiKey or Google Titan</source>
+  <target>Кроссплатформенный: переносной аутентификатор, например YubiKey или Google Titan</target>
 </trans-unit>
 <trans-unit id="sc157c7dcb3d1b096">
   <source>Controls the authenticatorAttachment parameter sent to the browser during WebAuthn registration. If Hints are configured and this is left as 'No preference', a value is inferred from the selected hints for backward compatibility with older browsers.</source>
+  <target>Управляет параметромuthentatorAttachment, отправляемым в браузер во время регистрации WebAuthn. Если подсказки настроены и оставлено значение «Нет предпочтений», значение выводится из выбранных подсказок для обратной совместимости со старыми браузерами.</target>
 </trans-unit>
 <trans-unit id="s1baea1b8ac34d554">
   <source>New Invitation</source>
+  <target>Новое приглашение</target>
 </trans-unit>
 <trans-unit id="sfd74a380e957d0d3">
   <source>Enrollment Flow</source>
+  <target>Поток регистрации</target>
 </trans-unit>
 <trans-unit id="scc869d556216d748">
   <source>Invitation Details</source>
+  <target>Детали приглашения</target>
 </trans-unit>
 <trans-unit id="sf3b89a70e20af6c8">
   <source>Blueprint validation failed</source>
+  <target>Проверка чертежа не удалась</target>
 </trans-unit>
 <trans-unit id="sa04b7204708f4f74">
   <source>Flow with slug "<x id="0" equiv-text="${data.slug}"/>" not found after import</source>
+  <target>Поток с меткой «<x id="0" equiv-text="${data.slug}"/>» не найден после импорта</target>
 </trans-unit>
 <trans-unit id="saaa9fd0d3ebc35aa">
   <source>Enrolled users are created as external (e.g. customers, guests). New users will be placed under users/external.</source>
+  <target>Зарегистрированные пользователи создаются как внешние (например, клиенты, гости). Новые пользователи будут размещены в users/external.</target>
 </trans-unit>
 <trans-unit id="s726dff63487da085">
   <source>Enrolled users are created as internal (e.g. employees). New users will be placed under users/internal.</source>
+  <target>Зарегистрированные пользователи создаются как внутренние (например, сотрудники). Новые пользователи будут помещены в раздел пользователи/внутренние.</target>
 </trans-unit>
 <trans-unit id="sc1358130ac327120">
   <source>If enabled, the stage will jump to the next stage when no invitation is given. If disabled, the flow will be cancelled without a valid invitation.</source>
+  <target>Если эта опция включена, этап перейдет на следующий этап, если приглашение не будет получено. Если этот параметр отключен, поток будет отменен без действительного приглашения.</target>
 </trans-unit>
 <trans-unit id="s00febd85a4889bb1">
   <source>Redirect the user to a static URL or another flow, optionally with all gathered context.</source>
+  <target>Перенаправить пользователя на статический URL или другой поток, при необходимости со всем собранным контекстом.</target>
 </trans-unit>
 <trans-unit id="sdbc1d47f0f0ed54d">
   <source>The element could not be loaded. This may be due to a missing import or a version mismatch.</source>
+  <target>Элемент не удалось загрузить. Возможно, отсутствует импорт или несовпадение версий.</target>
 </trans-unit>
 <trans-unit id="scf8a3d48f9969535">
   <source>An element could not be loaded. Please try refreshing the page or clearing your cache.</source>
+  <target>Не удалось загрузить элемент. Пожалуйста, попробуйте обновить страницу или очистить кеш.</target>
 </trans-unit>
 <trans-unit id="se2f00b2619675217">
   <source>Failed to load element</source>
+  <target>Не удалось загрузить элемент</target>
 </trans-unit>
 <trans-unit id="sac974f7c36f0c5c1">
   <source>SAML Endpoint</source>
+  <target>Конечная точка SAML</target>
 </trans-unit>
 <trans-unit id="sfb0aa7e424580866">
   <source>SAML provider endpoint. Use this URL for SP configuration.</source>
+  <target>Конечная точка поставщика SAML. Используйте этот URL-адрес для настройки SP.</target>
 </trans-unit>
 <trans-unit id="s2be14ff0704995c7">
   <source>Throttling settings</source>
+  <target>Настройки ограничения частоты</target>
 </trans-unit>
 <trans-unit id="s05b71dc850552880">
   <source>Email OTP throttling factor</source>
+  <target>Коэффициент регулирования OTP электронной почты</target>
 </trans-unit>
 <trans-unit id="s55c0221c9247ad7d">
   <source>SMS OTP throttling factor</source>
+  <target>Коэффициент регулирования SMS OTP</target>
 </trans-unit>
 <trans-unit id="sd63868fff5022ef6">
   <source>TOTP throttling factor</source>
+  <target>Коэффициент регулирования TOTP</target>
 </trans-unit>
 <trans-unit id="s89361efde7c66054">
   <source>Static OTP throttling factor</source>
+  <target>Статический коэффициент регулирования OTP</target>
 </trans-unit>
 <trans-unit id="s3162a5abea92514e">
   <source>View Credentials</source>
+  <target>Просмотр учетных данных</target>
 </trans-unit>
 <trans-unit id="s7cbd6ddbb3cdbda4">
   <source>OAuth (Silent)</source>
+  <target>OAuth (без звука)</target>
 </trans-unit>
 <trans-unit id="sf74719393c9d600b">
   <source>OAuth (Interactive)</source>
+  <target>OAuth (интерактивный)</target>
 </trans-unit>
 <trans-unit id="s364366c872ccd349">
   <source>Authenticate SCIM requests using OAuth, interactively authorized.</source>
+  <target>Аутентификация запросов SCIM с использованием OAuth в интерактивном режиме.</target>
 </trans-unit>
 <trans-unit id="s67dbb822a17bf6fc">
   <source>OAuth Token last updated</source>
+  <target>Токен OAuth последний раз обновлялся</target>
 </trans-unit>
 <trans-unit id="sb586db2f11959745">
   <source>OAuth Token expires</source>
+  <target>Срок действия токена OAuth истекает</target>
 </trans-unit>
 <trans-unit id="s4011de0d7365d106">
   <source>OAuth Status</source>
+  <target>Статус OAuth</target>
 </trans-unit>
 <trans-unit id="s169a1a1dce3987b8">
   <source>Authenticated</source>
+  <target>Аутентифицированный</target>
 </trans-unit>
 <trans-unit id="s02e7dfce69646f50">
   <source>No token saved</source>
+  <target>Токен не сохранен</target>
 </trans-unit>
 <trans-unit id="sde2c41117de5db9d">
   <source>(Re-)authenticate</source>
+  <target>(Повторно)аутентифицироваться</target>
 </trans-unit>
 <trans-unit id="s13c4adf0d185f12e">
   <source>OAuth Callback URL</source>
+  <target>URL обратного вызова OAuth</target>
 </trans-unit>
 <trans-unit id="s2736fa38f8fb1b04">
   <source>The name displayed in the Application Dashboard.</source>
+  <target>Имя, отображаемое на панели управления приложением.</target>
 </trans-unit>
 <trans-unit id="sb8bbbd3b5cd45ad2">
   <source>If checked, the launch URL will open in a new browser tab or window from the user's Application Dashboard.</source>
+  <target>Если этот флажок установлен, URL-адрес запуска откроется в новой вкладке браузера или в новом окне панели управления приложения пользователя.</target>
 </trans-unit>
 <trans-unit id="s55272b9955f1d985">
   <source>Hide from Application Dashboard</source>
+  <target>Скрыть с панели управления приложения</target>
 </trans-unit>
 <trans-unit id="s4e8256e5793952d7">
   <source>If checked, this application will not be shown on the user's Application Dashboard.</source>
+  <target>Если этот флажок установлен, это приложение не будет отображаться на панели управления приложениями пользователя.</target>
 </trans-unit>
 <trans-unit id="s7d9707524fb7e539">
   <source>The publisher is shown in the Application Dashboard.</source>
+  <target>Издатель отображается на панели управления приложения.</target>
 </trans-unit>
 <trans-unit id="sf04a246ad842c3cf">
   <source>The description is shown in the Application Dashboard and may provide additional information about the application to end users.</source>
+  <target>Описание отображается на панели управления приложением и может предоставлять конечным пользователям дополнительную информацию о приложении.</target>
 </trans-unit>
 <trans-unit id="s88c83ac92bfb1f6c">
   <source>You've logged out of <x id="0" equiv-text="${challenge.applicationName}"/>. You can log out of your authentik account.</source>
+  <target>Вы вышли из <x id="0" equiv-text="${challenge.applicationName}"/>. Можно выйти из учётной записи authentik.</target>
 </trans-unit>
 <trans-unit id="sa5c3a21cbc762ce9">
   <source>You've logged out of <x id="0" equiv-text="${challenge.applicationName}"/>.</source>
+  <target>Вы вышли из <x id="0" equiv-text="${challenge.applicationName}"/>.</target>
 </trans-unit>
 <trans-unit id="s92c038a5e1dade49">
   <source>Application Dashboard</source>
+  <target>Панель управления приложением</target>
 </trans-unit>
 <trans-unit id="s633e3919f46a8cd3">
   <source>View details of role "<x id="0" equiv-text="${item.name}"/>"</source>
+  <target>Посмотреть подробную информацию о роли " <x id="0" equiv-text="${item.name}"/> "</target>
 </trans-unit>
 <trans-unit id="sc1fc93e04011152f">
   <source>New Stage</source>
+  <target>Новая сцена</target>
 </trans-unit>
 <trans-unit id="wizard.step.choose-type.generic">
   <source>Choose type</source>
+  <target>Выберите тип</target>
   <note from="lit-localize">Generic label for the initial step in the creation wizard where the type of the entity being created is selected, used when no singular entity name is provided.</note>
 </trans-unit>
 <trans-unit id="wizard.step.choose-type">
   <source>Choose <x id="0" equiv-text="${this.verboseName}"/> Type</source>
+  <target>Выберите тип <x id="0" equiv-text="${this.verboseName}"/>.</target>
   <note from="lit-localize">Label for the initial step in the creation wizard where the type of the entity being created is selected. The placeholder {entity} is replaced with the singular name of the entity, for example 'Choose User Type' or 'Choose Group Type'.</note>
 </trans-unit>
 <trans-unit id="wizard.step.details">
   <source><x id="0" equiv-text="${entityLabel}"/> Details</source>
+  <target><x id="0" equiv-text="${entityLabel}"/> Подробности</target>
   <note from="lit-localize">Label for the step in the creation wizard where the details of the entity being created are filled in. The placeholder {entity} is replaced with the name of the entity type, for example 'User Details' or 'Group Details'.</note>
 </trans-unit>
 <trans-unit id="sd1b98c71ea0d603b">
   <source>Flags allow you to enable new functionality and behavior in authentik early.</source>
+  <target>Флаги позволяют заранее включить новые функции и поведение в authentik.</target>
 </trans-unit>
 <trans-unit id="s00640d26256c4878">
   <source>Cap Endpoint</source>
+  <target>Ограничить конечную точку</target>
 </trans-unit>
 <trans-unit id="s40bf0fb50dad7090">
   <source>https://cap.example.com/site-key/</source>
+  <target>https://cap.example.com/site-key/</target>
 </trans-unit>
 <trans-unit id="sc18a73a5831aca7b">
   <source>For Cap, prefer the self-hosted widget asset, for example https://cap.example.com/assets/widget.js. If using a CDN, pin a reviewed release.</source>
+  <target>Для Cap предпочтительнее самостоятельно размещённый виджет, например https://cap.example.com/assets/widget.js. При использовании CDN закрепите проверенный релиз.</target>
 </trans-unit>
 <trans-unit id="s4e1e8db555003a9a">
   <source>Cap's server-side verification endpoint, for example https://cap.example.com/site-key/siteverify.</source>
+  <target>Серверная конечная точка проверки Cap, например https://cap.example.com/site-key/siteverify.</target>
 </trans-unit>
 <trans-unit id="sdb752cddc543357d">
   <source>Request Content Type</source>
+  <target>Тип контента запроса</target>
 </trans-unit>
 <trans-unit id="s8afdb5c5a27d37eb">
   <source>Content-Type used for server-side verification. Cap requires JSON; most other providers use form-encoded requests.</source>
+  <target>Content-Type, используемый для проверки на стороне сервера. Для Cap требуется JSON; большинство других поставщиков используют запросы с кодировкой формы.</target>
 </trans-unit>
 <trans-unit id="captcha.request-content-type.form">
   <source>Form encoded</source>
+  <target>Форма (form-encoded)</target>
 </trans-unit>
 <trans-unit id="captcha.request-content-type.json">
   <source>JSON</source>
+  <target>JSON</target>
 </trans-unit>
 <trans-unit id="captcha.providers.cap">
   <source>Cap</source>
+  <target>Cap</target>
 </trans-unit>
 <trans-unit id="captcha.providers.cap.description">
   <source>Cap is a self-hostable CAPTCHA server that uses proof-of-work challenges.</source>
+  <target>Cap — самостоятельно размещаемый CAPTCHA-сервер с проверкой proof-of-work.</target>
 </trans-unit>
 <trans-unit id="captcha.providers.cap.setup-guide">
   <source>Cap documentation</source>
+  <target>Документация Cap</target>
 </trans-unit>
 <trans-unit id="captcha.cap-endpoint.description">
   <source>The public site-key endpoint of your Cap server.</source>
+  <target>Публичная конечная точка site-key вашего сервера Cap.</target>
   <note from="lit-localize">Description for Cap endpoint field.</note>
 </trans-unit>
 <trans-unit id="captcha.provider-link.cap">
   <source>Use the
                                         <x id="0" equiv-text="${html `&lt;a&#10;                                            target=&quot;_blank&quot;&#10;                                            rel=&quot;noopener noreferrer&quot;&#10;                                            href=${keyURL}&#10;                                            &gt;${formatAPISource()}&lt;/a&#10;                                        &gt;`}"/>
                                         to self-host Cap and configure the endpoint.</source>
+  <target>Используйте <x id="0" equiv-text="${html `&lt;a&#10;                                            target=&quot;_blank&quot;&#10;                                            rel=&quot;noopener noreferrer&quot;&#10;                                            href=${keyURL}&#10;                                            &gt;${formatAPISource()}&lt;/a&#10;                                        &gt;`}"/> для самостоятельного размещения Cap и настройки конечной точки.</target>
   <note from="lit-localize">Supplementary help text with link to Cap documentation.</note>
 </trans-unit>
 <trans-unit id="s71fed01f96762c78">
   <source>Connection Token</source>
+  <target>Токен подключения</target>
 </trans-unit>
 <trans-unit id="s2a27b0acaaccd6b1">
   <source>Connection Tokens</source>
+  <target>Токены подключения</target>
 </trans-unit>
 <trans-unit id="sd2e443fc08b24046">
   <source>Access Token</source>
+  <target>Access token</target>
 </trans-unit>
 <trans-unit id="s0c1fba42c6e31a0f">
   <source>Access Tokens</source>
+  <target>Токены доступа</target>
 </trans-unit>
 <trans-unit id="s113536ad62a8b179">
   <source>Refresh Token</source>
+  <target>Refresh token</target>
 </trans-unit>
 <trans-unit id="se61cf29ea4a4d3fe">
   <source>Refresh Tokens</source>
+  <target>Refresh tokens</target>
 </trans-unit>
 <trans-unit id="sb5cad46bad03dc19">
   <source>Unknown action</source>
+  <target>Неизвестное действие</target>
 </trans-unit>
 <trans-unit id="scc03df1c8a965428">
   <source>Custom action</source>
+  <target>Пользовательское действие</target>
 </trans-unit>
 <trans-unit id="s08670bea6a90a4e0">
   <source>Unknown user type</source>
+  <target>Неизвестный тип пользователя</target>
 </trans-unit>
 <trans-unit id="s8dfeaf9950df0ffa">
   <source>object</source>
+  <target>объект</target>
 </trans-unit>
 <trans-unit id="s26d3ea846b0765cb">
   <source>objects</source>
+  <target>объекты</target>
 </trans-unit>
 <trans-unit id="s7d041f0b6a10e8ea">
   <source>Consents</source>
+  <target>Согласия</target>
 </trans-unit>
 <trans-unit id="s8fd7c31e67f73d4c">
   <source>Reputation score</source>
+  <target>Оценка репутации</target>
 </trans-unit>
 <trans-unit id="wizard.ariaLabel.verbose-name.one">
   <source>New <x id="0" equiv-text="${verboseName}"/> Wizard</source>
+  <target>Мастер создания <x id="0" equiv-text="${verboseName}"/></target>
   <note from="lit-localize">ARIA label for the creation wizard, where the entity singular is interpolated.</note>
 </trans-unit>
 <trans-unit id="tokens.clipboard-copy.description">
   <source><x id="0" equiv-text="${formatIntentLabel(intent)}"/> token for <x id="1" equiv-text="${userObj.username}"/></source>
+  <target>Токен <x id="0" equiv-text="${formatIntentLabel(intent)}"/> для <x id="1" equiv-text="${userObj.username}"/></target>
   <note from="lit-localize">Description for a clipboard copy action for tokens, with the token intent and username as variables.</note>
 </trans-unit>
 <trans-unit id="table.emptyState.default">
   <source>No <x id="0" equiv-text="${pluralNoun}"/> found.</source>
+  <target><x id="0" equiv-text="${pluralNoun}"/> не найден.</target>
   <note from="lit-localize">Empty state message when no objects are found, where the entity plural is interpolated.</note>
 </trans-unit>
 <trans-unit id="table.emptyState.search">
   <source>No <x id="0" equiv-text="${singularNoun}"/> matches "<x id="1" equiv-text="${truncateWords(this.search, 50)}"/>"</source>
+  <target>Нет <x id="0" equiv-text="${singularNoun}"/>, соответствующих «<x id="1" equiv-text="${truncateWords(this.search, 50)}"/>»</target>
   <note from="lit-localize">Empty state message when no objects match the search query, where the entity singular is interpolated, followed by the search query truncated to 50 characters.</note>
 </trans-unit>
 <trans-unit id="wizard.header.verbose-name.one">
   <source>Create New <x id="0" equiv-text="${verboseName}"/></source>
+  <target>Создать <x id="0" equiv-text="${verboseName}"/></target>
   <note from="lit-localize">Header for the creation wizard, where the entity singular is interpolated.</note>
 </trans-unit>
 <trans-unit id="tokens.copy-button.label">
   <source>Copy token</source>
+  <target>Копировать токен</target>
   <note from="lit-localize">Label for a button that copies a token to the clipboard.</note>
 </trans-unit>
 <trans-unit id="tokens.copy-button.entity-label">
   <source>Token</source>
+  <target>Токен</target>
   <note from="lit-localize">Label for a token entity, used in clipboard copy success messages.</note>
 </trans-unit>
 <trans-unit id="table.search.placeholder">
   <source>Search for <x id="0" equiv-text="${pluralNoun}"/>...</source>
+  <target>Поиск <x id="0" equiv-text="${pluralNoun}"/>...</target>
   <note from="lit-localize">Placeholder text for the search input, where the entity plural is interpolated.</note>
 </trans-unit>
 <trans-unit id="s7a72b0fd722d51e0">
   <source>Waiting for dependencies</source>
+  <target>Ожидание зависимостей</target>
 </trans-unit>
 <trans-unit id="policy.password.score-threshold.description.too-guessable">
   <source>0: Too guessable: risky password. (guesses &lt; 10^3)</source>
+  <target>0: Too guessable: risky password. (guesses &amp;lt; 10^3)</target>
 </trans-unit>
 <trans-unit id="policy.password.score-threshold.description.very-guessable">
   <source>1: Very guessable: protection from throttled online attacks. (guesses &lt; 10^6)</source>
+  <target>1: Вполне вероятно: защита от сдерживаемых онлайн-атак. (угадай &lt;10^6)</target>
 </trans-unit>
 <trans-unit id="policy.password.score-threshold.description.somewhat-guessable">
   <source>2: Somewhat guessable: protection from unthrottled online attacks. (guesses &lt; 10^8)</source>
+  <target>2: Somewhat guessable: protection from unthrottled online attacks. (guesses &amp;lt; 10^8)</target>
 </trans-unit>
 <trans-unit id="policy.password.score-threshold.description.safely-unguessable">
   <source>3: Safely unguessable: moderate protection from offline slow-hash scenario. (guesses &lt; 10^10)</source>
+  <target>3: Safely unguessable: moderate protection from offline slow-hash scenario. (guesses &amp;lt; 10^10)</target>
 </trans-unit>
 <trans-unit id="policy.password.score-threshold.description.very-unguessable">
   <source>4: Very unguessable: strong protection from offline slow-hash scenario. (guesses &gt;= 10^10)</source>
+  <target>4: Very unguessable: strong protection from offline slow-hash scenario. (guesses &amp;gt;= 10^10)</target>
 </trans-unit>
 <trans-unit id="sb45f9fb4dba6e71a">
   <source>Unset</source>
+  <target>Не задано</target>
 </trans-unit>
 <trans-unit id="s02e9603605609ae6">
   <source>Successfully created <x id="0" equiv-text="${this.verboseName}"/></source>
+  <target>Успешно создан <x id="0" equiv-text="${this.verboseName}"/>.</target>
 </trans-unit>
 <trans-unit id="s58273fbf883b497d">
   <source>Successfully updated <x id="0" equiv-text="${this.verboseName}"/></source>
+  <target><x id="0" equiv-text="${this.verboseName}"/> успешно обновлён</target>
 </trans-unit>
 <trans-unit id="s221db22dbb4e0105">
   <source>Unknown Field</source>
+  <target>Неизвестное поле</target>
 </trans-unit>
 <trans-unit id="s47ff2d052ccbcaf3">
   <source>Unknown Field <x id="0" equiv-text="${fieldLike}"/></source>
+  <target>Неизвестное поле <x id="0" equiv-text="${fieldLike}"/></target>
 </trans-unit>
 <trans-unit id="form.submit.verb.created">
   <source>Created</source>
+  <target>Создано</target>
 </trans-unit>
 <trans-unit id="form.submit.changes-saved">
   <source>Changes Saved</source>
+  <target>Изменения сохранены</target>
 </trans-unit>
 <trans-unit id="library.application.row.aria-label">
   <source>Open "<x id="0" equiv-text="${application.name}"/>"</source>
+  <target>Открыть "<x id="0" equiv-text="${application.name}"/>"</target>
   <note from="lit-localize">Screen reader label for the application list row</note>
 </trans-unit>
 <trans-unit id="form.submitted.verb-entity">
   <source><x id="0" equiv-text="${verb} ${noun}"/></source>
+  <target><x id="0" equiv-text="${verb} ${noun}"/></target>
   <note from="lit-localize">The message shown after a form is successfully submitted.</note>
 </trans-unit>
 <trans-unit id="user.library.view-toggle.to-list">
   <source>Switch to list view</source>
+  <target>Переключиться на список</target>
   <note from="lit-localize">Tooltip on the library view toggle when grid view is active</note>
 </trans-unit>
 <trans-unit id="user.library.view-toggle.to-grid">
   <source>Switch to grid view</source>
+  <target>Переключиться на сетку</target>
   <note from="lit-localize">Tooltip on the library view toggle when list view is active</note>
 </trans-unit>
 <trans-unit id="users.recovery.no-email.description">
   <source>This user does not have an email address, so authentik cannot email a recovery link. Add an email address to enable email recovery.</source>
+  <target>У этого пользователя нет адреса электронной почты, поэтому authentik не может отправить ссылку восстановления. Добавьте адрес электронной почты, чтобы включить восстановление по email.</target>
 </trans-unit>
 <trans-unit id="users.recovery.no-brand-flow.description">
   <source>This brand does not have a recovery flow, so recovery links cannot be created. Configure a recovery flow in the brand settings to enable recovery.</source>
+  <target>У этого бренда нет потока восстановления, поэтому ссылки восстановления создать нельзя. Настройте поток восстановления в параметрах бренда.</target>
 </trans-unit>
 <trans-unit id="s7445550f2bfb2f2f">
   <source>No notes.</source>
+  <target>Никаких примечаний.</target>
 </trans-unit>
 <trans-unit id="s0502740c80377fe0">
   <source>Enrollment Flows</source>
+  <target>Потоки регистрации</target>
 </trans-unit>
 <trans-unit id="s36d3e9e28a1b4ffd">
   <source>Successfully created enrollment flow with invitation stage.</source>
+  <target>Поток регистрации с этапом приглашения успешно создан.</target>
 </trans-unit>
 <trans-unit id="seb916cadb4a7c437">
   <source>Type a name for the new enrollment flow...</source>
+  <target>Введите имя для нового потока регистрации...</target>
 </trans-unit>
 <trans-unit id="sba43d2c76afbf380">
   <source>Flow Slug</source>
+  <target>Slug потока</target>
 </trans-unit>
 <trans-unit id="sc0b5b66c35a4c34f">
   <source>Internal flow name used in URLs.</source>
+  <target>Внутреннее имя потока, используемое в URL.</target>
 </trans-unit>
 <trans-unit id="s6e59fc2534d00751">
   <source>e.g. my-enrollment-flow</source>
+  <target>например, my-enrollment-flow</target>
 </trans-unit>
 <trans-unit id="se53244cd28aeccd7">
   <source>Invitation Stage Name</source>
+  <target>Имя этапа приглашения</target>
 </trans-unit>
 <trans-unit id="s82c71ab0a2d18257">
   <source>Type a name for the stage...</source>
+  <target>Введите имя для этапа...</target>
 </trans-unit>
 <trans-unit id="s10dd794d4839378e">
   <source>Select an enrollment flow.</source>
+  <target>Выберите поток регистрации.</target>
 </trans-unit>
 <trans-unit id="sece0e7e9d7ad08bf">
   <source>e.g. my-invite</source>
+  <target>например, my-invite</target>
 </trans-unit>
 <trans-unit id="s0bce09e0fcbb5931">
   <source>Create a new enrollment flow with invitation stage...</source>
+  <target>Создать новый поток регистрации с этапом приглашения...</target>
 </trans-unit>
 <trans-unit id="s6d4209fcf153eda5">
   <source>The enrollment flow the invitation link will use. The flow should have an invitation stage bound to it for the invitation to be accepted.</source>
+  <target>Порядок регистрации, который будет использоваться по ссылке-приглашению. Поток должен иметь привязанную к нему стадию приглашения, чтобы приглашение было принято.</target>
 </trans-unit>
 <trans-unit id="s0d66a3b9441ea7f4">
   <source>Invitation Stage</source>
+  <target>Этап приглашения</target>
 </trans-unit>
 <trans-unit id="se40fbacec016aa65">
   <source>Invitation Stages</source>
+  <target>Этапы приглашения</target>
 </trans-unit>
 <trans-unit id="sb401ca35f1d61eed">
   <source>e.g. invitation-stage</source>
+  <target>например, invitation-stage</target>
 </trans-unit>
 <trans-unit id="sc30c9b42e2a1ebe7">
   <source>Token exchange</source>
+  <target>Обмен токенами</target>
 </trans-unit>
 <trans-unit id="s466fe1c428b4b61a">
   <source>Issuer override</source>
+  <target>Переопределение issuer</target>
 </trans-unit>
 <trans-unit id="s19ccfb86a879e6b9">
   <source>Also known as Entity ID. Defaults to the Metadata URL.</source>
+  <target>Также известен как идентификатор объекта. По умолчанию используется URL-адрес метаданных.</target>
 </trans-unit>
 <trans-unit id="sedf57cb30482d9da">
   <source>Object Attribute</source>
+  <target>Атрибут объекта</target>
 </trans-unit>
 <trans-unit id="sdafc8d30aa57da2b">
   <source>Object Attributes</source>
+  <target>Атрибуты объекта</target>
 </trans-unit>
 <trans-unit id="s894c49aaafdba91f">
   <source>Successfully updated attribute.</source>
+  <target>Атрибут успешно обновлён.</target>
 </trans-unit>
 <trans-unit id="s845c2967bcd46316">
   <source>Successfully created attribute.</source>
+  <target>Атрибут успешно создан.</target>
 </trans-unit>
 <trans-unit id="s908b5be2d8f0db21">
   <source>Type a human-readable name...</source>
+  <target>Введите понятное имя...</target>
 </trans-unit>
 <trans-unit id="s7d311363234d73fb">
   <source>Human-readable name of this attribute.</source>
+  <target>Понятное имя этого атрибута.</target>
 </trans-unit>
 <trans-unit id="s5d78a1c414da5e44">
   <source>Unique identifier per object type, which is used as a key in the attributes field.</source>
+  <target>Уникальный идентификатор для типа объекта, используемый как ключ в поле attributes.</target>
 </trans-unit>
 <trans-unit id="s657dc9ce441c7700">
   <source>Type an optional group identifier...</source>
+  <target>Введите необязательный идентификатор группы...</target>
 </trans-unit>
 <trans-unit id="s43c8d24ef6f60d2d">
   <source>Optional grouping for this attribute in forms.</source>
+  <target>Необязательная группировка этого атрибута в формах.</target>
 </trans-unit>
 <trans-unit id="sb06ff586521714ae">
   <source>When checked, attribute will be shown in forms for the selected object type.</source>
+  <target>Если отмечено, атрибут будет отображаться в формах для выбранного типа объекта.</target>
 </trans-unit>
 <trans-unit id="s2492f5fb1b05b45e">
   <source>Text</source>
+  <target>Текст</target>
 </trans-unit>
 <trans-unit id="s0b946f226c5700df">
   <source>Boolean</source>
+  <target>Логический</target>
 </trans-unit>
 <trans-unit id="sd61653ebe961b17a">
   <source>Validation</source>
+  <target>Проверка</target>
 </trans-unit>
 <trans-unit id="s0e777c63f8b66f42">
   <source>Attribute is required</source>
+  <target>Укажите атрибут</target>
 </trans-unit>
 <trans-unit id="sf045a55e8aaa66c1">
   <source>Value of the attribute cannot be empty.</source>
+  <target>Значение атрибута не может быть пустым.</target>
 </trans-unit>
 <trans-unit id="s10a69c9ec42f1344">
   <source>Attribute is unique</source>
+  <target>Атрибут уникален</target>
 </trans-unit>
 <trans-unit id="s5e545b0cdccce0f7">
   <source>Value of the attribute must be unique across all instances of the selected object type.</source>
+  <target>Значение атрибута должно быть уникальным среди всех экземпляров выбранного типа объекта.</target>
 </trans-unit>
 <trans-unit id="sd20d8f54ac490098">
   <source>RegEx</source>
+  <target>регулярное выражение</target>
 </trans-unit>
 <trans-unit id="s801c8da3397d5e8a">
   <source>Enter an optional Regular Expression for validation...</source>
+  <target>Введите необязательное регулярное выражение для проверки...</target>
 </trans-unit>
 <trans-unit id="s279bfeba4a09f52b">
   <source>Optional RegEx to validate any value against. Uses the Python RegEx engine.</source>
+  <target>Необязательный RegEx для проверки любого значения. Использует механизм Python RegEx.</target>
 </trans-unit>
 <trans-unit id="s0b9470a6fac5a80b">
   <source>Object attributes</source>
+  <target>Атрибуты объекта</target>
 </trans-unit>
 <trans-unit id="s25fb1e88492eba62">
   <source>Object Attribute(s)</source>
+  <target>Атрибут(ы) объекта</target>
 </trans-unit>
 <trans-unit id="sc8d9d9b824e7e8e9">
   <source>New Attribute</source>
+  <target>Новый атрибут</target>
 </trans-unit>
 <trans-unit id="s8d0c9855df034712">
   <source>User Count Exceeded</source>
+  <target>Превышено количество пользователей</target>
 </trans-unit>
 <trans-unit id="sc4804358f202968c">
   <source>Internal user usage</source>
+  <target>Использование внутренних пользователей</target>
 </trans-unit>
 <trans-unit id="sae72e1569d34fb02">
   <source>External user usage</source>
+  <target>Использование внешним пользователем</target>
 </trans-unit>
 <trans-unit id="s3bca5a165739e8c9">
   <source>Allow application access with no policies</source>
+  <target>Разрешить доступ к приложению без политик</target>
 </trans-unit>
 <trans-unit id="s36ecc1d57c02c225">
   <source>Applications with no policies bound can be accessed by any user..</source>
+  <target>Доступ к приложениям без привязки к политикам может получить любой пользователь.</target>
 </trans-unit>
 <trans-unit id="s98a962f4514c9628">
   <source>Expiring today</source>
+  <target>Срок действия истекает сегодня</target>
 </trans-unit>
 <trans-unit id="se10a40e85fe55d76">
   <source>Expiring in <x id="0" equiv-text="${formatDistanceStrict(new Date(), valid, { unit: &quot;day&quot; })}"/></source>
+  <target>Срок действия истекает через <x id="0" equiv-text="${formatDistanceStrict(new Date(), valid, { unit: &quot;day&quot; })}"/></target>
 </trans-unit>
 <trans-unit id="wsfed.saml-version.option.saml11">
   <source>SAML 1.1 (required by Microsoft Entra ID / ADFS)</source>
+  <target>SAML 1.1 (требуется Microsoft Entra ID/ADFS)</target>
 </trans-unit>
 <trans-unit id="wsfed.saml-version.option.saml20">
   <source>SAML 2.0</source>
+  <target>SAML 2.0</target>
 </trans-unit>
 <trans-unit id="wsfed.saml-version.label">
   <source>SAML assertion version</source>
+  <target>Версия утверждения SAML</target>
 </trans-unit>
 <trans-unit id="wsfed.saml-version.description">
   <source>Microsoft Entra ID and classic ADFS-style relying parties typically require SAML 1.1.</source>
+  <target>Microsoft Entra ID и классические проверяющие стороны в стиле ADFS обычно требуют SAML 1.1.</target>
 </trans-unit>
 <trans-unit id="settings.base-url.label">
   <source>Base URL</source>
+  <target>Базовый URL</target>
 </trans-unit>
 <trans-unit id="settings.base-url.description">
   <source>Configure the base URL under which this authentik instance is reachable, e.g. https://authentik.company. Do not include any path component (for example, /authentik).</source>
+  <target>Настройте базовый URL-адрес, по которому доступен этот экземпляр authentik, например. https://authentik.company. Не включайте компоненты пути (например, /authentik).</target>
 </trans-unit>
 <trans-unit id="sb83f872f267d8506">
   <source>Sync Group Hierarchy</source>
+  <target>Иерархия групп синхронизации</target>
 </trans-unit>
 <trans-unit id="s9589dc36c516341a">
   <source>Sync group hierarchy from LDAP directories.</source>
+  <target>Синхронизируйте иерархию групп из каталогов LDAP.</target>
 </trans-unit>
 <trans-unit id="s9e8574c0abf42187">
   <source>Additional Parent Group</source>
+  <target>Дополнительная родительская группа</target>
 </trans-unit>
 <trans-unit id="banner.dismiss.aria-label">
   <source>Dismiss banner</source>
+  <target>Закрыть баннер</target>
 </trans-unit>
 <trans-unit id="settings.base-url.banner.action">
   <source>Configure it in the system settings</source>
+  <target>Настройте это в настройках системы</target>
 </trans-unit>
 <trans-unit id="settings.base-url.banner.label">
   <source>The base URL has not been configured.</source>
+  <target>Базовый URL-адрес не настроен.</target>
 </trans-unit>
 <trans-unit id="sf993bb199fefbe04">
   <source>All</source>
+  <target>Все</target>
 </trans-unit>
 <trans-unit id="sfa1b95e8d5f908ef">
   <source>Search for an offboarding by username...</source>
+  <target>Поиск оффборда по имени пользователя...</target>
 </trans-unit>
 <trans-unit id="s666e836aa05114ac">
   <source>User Offboardings</source>
+  <target>Отключение пользователей</target>
 </trans-unit>
 <trans-unit id="s56d1d0a4e7bf5ae5">
   <source>Scheduled deactivation or deletion of users, and their outcomes.</source>
+  <target>Запланированная деактивация или удаление пользователей и их результаты.</target>
 </trans-unit>
 <trans-unit id="s4677a21818ee3277">
   <source>Only show pending offboardings</source>
+  <target>Показывать только ожидающие отключения</target>
 </trans-unit>
 <trans-unit id="s39689ea96631ed97">
   <source>Scheduled for</source>
+  <target>Запланировано на</target>
 </trans-unit>
 <trans-unit id="scae52d94b155a605">
   <source>Scheduled by</source>
+  <target>Запланировано</target>
 </trans-unit>
 <trans-unit id="s116de51b09153006">
   <source>Offboarding(s)</source>
+  <target>Оффбординг(ы)</target>
 </trans-unit>
 <trans-unit id="see8b386a20d5d43a">
   <source>canceled</source>
+  <target>отменено</target>
 </trans-unit>
 <trans-unit id="sdaf25bddf0323e13">
   <source>Cancel Offboardings</source>
+  <target>Отменить отключения</target>
 </trans-unit>
 <trans-unit id="s3dfc819b4986e252">
   <source>Cancel Offboarding</source>
+  <target>Отменить оффборд</target>
 </trans-unit>
 <trans-unit id="s78636b92c1a3909c">
   <source>Pending</source>
+  <target>В ожидании</target>
 </trans-unit>
 <trans-unit id="s39ad5f4fbea4fb3f">
   <source>Offboardings</source>
+  <target>Offboarding</target>
 </trans-unit>
 <trans-unit id="sfcfc3964931c0d94">
   <source>Hide managed</source>
+  <target>Скрыть управляемое</target>
 </trans-unit>
 <trans-unit id="s3ac26c004d6ba636">
   <source>Managed</source>
+  <target>Управляемый</target>
 </trans-unit>
 <trans-unit id="common.boolean.yes">
   <source>Yes</source>
+  <target>Да</target>
 </trans-unit>
 <trans-unit id="common.boolean.no">
   <source>No</source>
+  <target>Нет</target>
 </trans-unit>
 <trans-unit id="offboarding.cancel.success">
   <source>Successfully cancelled offboarding.</source>
+  <target>Offboarding успешно отменён.</target>
 </trans-unit>
 <trans-unit id="offboarding.cancel.error">
   <source>Failed to cancel offboarding</source>
+  <target>Не удалось отменить отключение.</target>
 </trans-unit>
 <trans-unit id="offboarding.cancel.confirm.label">
   <source>Cancel offboarding</source>
+  <target>Отменить offboarding</target>
 </trans-unit>
 <trans-unit id="offboarding.cancel.header">
   <source>Cancel scheduled offboarding</source>
+  <target>Отменить запланированное отключение</target>
 </trans-unit>
 <trans-unit id="offboarding.cancel.description">
   <source>The following scheduled offboarding will be cancelled:</source>
+  <target>Следующий запланированный offboarding будет отменён:</target>
 </trans-unit>
 <trans-unit id="offboarding.cancel.tooltip">
   <source>Offboarding scheduled for <x id="0" equiv-text="${offboarding.scheduledAt.toLocaleString()}"/></source>
+  <target>Отключение запланировано на <x id="0" equiv-text="${offboarding.scheduledAt.toLocaleString()}"/></target>
 </trans-unit>
 <trans-unit id="offboarding.cancel.trigger.label">
   <source>Cancel Offboarding</source>
+  <target>Отменить оффборд</target>
 </trans-unit>
 <trans-unit id="offboarding.schedule.submit.label">
   <source>Schedule</source>
+  <target>Расписание</target>
 </trans-unit>
 <trans-unit id="offboarding.schedule.header">
   <source>Schedule Offboarding</source>
+  <target>Запланировать offboarding</target>
 </trans-unit>
 <trans-unit id="offboarding.schedule.trigger.label">
   <source>Schedule Offboarding</source>
+  <target>Запланировать offboarding</target>
 </trans-unit>
 <trans-unit id="offboarding.form.verbose-name">
   <source>User Offboarding</source>
+  <target>Offboarding пользователя</target>
 </trans-unit>
 <trans-unit id="offboarding.form.verbose-name-plural">
   <source>User Offboardings</source>
+  <target>Отключение пользователей</target>
 </trans-unit>
 <trans-unit id="offboarding.schedule.success">
   <source>Successfully scheduled offboarding.</source>
+  <target>Отключение запланировано успешно.</target>
 </trans-unit>
 <trans-unit id="offboarding.field.action.label">
   <source>Action</source>
+  <target>Действие</target>
 </trans-unit>
 <trans-unit id="offboarding.action.deactivate.label">
   <source>Deactivate</source>
+  <target>Деактивировать</target>
 </trans-unit>
 <trans-unit id="offboarding.action.deactivate.description">
   <source>Lock the user out of authentik without removing their account.</source>
+  <target>Заблокировать доступ пользователя к authentik без удаления учётной записи.</target>
 </trans-unit>
 <trans-unit id="offboarding.action.delete.label">
   <source>Delete</source>
+  <target>Удалить</target>
 </trans-unit>
 <trans-unit id="offboarding.action.delete.description">
   <source>Permanently delete the user's account.</source>
+  <target>Безвозвратно удалить учётную запись пользователя.</target>
 </trans-unit>
 <trans-unit id="offboarding.field.scheduled-for.label">
   <source>Scheduled for</source>
+  <target>Запланировано на</target>
 </trans-unit>
 <trans-unit id="offboarding.field.scheduled-for.description">
   <source>The offboarding runs on the next scheduled check after this time (within a few minutes).</source>
+  <target>Offboarding выполняется при следующей запланированной проверке после этого времени (в течение нескольких минут).</target>
 </trans-unit>
 <trans-unit id="offboarding.field.revoke-sessions.label">
   <source>Revoke sessions</source>
+  <target>Отменить сеансы</target>
 </trans-unit>
 <trans-unit id="offboarding.field.revoke-sessions.description">
   <source>Revoke all of the user's sessions when offboarding.</source>
+  <target>Отозвать все сессии пользователя при offboarding.</target>
 </trans-unit>
 <trans-unit id="offboarding.field.revoke-tokens.label">
   <source>Revoke tokens</source>
+  <target>Отозвать токены</target>
 </trans-unit>
 <trans-unit id="offboarding.field.revoke-tokens.description">
   <source>Revoke all of the user's tokens when offboarding.</source>
+  <target>Отозвать все токены пользователя при offboarding.</target>
 </trans-unit>
 <trans-unit id="sbe3eca5340d724c3">
   <source>User was offboarded</source>
+  <target>Пользователь прошёл offboarding</target>
 </trans-unit>
 <trans-unit id="s7a677507399dca59">
   <source>Request rules</source>
+  <target>Правила запросов</target>
 </trans-unit>
 <trans-unit id="s2072c9a69b14fee2">
   <source>Configure rules which grant users the ability to request access to this app.</source>
+  <target>Настройте правила, которые предоставляют пользователям возможность запрашивать доступ к этому приложению.</target>
 </trans-unit>
 <trans-unit id="s1fc34f990dd8e442">
   <source>Request flow</source>
+  <target>Поток запроса</target>
 </trans-unit>
 <trans-unit id="s3926945b8747fe55">
   <source>Select a request flow...</source>
+  <target>Выберите поток запроса...</target>
 </trans-unit>
 <trans-unit id="sf0e0d71b74a9e77f">
   <source>Default flow used by users requesting access.</source>
+  <target>Поток по умолчанию, используемый пользователями, запрашивающими доступ.</target>
 </trans-unit>
 <trans-unit id="sa6e1274964f6a4b4">
   <source>Fulfill request</source>
+  <target>Выполнить запрос</target>
 </trans-unit>
 <trans-unit id="sb3d4f79d9d8b71e5">
   <source>Submit</source>
+  <target>Отправить</target>
 </trans-unit>
 <trans-unit id="sd348917df892e7a5">
   <source>Requester</source>
+  <target>Запрашивающая сторона</target>
 </trans-unit>
 <trans-unit id="s7e09dc48031bb282">
   <source>Fulfiller</source>
+  <target>Исполнитель</target>
 </trans-unit>
 <trans-unit id="sfecdd5e13f68c9ba">
   <source>Approved</source>
+  <target>Одобрено</target>
 </trans-unit>
 <trans-unit id="s93390561e1afc0b6">
   <source>Denied</source>
+  <target>Отклонено</target>
 </trans-unit>
 <trans-unit id="sac8256732f2ee1e5">
   <source>Data</source>
+  <target>Данные</target>
 </trans-unit>
 <trans-unit id="sfa9d8c928d994bf5">
   <source>Revoked</source>
+  <target>Отозвано</target>
 </trans-unit>
 <trans-unit id="s5105f7e2595f69cf">
   <source>Access Requests</source>
+  <target>Запросы доступа</target>
 </trans-unit>
 <trans-unit id="scbf29ce484222325">
   <source></source>
+  <target></target>
 </trans-unit>
 <trans-unit id="sf7eeef8b4d6e602d">
   <source>Apps</source>
+  <target>Приложения</target>
 </trans-unit>
 <trans-unit id="s2fe7939fcead9e47">
   <source>Requester Data</source>
+  <target>Данные запрашивающей стороны</target>
 </trans-unit>
 <trans-unit id="s116f756708f81fc1">
   <source>Targets</source>
+  <target>Цели</target>
 </trans-unit>
 <trans-unit id="sd85e6d7c4f752f89">
   <source>Fulfill</source>
+  <target>Выполнить</target>
 </trans-unit>
 <trans-unit id="s570f91a499d87fa4">
   <source>Successfully revoked grant</source>
+  <target>Предоставление успешно отозвано</target>
 </trans-unit>
 <trans-unit id="sb64a788e51aa5737">
   <source>Failed to revoke grant</source>
+  <target>Не удалось отозвать предоставление</target>
 </trans-unit>
 <trans-unit id="s0e871352ba4b17d3">
   <source>Revoke</source>
+  <target>Отозвать</target>
 </trans-unit>
 <trans-unit id="s6e05f32519eb6551">
   <source>Revoke grant</source>
+  <target>Отозвать предоставление</target>
 </trans-unit>
 <trans-unit id="s312cccc7c299a685">
   <source>Are you sure you want to revoke this grant? Access will be removed immediately.</source>
+  <target>Вы уверены, что хотите отозвать это предоставление? Доступ будет немедленно удалён.</target>
 </trans-unit>
 <trans-unit id="sf4cfca0c6dcd5cc8">
   <source>Entitlement(s)</source>
+  <target>Право(а) доступа</target>
 </trans-unit>
 <trans-unit id="s98b0bb374889b323">
   <source>Request rule binding(s)</source>
+  <target>Привязка(и) правила запроса</target>
 </trans-unit>
 <trans-unit id="sd700d2a7e8fe68e7">
   <source>Bind existing rule</source>
+  <target>Привязать существующее правило</target>
 </trans-unit>
 <trans-unit id="s84d52a11b0a6dbd2">
   <source>These bindings control which users/groups can request access to this object.</source>
+  <target>Эти привязки определяют, какие пользователи/группы могут запрашивать доступ к этому объекту.</target>
 </trans-unit>
 <trans-unit id="s3c7ee40c88248316">
   <source>No request rules bound.</source>
+  <target>Правила запросов не привязаны.</target>
 </trans-unit>
 <trans-unit id="sb9c80985c2d1542c">
   <source>No request rules are currently bound to this object.</source>
+  <target>К этому объекту сейчас не привязано правил запросов.</target>
 </trans-unit>
 <trans-unit id="s8709be0a895e659b">
   <source>Request rule actions</source>
+  <target>Действия правила запроса</target>
 </trans-unit>
 <trans-unit id="s377403d8bfe91b11">
   <source>Request Rule Binding</source>
+  <target>Привязка правила запроса</target>
 </trans-unit>
 <trans-unit id="s233deb4e19198786">
   <source>Request Rule Bindings</source>
+  <target>Привязки правил запросов</target>
 </trans-unit>
 <trans-unit id="sc3564115b1095d47">
   <source>Pending expiry</source>
+  <target>Срок ожидания</target>
 </trans-unit>
 <trans-unit id="s6aed0f4539da522a">
   <source>How long a request against this binding stays pending before it automatically lapses if not approved or denied.</source>
+  <target>Как долго запрос по этой привязке остаётся в ожидании, прежде чем автоматически истечёт без одобрения или отклонения.</target>
 </trans-unit>
 <trans-unit id="sc44b28e93e47e9a5">
   <source>Maximum granted expiry</source>
+  <target>Максимальный срок предоставления</target>
 </trans-unit>
 <trans-unit id="s2d0e00ac0ae213d9">
   <source>The maximum duration a grant approved against this binding can last. Requesters may ask for less, but never more.</source>
+  <target>Максимальный срок действия гранта, утвержденного в соответствии с этим обязательством. Запрашивающие могут просить меньше, но никогда больше.</target>
 </trans-unit>
 <trans-unit id="sf896f79b1a8d4630">
   <source>Additional entitlements</source>
+  <target>Дополнительные права доступа</target>
 </trans-unit>
 <trans-unit id="s79f726678209b6a4">
   <source>Available entitlements</source>
+  <target>Доступные права доступа</target>
 </trans-unit>
 <trans-unit id="s79bcc347f11b5328">
   <source>Granted entitlements</source>
+  <target>Предоставленные права доступа</target>
 </trans-unit>
 <trans-unit id="s6c360d11fb96de23">
   <source>Application entitlements granted alongside access to this object when a request is approved.</source>
+  <target>Права приложения, предоставляемые вместе с доступом к этому объекту после утверждения запроса.</target>
 </trans-unit>
 <trans-unit id="sc1d364a9eb95428f">
   <source>Everyone who can approve</source>
+  <target>Все, кто может одобрять</target>
 </trans-unit>
 <trans-unit id="s1d7c1b9c4e4df721">
   <source>Only individually-selected reviewers</source>
+  <target>Только индивидуально отобранные рецензенты</target>
 </trans-unit>
 <trans-unit id="se75f92adbb736d2e">
   <source>A random subset (of size “minimum reviewers”) of everyone who can approve</source>
+  <target>Случайное подмножество (размером «минимум рецензентов») из всех, кто может одобрять</target>
 </trans-unit>
 <trans-unit id="sa8b63f3fcf8c7990">
   <source>Request Rule</source>
+  <target>Правило запроса</target>
 </trans-unit>
 <trans-unit id="s3a275c6dabb31cb9">
   <source>Request Rules</source>
+  <target>Правила запросов</target>
 </trans-unit>
 <trans-unit id="s847bbdf12f129557">
   <source>Type a name for this request rule...</source>
+  <target>Введите имя для этого правила запроса...</target>
 </trans-unit>
 <trans-unit id="s7adc3ba259e3407b">
   <source>Number of reviewers that must approve the request before it is granted.</source>
+  <target>Количество рецензентов, которые должны одобрить запрос до его предоставления.</target>
 </trans-unit>
 <trans-unit id="s9129035195f5d21c">
   <source>Notify</source>
+  <target>Уведомить</target>
 </trans-unit>
 <trans-unit id="saedaac3c39d38950">
   <source>Who to notify when a request is created against this rule.</source>
+  <target>Кого уведомлять при создании запроса по этому правилу.</target>
 </trans-unit>
 <trans-unit id="sa12ce38de4a60975">
   <source>Optional flow to use when a user requests access to a target bound to this rule.</source>
+  <target>Необязательный поток при запросе пользователем доступа к цели, привязанной к этому правилу.</target>
 </trans-unit>
 <trans-unit id="sec1b7428fb52aa12">
   <source>Select which transports should be used to notify reviewers. If none are selected, the notification will only be shown in the authentik UI.</source>
+  <target>Выберите транспорты для уведомления рецензентов. Если ничего не выбрано, уведомление будет показано только в интерфейсе authentik.</target>
 </trans-unit>
 <trans-unit id="seeff588bc60db034">
   <source>Search for a request rule by name...</source>
+  <target>Поиск правила запроса по имени...</target>
 </trans-unit>
 <trans-unit id="s26f4259720f742fa">
   <source>Define who can approve access requests for the objects these rules are bound to.</source>
+  <target>Определите, кто может одобрять запросы доступа к объектам, к которым привязаны эти правила.</target>
 </trans-unit>
 <trans-unit id="s5b612c6c619807b0">
   <source>Bound to</source>
+  <target>Привязано к</target>
 </trans-unit>
 <trans-unit id="s0a6c5f79e64745b8">
   <source>Request rule(s)</source>
+  <target>Правило(а) запроса</target>
 </trans-unit>
 <trans-unit id="s569fd8461083ddc0">
   <source><x id="0" equiv-text="${item.targets.length}"/> object(s)</source>
+  <target><x id="0" equiv-text="${item.targets.length}"/> объект(ов)</target>
 </trans-unit>
 <trans-unit id="s2479a752090884e8">
   <source>These bindings control which users/groups can approve requests.</source>
+  <target>Эти привязки определяют, какие пользователи/группы могут одобрять запросы.</target>
 </trans-unit>
 <trans-unit id="s3ab67886838d8ce6">
   <source>Access request created</source>
+  <target>Запрос доступа создан</target>
 </trans-unit>
 <trans-unit id="s623bd29021bd66ed">
   <source>Access request approved</source>
+  <target>Запрос на доступ одобрен</target>
 </trans-unit>
 <trans-unit id="sb369884c94dd6c09">
   <source>Access request denied</source>
+  <target>Запрос доступа отклонён</target>
 </trans-unit>
 <trans-unit id="sec37b60630a51c4c">
   <source>Access request revoked</source>
+  <target>Запрос доступа отозван</target>
 </trans-unit>
 <trans-unit id="se1d45bc0235e1e95">
   <source>Show all schedules</source>
+  <target>Показать все расписания</target>
 </trans-unit>
 <trans-unit id="s70019e824a0ddf65">
   <source>Show all tasks</source>
+  <target>Показать все задачи</target>
 </trans-unit>
 <trans-unit id="s31bf1464d6e1e996">
   <source>Standalone</source>
+  <target>Автономный</target>
 </trans-unit>
 <trans-unit id="s10e05123a5ebc6d9">
   <source>Include successful tasks</source>
+  <target>Включать успешные задачи</target>
 </trans-unit>
 <trans-unit id="s2d6a5f1d98d0738e">
   <source>Discover</source>
+  <target>Обнаружить</target>
 </trans-unit>
 <trans-unit id="s6b3ade1f5b1361a6">
   <source>Requests to review: </source>
+  <target>Запросы на рассмотрение:</target>
 </trans-unit>
 <trans-unit id="sfccc1509c1ccb5af">
   <source>Access requests</source>
+  <target>Запросы доступа</target>
 </trans-unit>
 <trans-unit id="s99fa943a22c13e67">
   <source>Browse</source>
+  <target>Обзор</target>
 </trans-unit>
 <trans-unit id="s7ad2216da77cf1c7">
   <source>My Requests</source>
+  <target>Мои запросы</target>
 </trans-unit>
 <trans-unit id="sc54fa983c3064e46">
   <source>For My Review</source>
+  <target>На моё рассмотрение</target>
 </trans-unit>
 <trans-unit id="sc9caf0426eadbec7">
   <source>Nothing available to request.</source>
+  <target>Нет доступного для запроса.</target>
 </trans-unit>
 <trans-unit id="sa18bee42f167d8a5">
   <source>There's currently nothing you're eligible to request access to.</source>
+  <target>Сейчас нет объектов, к которым вы можете запросить доступ.</target>
 </trans-unit>
 <trans-unit id="se7e7bc73ad0cf1a9">
   <source>Requestable applications</source>
+  <target>Приложения, доступные для запроса</target>
 </trans-unit>
 <trans-unit id="sd3489b7df892f8a3">
   <source>Requested</source>
+  <target>Запрошено</target>
 </trans-unit>
 <trans-unit id="s1c0f85facbc5e032">
   <source>Successfully cancelled request</source>
+  <target>Запрос успешно отменен</target>
 </trans-unit>
 <trans-unit id="sace831616cf735f4">
   <source>Failed to cancel request</source>
+  <target>Не удалось отменить запрос</target>
 </trans-unit>
 <trans-unit id="sdc8e4cc65cb74f16">
   <source>Cancel request</source>
+  <target>Отменить запрос</target>
 </trans-unit>
 <trans-unit id="s69882ac7b03b16d4">
   <source>Are you sure you want to cancel this pending request?</source>
+  <target>Вы уверены, что хотите отменить этот ожидающий запрос?</target>
 </trans-unit>
 <trans-unit id="sccd6f7d0d94e8b9c">
   <source>No requests yet.</source>
+  <target>Запросов пока нет.</target>
 </trans-unit>
 <trans-unit id="s87e7dd8fdbee7446">
   <source>Requests you've made for access will show up here.</source>
+  <target>Здесь будут отображаться ваши запросы на доступ.</target>
 </trans-unit>
 <trans-unit id="s8a9b9b19ed901231">
   <source>Nothing to review.</source>
+  <target>Нечего пересматривать.</target>
 </trans-unit>
 <trans-unit id="sa4c37312c86d7ceb">
   <source>Requests waiting on your approval will show up here.</source>
+  <target>Здесь будут отображаться запросы, ожидающие вашего одобрения.</target>
 </trans-unit>
 <trans-unit id="requests.browse.entitlement-modal.search-placeholder">
   <source>Search for an entitlement...</source>
+  <target>Поиск права доступа...</target>
 </trans-unit>
 <trans-unit id="requests.browse.entitlement-modal.empty-state">
   <source>No entitlements found for this application.</source>
+  <target>Для этого приложения права доступа не найдены.</target>
 </trans-unit>
 <trans-unit id="requests.browse.entitlement-modal.header">
   <source>Select entitlement</source>
+  <target>Выберите право</target>
 </trans-unit>
 <trans-unit id="requests.browse.entitlement-modal.column.entitlement">
   <source>Entitlement</source>
+  <target>Право доступа</target>
 </trans-unit>
 <trans-unit id="s02af005e476ed332">
   <source>Requestor notes</source>
+  <target>Примечания запрашивающего</target>
 </trans-unit>
 <trans-unit id="h91e3f27bdaf2308c">
   <source>When enabled, fulfilling the request requires at least that many reviewers
                         from <x id="0" equiv-text="&lt;em&gt;"/>each<x id="1" equiv-text="&lt;/em&gt;"/> of the reviewer groups bound to this rule. When disabled,
                         the value is a total across all reviewer groups.</source>
+  <target>Если включено, для выполнения запроса требуется как минимум указанное число рецензентов из <x id="0" equiv-text="&lt;em&gt;"/>каждой<x id="1" equiv-text="&lt;/em&gt;"/> группы рецензентов, привязанной к этому правилу. Если выключено, значение — суммарно по всем группам рецензентов.</target>
 </trans-unit>
 <trans-unit id="s2359768b2b1758f1">
   <source>Unknown Grant type</source>
+  <target>Неизвестный тип grant</target>
 </trans-unit>
 <trans-unit id="s22c7fdd77bf0e826">
   <source>Dynamic Client Registration</source>
+  <target>Динамическая регистрация клиентов</target>
 </trans-unit>
 <trans-unit id="s3ceb0c74bfc02e24">
   <source>Successfully updated Dynamic Client Registration.</source>
+  <target>Динамическая регистрация клиентов успешно обновлена.</target>
 </trans-unit>
 <trans-unit id="sb0f2f6351f4feb26">
   <source>Successfully enabled Dynamic Client Registration.</source>
+  <target>Динамическая регистрация клиентов успешно включена.</target>
 </trans-unit>
 <trans-unit id="s293ab004e5f8471b">
   <source>Default application group</source>
+  <target>Группа приложений по умолчанию</target>
 </trans-unit>
 <trans-unit id="sb9447a484a8e36db">
   <source>Group assigned to automatically created applications.</source>
+  <target>Группа, назначаемая автоматически создаваемым приложениям.</target>
 </trans-unit>
 <trans-unit id="sb3932671e3f5c1f8">
   <source>Override authorization flow</source>
+  <target>Переопределить процесс авторизации</target>
 </trans-unit>
 <trans-unit id="sd00e1714556429bc">
   <source>Authorization flow applied to dynamically registered clients. When not selected, authorization flow of the parent provider is used.</source>
+  <target>Поток авторизации для динамически зарегистрированных клиентов. Если не выбран, используется поток авторизации родительского провайдера.</target>
 </trans-unit>
 <trans-unit id="s37a7c8fd3eb8c9dd">
   <source>Override invalidation flow</source>
+  <target>Переопределить поток инвалидации</target>
 </trans-unit>
 <trans-unit id="s6ceeb9457b7428bb">
   <source>Invalidation flow applied to dynamically registered clients. When not selected, authorization flow of the parent provider is used.</source>
+  <target>Поток инвалидации для динамически зарегистрированных клиентов. Если не выбран, используется поток авторизации родительского провайдера.</target>
 </trans-unit>
 <trans-unit id="sa4ad8a8c594e1355">
   <source>Override property mappings</source>
+  <target>Переопределить сопоставления свойств</target>
 </trans-unit>
 <trans-unit id="s9c21e17fba762b70">
   <source>Access token validity</source>
+  <target>Срок действия токена доступа</target>
 </trans-unit>
 <trans-unit id="sfac8408c13382097">
   <source>Maximum access token validity for registered clients.</source>
+  <target>Максимальный срок действия access token для зарегистрированных клиентов.</target>
 </trans-unit>
 <trans-unit id="sec80d3ef86fdb459">
   <source>Refresh token validity</source>
+  <target>Срок действия refresh token</target>
 </trans-unit>
 <trans-unit id="scf699415de52233e">
   <source>Maximum refresh token validity for registered clients.</source>
+  <target>Максимальный срок действия refresh token для зарегистрированных клиентов.</target>
 </trans-unit>
 <trans-unit id="sdf7ebf88f98e5728">
   <source>Allowed grant types</source>
+  <target>Разрешённые типы grant</target>
 </trans-unit>
 <trans-unit id="s35ec166b7499880b">
   <source>If none are selected, all grant types are allowed.</source>
+  <target>Если ничего не выбрано, разрешены все типы grant.</target>
 </trans-unit>
 <trans-unit id="s752c7742ccf74988">
   <source>Dynamic Client Registration is not enabled.</source>
+  <target>Динамическая регистрация клиентов не включена.</target>
 </trans-unit>
 <trans-unit id="s8057d48d01ca8a97">
   <source>Allow OAuth2/OIDC clients to register themselves against this provider (RFC 7591).</source>
+  <target>Разрешить клиентам OAuth2/OIDC самостоятельно регистрироваться у этого провайдера (RFC 7591).</target>
 </trans-unit>
 <trans-unit id="s617985af530d2fb3">
   <source>Enable Dynamic Client Registration</source>
+  <target>Включить динамическую регистрацию клиентов</target>
 </trans-unit>
 <trans-unit id="s8f47c8a79b1a4062">
   <source>Dynamic application policies</source>
+  <target>Динамические политики приложений</target>
 </trans-unit>
 <trans-unit id="safbe8177d10f3a25">
   <source>Bindings configured here will be copied to dynamically registered applications. If no bindings are created, bindings of this providers' application are copied.</source>
+  <target>Привязки, настроенные здесь, будут скопированы в динамически зарегистрированные приложения. Если привязки не созданы, копируются привязки приложения этого провайдера.</target>
 </trans-unit>
 <trans-unit id="brand.form.flow-user-switch.label">
   <source>User switch flow</source>
+  <target>Поток переключения пользователя</target>
 </trans-unit>
 <trans-unit id="brand.form.flow-user-switch.placeholder">
   <source>Select a user switch flow...</source>
+  <target>Выберите поток переключения пользователя...</target>
 </trans-unit>
 <trans-unit id="brand.form.flow-user-switch.description">
   <source>Authentication flow used when switching between users signed in on the same browser. If left empty, user switching is disabled.</source>
+  <target>Поток аутентификации при переключении между пользователями, вошедшими в одном браузере. Если оставить пустым, переключение пользователей отключено.</target>
 </trans-unit>
 <trans-unit id="user-switcher.toggle.label">
   <source>Switch user</source>
+  <target>Переключить пользователя</target>
 </trans-unit>
 <trans-unit id="user-switcher.actions.add-user.label">
   <source>Add another user</source>
+  <target>Добавить другого пользователя</target>
 </trans-unit>
 <trans-unit id="user-switcher.actions.sign-out-current.label">
   <source>Sign out current user</source>
+  <target>Выйти из текущей учётной записи</target>
 </trans-unit>
 <trans-unit id="brand.map-tiles.label">
   <source>Map tiles</source>
+  <target>Тайлы карты</target>
 </trans-unit>
 <trans-unit id="brand.map-tiles.description">
   <source>Vector tile source for the events map. Accepts a pmtiles:// archive URL or an XYZ template such as /tiles/{z}/{x}/{y}.mvt. Leave empty to use the bundled basemap, which needs no tile server. This URL is served to unauthenticated clients along with the rest of the brand, so avoid tile providers that carry an API key in the URL.</source>
+  <target>Источник векторных тайлов для карты событий. Принимает URL архива pmtiles:// или шаблон XYZ, например /tiles/{z}/{x}/{y}.mvt. Оставьте пустым, чтобы использовать встроенную базовую карту без тайлового сервера. Этот URL передаётся неаутентифицированным клиентам вместе с остальными данными бренда, поэтому избегайте провайдеров тайлов с API-ключом в URL.</target>
 </trans-unit>
 <trans-unit id="events.map.kind.login.label">
   <source>Login</source>
+  <target>Вход</target>
 </trans-unit>
 <trans-unit id="events.map.kind.login-failed.label">
   <source>Failed login</source>
+  <target>Не удалось войти</target>
 </trans-unit>
 <trans-unit id="events.map.kind.logout.label">
   <source>Logout</source>
+  <target>Выйти</target>
 </trans-unit>
 <trans-unit id="events.map.kind.authorize-application.label">
   <source>Authorize Application</source>
+  <target>Авторизовать приложение</target>
 </trans-unit>
 <trans-unit id="events.map.kind.other.label">
   <source>Other</source>
+  <target>Другое</target>
 </trans-unit>
 <trans-unit id="s0ef37c2c3c5770e4">
   <source>Adding</source>
+  <target>Добавление</target>
 </trans-unit>
 <trans-unit id="sf1d3d13eaff0f517">
   <source>Enable automatic discovery of remote resources.</source>
+  <target>Включить автоматическое обнаружение удалённых ресурсов.</target>
 </trans-unit>
 <trans-unit id="s9d1116ec684cc9dc">
   <source>Scope mappings applied to dynamically registered clients. When not selected, scope mappings of the parent provider are used.</source>
+  <target>Сопоставления scope для динамически зарегистрированных клиентов. Если не выбраны, используются сопоставления scope родительского провайдера.</target>
 </trans-unit>
 <trans-unit id="s5a64cc153009e9fb">
   <source>Dynamic Client Registration URL</source>
+  <target>URL динамической регистрации клиентов</target>
 </trans-unit>
 <trans-unit id="scb836fa821092872">
   <source>Successfully deleted Dynamic Client Registration configuration</source>
+  <target>Конфигурация динамической регистрации клиентов успешно удалена</target>
 </trans-unit>
 <trans-unit id="sf21f2ef85ea4c84b">
   <source>Failed to delete Dynamic Client Registration configuration</source>
+  <target>Не удалось удалить конфигурацию динамической регистрации клиентов</target>
 </trans-unit>
 <trans-unit id="s36865a6d374ff739">
   <source>Delete Dynamic Client Registration configuration</source>
+  <target>Удалить конфигурацию динамической регистрации клиентов</target>
 </trans-unit>
 <trans-unit id="s2242f5c6b4625d84">
   <source>Are you sure you want to delete the Dynamic Client Registration configuration for this provider? No new clients will be able to register themselves, existing clients will not be removed.</source>
+  <target>Вы уверены, что хотите удалить конфигурацию динамической регистрации клиентов для этого провайдера? Новые клиенты не смогут регистрироваться, существующие клиенты не будут удалены.</target>
 </trans-unit>
 <trans-unit id="s583559b56228966c">
   <source>Define who can approve access requests for the objects this rule is bound to.</source>
+  <target>Определите, кто может одобрять запросы доступа к объектам, к которым привязано это правило.</target>
 </trans-unit>
 <trans-unit id="s15ee5b29a732e82a">
   <source>New Request Rule</source>
+  <target>Новое правило запроса</target>
 </trans-unit>
 <trans-unit id="s90eefcc5ed423895">
   <source>Create a new request rule to bind to this object.</source>
+  <target>Создать новое правило запроса для привязки к этому объекту.</target>
 </trans-unit>
 <trans-unit id="s622e11fa5a62c709">
   <source>Existing Request Rule</source>
+  <target>Существующее правило запроса</target>
 </trans-unit>
 <trans-unit id="scf0457b46d32a983">
   <source>Bind an existing request rule to this object.</source>
+  <target>Привязать существующее правило запроса к этому объекту.</target>
 </trans-unit>
 <trans-unit id="agent.policy-behavior.mirror.label">
   <source>Mirror</source>
+  <target>Зеркало</target>
 </trans-unit>
 <trans-unit id="agent.policy-behavior.mirror.description">
   <source>The agent has exactly the parent user's access, evaluated live.</source>
+  <target>Агент имеет точно такой же доступ, как родительский пользователь, с оценкой в реальном времени.</target>
 </trans-unit>
 <trans-unit id="agent.policy-behavior.copy.label">
   <source>Copy</source>
+  <target>Копировать</target>
 </trans-unit>
 <trans-unit id="agent.policy-behavior.copy.description">
   <source>Copy the parent's policy bindings onto the agent.</source>
+  <target>Скопировать привязки политик родителя на агента.</target>
 </trans-unit>
 <trans-unit id="agent.policy-behavior.none.label">
   <source>None</source>
+  <target>Никто</target>
 </trans-unit>
 <trans-unit id="agent.policy-behavior.none.description">
   <source>The agent uses only its own policy bindings.</source>
+  <target>Агент использует только собственные привязки политик.</target>
 </trans-unit>
 <trans-unit id="s95416925fd51a346">
   <source>Agent</source>
+  <target>Агент</target>
 </trans-unit>
 <trans-unit id="sefc8e08d71b8530f">
   <source>Agents</source>
+  <target>Агенты</target>
 </trans-unit>
 <trans-unit id="agent.form.close.label">
   <source>Close</source>
+  <target>Закрыть</target>
 </trans-unit>
 <trans-unit id="s3687e4f7ae814ce1">
   <source>Successfully created agent.</source>
+  <target>Агент успешно создан.</target>
 </trans-unit>
 <trans-unit id="s725865ad04deb9d4">
   <source>Parent user</source>
+  <target>Родительский пользователь</target>
 </trans-unit>
 <trans-unit id="sb4e8961d5ee9a6df">
   <source>The user this agent acts on behalf of.</source>
+  <target>Пользователь, от имени которого действует этот агент.</target>
 </trans-unit>
 <trans-unit id="s41a70d75feb46cd2">
   <source>Optional display name. Defaults to the parent user's name.</source>
+  <target>Необязательное отображаемое имя. По умолчанию используется имя родительского пользователя.</target>
 </trans-unit>
 <trans-unit id="agent.policy-behavior.label">
   <source>Policy behavior</source>
+  <target>Политика поведения</target>
 </trans-unit>
 <trans-unit id="agent.policy-behavior.help">
   <source>How the agent's access relates to its parent user.</source>
+  <target>Как доступ агента связан с его родительским пользователем.</target>
 </trans-unit>
 <trans-unit id="se105d24a03216c66">
   <source>Whether this agent should be automatically removed once it expires.</source>
+  <target>Должен ли этот агент автоматически удаляться по истечении срока его действия.</target>
 </trans-unit>
 <trans-unit id="agent.token.description">
   <source>Use the token below to authenticate as this agent. It is shown only once — store it now.</source>
+  <target>Используйте токен ниже для аутентификации в качестве этого агента. Он отображается только один раз — сохраните его сейчас.</target>
 </trans-unit>
 <trans-unit id="agent.token.label">
   <source>Token</source>
+  <target>Токен</target>
 </trans-unit>
 <trans-unit id="s2854025f8d4405b6">
   <source>Search for a agent...</source>
+  <target>Ищите агента...</target>
 </trans-unit>
 <trans-unit id="s4a29404019d64d40">
   <source>Admin-provisioned delegate identities that access can be requested and granted for, separately from their parent user.</source>
+  <target>Идентификаторы делегатов, предоставленные администратором, доступ к которым можно запрашивать и предоставлять отдельно от родительского пользователя.</target>
 </trans-unit>
 <trans-unit id="s4eb514ebcb80553d">
   <source>Parent</source>
+  <target>Родитель</target>
 </trans-unit>
 <trans-unit id="s9e5233ef650728d6">
   <source>Agent(s)</source>
+  <target>Агент(ы)</target>
 </trans-unit>
 <trans-unit id="user.activation.confirm.deactivate">
   <source>Are you sure you want to deactivate <x id="0" equiv-text="&lt;code&gt;${displayName}&lt;/code&gt;"/>?</source>
+  <target>Вы уверены, что хотите деактивировать <x id="0" equiv-text="&lt;code&gt;${displayName}&lt;/code&gt;"/>?</target>
 </trans-unit>
 <trans-unit id="user.activation.confirm.activate">
   <source>Are you sure you want to activate <x id="0" equiv-text="&lt;code&gt;${displayName}&lt;/code&gt;"/>?</source>
+  <target>Вы уверены, что хотите активировать <x id="0" equiv-text="&lt;code&gt;${displayName}&lt;/code&gt;"/>?</target>
 </trans-unit>
 <trans-unit id="agent.column.name">
   <source>Name</source>
+  <target>Имя</target>
 </trans-unit>
 <trans-unit id="agent.column.expires">
   <source>Expires</source>
+  <target>Истекает</target>
 </trans-unit>
 <trans-unit id="agent.column.actions">
   <source>Actions</source>
+  <target>Действия</target>
 </trans-unit>
 <trans-unit id="agent.delete.object-label">
   <source>Agent(s)</source>
+  <target>Агент(ы)</target>
 </trans-unit>
 <trans-unit id="agent.delete.trigger">
   <source>Delete</source>
+  <target>Удалить</target>
 </trans-unit>
 <trans-unit id="agent.expires.never">
   <source>-</source>
+  <target>-</target>
 </trans-unit>
 <trans-unit id="agent.delete.object-label-single">
   <source>Agent</source>
+  <target>Агент</target>
 </trans-unit>
 <trans-unit id="agent.delete.tooltip">
   <source>Delete</source>
+  <target>Удалить</target>
 </trans-unit>
 <trans-unit id="s98d9f46353f3fd25">
   <source>Copy value</source>
+  <target>Копировать значение</target>
 </trans-unit>
 <trans-unit id="agent.verbose-name.label">
   <source>Agent</source>
+  <target>Агент</target>
 </trans-unit>
 <trans-unit id="agent.verbose-name-plural.label">
   <source>Agents</source>
+  <target>Агенты</target>
 </trans-unit>
 <trans-unit id="agent.create.label">
   <source>Create</source>
+  <target>Создать</target>
 </trans-unit>
 <trans-unit id="agent.create.submit">
   <source>Create</source>
+  <target>Создать</target>
 </trans-unit>
 <trans-unit id="agent.create.success">
   <source>Successfully created agent.</source>
+  <target>Агент успешно создан.</target>
 </trans-unit>
 <trans-unit id="agent.label.label">
   <source>Label</source>
+  <target>Этикетка</target>
 </trans-unit>
 <trans-unit id="agent.label.description">
   <source>Optional display name for this agent.</source>
+  <target>Необязательное отображаемое имя для этого агента.</target>
 </trans-unit>
 <trans-unit id="agent.mirror.description">
   <source>This agent mirrors your access: it can act on exactly the applications you can, and never more.</source>
+  <target>Этот агент отражает ваш доступ: он может действовать именно на те приложения, которые вы можете использовать, и никогда больше.</target>
 </trans-unit>
 <trans-unit id="agent.list.empty">
   <source>No agents.</source>
+  <target>Никаких агентов.</target>
 </trans-unit>
 <trans-unit id="agent.create.header">
   <source>Create Agent</source>
+  <target>Создать агента</target>
 </trans-unit>
 <trans-unit id="agent.create.trigger">
   <source>Create Agent</source>
+  <target>Создать агента</target>
 </trans-unit>
 <trans-unit id="agent.page.description">
   <source>Create expiring agent identities and hand their token to a harness so it can act on your behalf via the API.</source>
+  <target>Создайте удостоверения агента с истекающим сроком действия и передайте их токен в систему, чтобы она могла действовать от вашего имени через API.</target>
 </trans-unit>
 <trans-unit id="s46eb6cf13a8022e9">
   <source>Select File</source>
+  <target>Выберите файл</target>
 </trans-unit>
 <trans-unit id="s0d1ed094b601e76d">
   <source>Type an optional file name without an extension...</source>
+  <target>Введите дополнительное имя файла без расширения...</target>
 </trans-unit>
 <trans-unit id="s384efdec2b99d471">
   <source>Custom Name</source>
+  <target>Пользовательское имя</target>
 </trans-unit>
 <trans-unit id="sd749d80c570a0d0e">
   <source>Leave empty to keep the original filename.</source>
+  <target>Оставьте пустым, чтобы сохранить исходное имя файла.</target>
 </trans-unit>
 <trans-unit id="s1ea1d3a777930fd3">
   <source>List of CIDRs (comma-separated) that clients can connect from. A more specific CIDR will match before a looser one. Clients connecting from a non-specified CIDR will be dropped.</source>
+  <target>Список CIDR (разделенных запятыми), к которым могут подключаться клиенты. Более конкретный CIDR будет соответствовать более слабому. Клиенты, подключающиеся из неуказанного CIDR, будут удалены.</target>
 </trans-unit>
 <trans-unit id="file-picker.upload-link.label">
   <source>Upload file</source>
+  <target>Загрузить файл</target>
 </trans-unit>
 <trans-unit id="file-picker.value.placeholder">
   <source>Select a file or enter a value...</source>
+  <target>Выберите файл или введите значение...</target>
 </trans-unit>
 <trans-unit id="file-picker.value.description">
   <source>Choose an existing file, or enter a URL or Font Awesome icon.</source>
+  <target>Выберите существующий файл или введите URL-адрес или значок Font Awesome.</target>
 </trans-unit>
 <trans-unit id="file-picker.documentation-link.label">
   <source>Supported values</source>
+  <target>Поддерживаемые значения</target>
 </trans-unit>
 <trans-unit id="file.name.validation.html">
   <source>Valid file names can contain letters, numbers, dots, hyphens, underscores, slashes, and
         placeholders such as <x id="0" equiv-text="${unsafeHTML(replacements)}"/>.</source>
+  <target>Допустимые имена файлов могут содержать буквы, цифры, точки, дефисы, символы подчеркивания, косую черту и заполнители, например <x id="0" equiv-text="${unsafeHTML(replacements)}"/> .</target>
   <note from="lit-localize">Validation message for file name input. The placeholders are displayed as code elements.</note>
 </trans-unit>
 <trans-unit id="file.name.validation.plaintext">
   <source>Valid file names can contain letters, numbers, dots, hyphens, underscores, slashes, and
         placeholders such as <x id="0" equiv-text="${replacements}"/>.</source>
+  <target>Допустимые имена файлов могут содержать буквы, цифры, точки, дефисы, символы подчеркивания, косую черту и заполнители, например <x id="0" equiv-text="${replacements}"/> .</target>
   <note from="lit-localize">Validation message for file name input. The placeholders are displayed as plain text.</note>
 </trans-unit>
 <trans-unit id="sdcded316146a0b76">
   <source>Object Attributes are in preview.</source>
+  <target>Атрибуты объекта находятся в предварительной версии.</target>
 </trans-unit>
 <trans-unit id="stages.source.resume-on-match-failures.label">
   <source>Resume on matching failures</source>
+  <target>Возобновление при сбоях сопоставления</target>
 </trans-unit>
 <trans-unit id="stages.source.resume-on-match-failures.description">
   <source>Resume this flow for the selected source matching failures. No source connection is created.</source>
+  <target>Возобновите этот процесс для выбранных ошибок сопоставления источников. Исходное соединение не создается.</target>
 </trans-unit>
 <trans-unit id="stages.source.match-failure.missing-property.label">
   <source>Missing property</source>
+  <target>Пропавшее имущество</target>
 </trans-unit>
 </body>
 </file>


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Completes Russian (`ru-RU`) translations for the lit-localize frontend bundle (`ru-RU.xlf`).

- Fills remaining empty or outdated `<target>` entries (~3 300+ strings)
- Covers authentication flows (including the post-logout screen), user library, admin UI, CAPTCHA, stages, and common UI chrome
- Preserves placeholders (`{0}`, Lit expressions); brand names (authentik, OAuth providers) kept as in source where appropriate

### Why is this change needed?

The existing `ru-RU` frontend locale was largely incomplete, which left significant parts of the web UI in English for Russian-speaking users—including critical auth flows such as logout confirmation and application library actions.

### How was this tested?

- Reviewed `ru-RU.xlf` for filled targets and consistent placeholder markup
- Manual smoke test on **authentik 2026.8** web UI with locale `ru-RU`: login, logout (end-session screen), user library / application list, and representative admin screens
- Verified Lit expression strings (e.g. logout buttons with app/brand names) render correctly with interpolated values

**Translator:** Anton Plaskonnyy (plaskonnyy@gmail.com)

### Linked issues

<!-- No linked issue; general locale improvement. -->

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).