### PR TITLE
website/integrations: buildbuddy: align with my experience setting it up

### DIFF
--- a/website/integrations/development/buildbuddy/index.mdx
+++ b/website/integrations/development/buildbuddy/index.mdx
@@ -27,7 +27,7 @@ This documentation lists only the settings that you need to change from their de
 :::
 
 :::info BuildBuddy requirements
-Self-hosted BuildBuddy supports authentication in its Enterprise version only, via OIDC. BuildBuddy Cloud uses SAML instead, and BuildBuddy support completes the activation after you share the authentik metadata URL with them.
+Self-hosted BuildBuddy supports authentication in its Enterprise version only, via OIDC. BuildBuddy Cloud uses SAML instead, configured in the organization settings.
 :::
 
 ## Integration configuration
@@ -125,11 +125,13 @@ BuildBuddy reads the user's email address from a SAML attribute named `email`.
 
 ### BuildBuddy configuration
 
-Share the authentik metadata URL, `https://authentik.company/application/saml/<application_slug>/metadata/`, with BuildBuddy support and ask them to enable SAML login for your organization slug. BuildBuddy support confirms when the activation is complete.
+1. Log in to BuildBuddy and navigate to **Settings** > **Single sign-on**.
+2. Set **IdP metadata URL** to `https://authentik.company/application/saml/<application_slug>/metadata/`.
+3. Click **Enable**.
 
 ### Configuration verification
 
-To confirm that authentik is properly configured with BuildBuddy, open `https://app.buildbuddy.io/login?slug=<org-slug>` and log in via authentik.
+To confirm that authentik is properly configured with BuildBuddy, log out of BuildBuddy, click **Continue with SSO**, enter your organization slug under **Team Slug**, and log back in via authentik. If your organization uses a BuildBuddy subdomain, open `https://<org-slug>.buildbuddy.io` and click the SSO login button labeled with your organization name instead.
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Well, I was surprised. Pricing page said Ent, but I finally set up SSO on my buildbuddy org and it worked... Cool!

Also, according to their docs:

> Still on the Sign On page, copy and share the Metadata URL (which should have the format https://xxxx.okta.com/app/XXXX/sso/saml/metadata) with BuildBuddy support.
> Once the app is created, share the Identity Provider Metadata URL with BuildBuddy support.
> ...

https://www.buildbuddy.io/docs/config-auth/#other-providers

But I was able to do everything from the settings page without involving support.