### PR TITLE
providers/oauth2: scope the end-session early return to this provider's flow

### DIFF
--- a/authentik/providers/oauth2/tests/test_end_session.py
+++ b/authentik/providers/oauth2/tests/test_end_session.py
@@ -287,6 +287,30 @@ class TestEndSessionView(OAuthTestCase):
             self.client.session[SESSION_KEY_PLAN].flow_pk, self.invalidation_flow.pk.hex
         )
 
+    def test_unresolvable_application_with_a_plan_falls_through(self):
+        """A plan present plus an unresolvable application must not return a blank 200.
+
+        The early return resolves the provider itself to learn which flow this request
+        would run. When that resolution fails, PolicyAccessView has to be the one to
+        build the response, so the request falls through instead of being answered with
+        an empty body.
+        """
+        self._brand_authentication_flow()
+        plan = FlowPlan(flow_pk=create_test_flow(FlowDesignation.AUTHENTICATION).pk.hex)
+        session = self.client.session
+        session[SESSION_KEY_PLAN] = plan
+        session.save()
+
+        response = self.client.get(
+            reverse(
+                "authentik_providers_oauth2:end-session",
+                kwargs={"application_slug": "does-not-exist"},
+            ),
+            HTTP_HOST=self.brand.domain,
+        )
+
+        self.assertEqual(response.status_code, 404)
+
     def test_frontchannel_iframe_callback_preserves_injected_stages(self):
         """Stages injected into the logout plan survive the iframe's end-session hit.
 

--- a/authentik/providers/oauth2/tests/test_end_session.py
+++ b/authentik/providers/oauth2/tests/test_end_session.py
@@ -255,6 +255,38 @@ class TestEndSessionView(OAuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.client.session[SESSION_KEY_PLAN].flow_pk, plan.flow_pk)
 
+    def test_unrelated_flow_plan_does_not_return_blank(self):
+        """A plan for a different flow must not short-circuit end-session (#25545).
+
+        After logging out in another tab the user lands on the login screen, which
+        stores an *authentication* flow plan in SESSION_KEY_PLAN. A logout triggered
+        from a second application then hit the early return meant for front-channel
+        logout iframes and rendered an empty 200 — a blank white page — instead of
+        running the invalidation flow.
+        """
+        self._brand_authentication_flow()
+        other_flow = create_test_flow(FlowDesignation.AUTHENTICATION)
+        plan = FlowPlan(flow_pk=other_flow.pk.hex)
+        session = self.client.session
+        session[SESSION_KEY_PLAN] = plan
+        session.save()
+
+        response = self.client.get(
+            reverse(
+                "authentik_providers_oauth2:end-session",
+                kwargs={"application_slug": self.app.slug},
+            ),
+            HTTP_HOST=self.brand.domain,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(f"/if/flow/{self.invalidation_flow.slug}/", response.url)
+        # The unrelated plan must be replaced by this request's invalidation plan,
+        # not left in place for the executor to resume.
+        self.assertEqual(
+            self.client.session[SESSION_KEY_PLAN].flow_pk, self.invalidation_flow.pk.hex
+        )
+
     def test_frontchannel_iframe_callback_preserves_injected_stages(self):
         """Stages injected into the logout plan survive the iframe's end-session hit.
 

--- a/authentik/providers/oauth2/views/end_session.py
+++ b/authentik/providers/oauth2/views/end_session.py
@@ -14,10 +14,11 @@ from authentik.common.oauth.constants import (
     PLAN_CONTEXT_OIDC_LOGOUT_IFRAME_SESSIONS,
     PLAN_CONTEXT_POST_LOGOUT_REDIRECT_URI,
 )
-from authentik.core.models import Application, AuthenticatedSession
+from authentik.core.models import Application, AuthenticatedSession, Provider
 from authentik.flows.models import Flow, in_memory_stage
 from authentik.flows.planner import (
     PLAN_CONTEXT_APPLICATION,
+    FlowPlan,
     FlowPlanner,
 )
 from authentik.flows.stage import SessionEndStage
@@ -118,16 +119,29 @@ class EndSessionView(PolicyAccessView):
             )
 
     def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        """Return early when a flow plan is already executing in this session.
+        """Return early when this provider's invalidation flow is already executing.
 
         Front-channel logout iframes navigate to this endpoint while the invalidation flow
         is still running, and `UserLogoutStage` has already made the request anonymous.
         Falling through to `PolicyAccessView` would plan an authentication flow and store it
         in `SESSION_KEY_PLAN`, replacing the invalidation plan and discarding every stage
         queued after the iframe logout stage.
