### PR TITLE
web: Fix imports when in compatibility mode.

### DIFF
--- a/web/bundler/style-loader-plugin/node.js
+++ b/web/bundler/style-loader-plugin/node.js
@@ -114,6 +114,31 @@ export function styleLoaderPlugin({
             });
 
             /**
+             * Handle plain `.css` text imports, i.e. a component's `static styles`.
+             *
+             * These bypass ESBuild's CSS pipeline entirely, so their authored source —
+             * native nesting included — reaches ShadyCSS verbatim. Lower the nesting
+             * here for the same reason the bundled path does.
+             *
+             * @see {@linkcode CSSNamespace.Bundled} for the rationale.
+             */
+            build.onLoad({ filter: /\.css$/, namespace: "file" }, async (args) => {
+                const cssContent = await readFile(args.path, "utf8");
+
+                const { code } = await build.esbuild.transform(cssContent, {
+                    loader: "css",
+                    minify: build.initialOptions.minify || false,
+                    supported: { nesting: false },
+                    logLevel: "silent",
+                });
+
+                return {
+                    contents: code,
+                    loader: "text",
+                };
+            });
+
+            /**
              * Handle `with { type: "bundled-text" }` imports.
              *
              * Bundle the CSS and return as text...

--- a/web/src/flow/stages/identification/styles.css
+++ b/web/src/flow/stages/identification/styles.css
@@ -1,5 +1,4 @@
-fieldset[name="login-sources"],
-ak-stage-identification.style-scope fieldset[name="login-sources"] {
+fieldset[name="login-sources"] {
     --ak-c-login-sources-padding-inline: var(--pf-global--spacer--xl);
 
     flex: 1 1 auto;

--- a/web/src/polyfill/index.entrypoint.ts
+++ b/web/src/polyfill/index.entrypoint.ts
@@ -1,6 +1,6 @@
 // sort-imports-ignore
 import "@webcomponents/webcomponentsjs";
-import "lit/polyfill-support.js";
+import "lit-element/polyfill-support.js";
 import "./custom-elements-get-name.js";
 import "core-js/actual";
 import "@formatjs/intl-listformat/polyfill.js";


### PR DESCRIPTION
## Details

This PR fixes several styles not applying in compatibility mode.

Compatibility mode forces ShadyDOM, but `lit/polyfill-support.js` has no development export condition. Development builds loaded the production polyfill and registered the wrong global, so Lit never installed it, causing the base stylesheets to have empty rules. Importing it from lit-element fixes resolution. Also lowers CSS nesting in plain .css text imports, which ShadyCSS silently strips declarations from.