### PR TITLE
docs(sources): fix group-sync disable snippet and document override behavior

### DIFF
--- a/website/docs/releases/2024/v2024.8.mdx
+++ b/website/docs/releases/2024/v2024.8.mdx
@@ -43,7 +43,7 @@ slug: "/releases/2024.8"
 
     ```python
     return {
-        "groups": [],
+        "groups": None,
     }
     ```
 

--- a/website/docs/users-sources/sources/property-mappings/index.mdx
+++ b/website/docs/users-sources/sources/property-mappings/index.mdx
@@ -78,6 +78,83 @@ The `groups` attribute is a special attribute that must contain group identifier
 
 An identifier has to be a simple value such as a string. Entries that are not, such as the objects some identity providers return in an OpenID Connect `groups` claim, are skipped, and a **Configuration error** event records how many were dropped.
 
+#### Disabling group synchronization
+
+Returning an empty list does **not** disable group synchronization. The
+`groups` a source collects (from the OpenID Connect `groups` claim, or the
+SAML group attribute) are placed into the base user properties before any
+property mapping runs, and mapping results are merged into them with a
+unique-append strategy. `return {"groups": []}` therefore appends nothing and
+the provider's groups are still imported.
+
+To discard the collected groups, return `None` for the attribute. As described
+in [Expression semantics](#expression-semantics), an attribute set to `None` is
+dropped entirely:
+
+```python
+return {"groups": None}
+```
+
+#### Overriding the collected groups
+
+Because results are merged rather than substituted, returning a list _adds to_
+the provider's groups instead of replacing them. There are two ways to end up
+with an exact set of groups and drop whatever the source collected.
+
+**Two ordered mappings (recommended).** Property mappings run in alphabetical
+order by name. Setting an attribute to `None` drops it (see
+[Expression semantics](#expression-semantics)); a later mapping can then set it
+to the value you want. Assign both as user property mappings on the source:
+
+- `aa - discard source groups`
+
+```python
+  return {"groups": None}
+```
+
+- `ab - set groups`
+
+```python
+  return {"groups": ["group1", "group2"]}
+```
+
+The first mapping clears the collected groups, the second sets the final list.
+Because it runs last, its value wins. The second mapping's list can also be
+built dynamically. This approach uses only documented return values; the names
+just need to sort so that the discarding mapping runs first.
+
+**Single mapping via the accumulator.** Alternatively, write to the
+`properties` accumulator directly and return `None` so nothing is merged
+afterwards:
+
+```python
+properties["groups"] = ["group1", "group2"]
+return None
+```
+
+`properties` is the object authentik builds the final result from, so assigning
+to it replaces the value outright, bypassing the merge.
+
+:::note Groups created or linked by a source are managed by that source
+When a source creates or links a group, authentik records the association per
+group and source, not per user. On every login through that source, authentik
+removes the user from every group they are in that is linked to that source,
+then re-adds only the groups the mappings return for this login. Groups the
+source has never created or linked — for example groups you created and
+assigned manually — are left untouched.
+
+Two consequences are easy to miss, because the group view does not show which
+source (if any) manages a group:
+
+- To keep a user in a source-linked group, the mappings must return it on every
+  login. If they stop returning it, the user is removed from it on the next
+  login through that source.
+- With the **Name link** group matching mode, a manually-created group becomes
+  source-managed the first time its name matches a group the source collects.
+  From then on, its membership for all of its members is reconciled on every
+  login through that source.
+  :::
+
 #### Object-shaped OpenID Connect group claims
 
 OpenID Connect does not define a `groups` claim, so providers are free to put anything in one. Some return group objects instead of plain identifiers.


### PR DESCRIPTION
## What

The 2024.8 release notes say to disable source group synchronization with
`return {"groups": []}`. That's a no-op — the provider's groups are still
imported. This corrects it and documents the surrounding merge/override
behavior.

## Why `[]` doesn't work

Group claims are written into the base user properties before any mapping runs
(OAuth/OIDC: `get_base_user_properties` → `"groups": info.get("groups", [])`;
SAML: the group attribute). `SourceMapper.build_object_properties` then merges
each mapping result into those base properties with `MERGE_LIST_UNIQUE`
(deepmerge `append_unique`), so appending `[]` changes nothing. The merge config
and base behavior are identical in `version/2024.8.0` and current — the snippet
was never correct. `None` is the only value that clears the attribute.

## Changes

- Correct the release-note snippet to `{"groups": None}`.
- Add to the property mappings page:
  - merging (not replacing) is the default;
  - disable with `{"groups": None}` (not `[]`);
  - exact override via two name-ordered mappings (`aa …` → `None`, then
    `ab …` → target list; relies on `PropertyMappingManager.order_by("name")`),
    or by assigning to the `properties` accumulator and returning `None`;
  - groups a source creates/links are reconciled per (group, source) on every
    login, which the group view doesn't surface (matters with Name link
    matching).

## Files

- `website/docs/releases/2024/v2024.8.mdx`
- `website/docs/users-sources/sources/property-mappings/index.mdx`

## Notes for reviewers

- Both override techniques rely on current behavior — the two-mapping one on
  execution order (`order_by("name")`), the single-mapping one on `properties`
  being the live accumulator. Flagging in case you'd prefer a dedicated replace
  semantic.
- The historical release note is corrected here; happy to instead leave it and
  only fix the living page.

## AI usage disclosure

Prepared with AI assistance (Anthropic's Claude): cross-checking behavior against
the authentik source, reproducing the list-merge locally with `deepmerge`,
drafting the docs, and running Prettier. I verified in a running 2026.8 instance
that `{"groups": []}` doesn't disable group sync, `{"groups": None}` does, and
the two-mapping approach works. I've reviewed all changes, understand them, and
can explain them without AI assistance.

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [X] The documentation has been updated and formatted (`make docs`)
-   [X] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