+
+        The plan has to belong to the flow this request would run. Any other plan means the
+        session is simply mid-flow elsewhere — most commonly the authentication flow stored
+        when a logout in another tab landed the user on the login screen — and answering
+        those with an empty body rendered a blank page instead of logging the user out
+        (#25545).
         """
-        if SESSION_KEY_PLAN in request.session:
-            return HttpResponse(status=200)
+        plan: FlowPlan | None = request.session.get(SESSION_KEY_PLAN)
+        if plan is not None:
+            try:
+                self.resolve_provider_application()
+            except Application.DoesNotExist, Provider.DoesNotExist, Http404:
+                # Let PolicyAccessView build the canonical error response.
+                return super().dispatch(request, *args, **kwargs)
+            if plan.flow_pk == self.flow.pk.hex:
+                return HttpResponse(status=200)
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:


### PR DESCRIPTION
## Details

Closes #25545.

`EndSessionView.dispatch` returned an empty `200` whenever *any* flow plan was present in the session:

```python
if SESSION_KEY_PLAN in request.session:
    return HttpResponse(status=200)
```

The guard is there so a front-channel logout iframe cannot replace an in-flight invalidation plan, but it matches every plan rather than that one.

The reporter's sequence produces a foreign plan: logging out in tab A leaves the user on the login screen, which stores an **authentication** flow plan in `SESSION_KEY_PLAN`. Logging out from a second application in tab B then hits the early return and renders a blank page — `200 OK`, empty body, no redirect — instead of running the invalidation flow.

This compares the stored plan's `flow_pk` against the flow the request would actually run, so an unrelated plan falls through to the normal logout path. `self.flow` is resolved in `resolve_provider_application()`, which `PolicyAccessView.dispatch` only calls after this override, so the override resolves it first and defers to `super()` for the resolution failures `PolicyAccessView` already handles.

Identity rather than `FlowDesignation` is the discriminator on purpose: a provider's `invalidation_flow` is not required to carry `FlowDesignation.INVALIDATION`, and the existing `test_active_flow_plan_returns_early` uses one that does not.

## Checklist

- [x] Local tests pass (`ak test authentik/`)
- [x] The code has been formatted (`make lint-fix`)

If an API change has been made

- [ ] The API schema has been updated (`make gen-build`)

If changes to the frontend have been made

- [ ] The code has been formatted (`make web`)

If applicable

- [ ] The documentation has been updated
- [ ] The documentation has been formatted (`make website`)

## Testing

`authentik/providers/oauth2/tests/` — **303 passed**, run against a local Postgres 18 + Redis.

The new `test_unrelated_flow_plan_does_not_return_blank` seeds an authentication-flow plan and asserts the request redirects into the invalidation flow. It was written first and failed on `main` with `AssertionError: 200 != 302` — the reporter's blank page, reproduced.

Both directions are covered, verified by reverting each half:

| mutation | result |
|---|---|
| drop the early return entirely | 2 fail — the iframe tests that motivated the guard |
| restore the original unscoped `if SESSION_KEY_PLAN in request.session` | 1 fail — the new test |

So the guard still does its original job, and the scoping is what the new test is pinning.

## AI assistance disclosure

Per `AI_POLICY.md`: I used Claude Code while working on this. It ran the searches and edits under my direction, and I reviewed every line before committing.

Two places where that mattered, since the policy asks for the extent rather than the fact:

My first assertion in the new test was `assertNotEqual(response.content, b"")`, which failed even with the fix applied — a 302 has an empty body by definition, so the assertion was testing the wrong thing. I replaced it with an assertion on the redirect target and on the plan actually being replaced.

I also nearly filed a second, unrelated report against `ExpiringModel` — `is_expired` does `now() > self.expires` while both field defaults are `expires=None, expiring=True`, which reads like a guaranteed `TypeError`. I wrote the reproduction before reporting it and it disproved me: `expiring_model_pre_save` in `authentik/core/signals.py` fills `expires` on save, and nothing in the codebase writes those models through `bulk_create` or a queryset `.update()`, so the state is unreachable. That one is not in this PR because it is not a bug.

I can explain this change, why the flow-identity comparison is the correct discriminator, and what it affects, without assistance.
