### PR TITLE
providers/oauth2: allow a provider to override its issuer

### DIFF
--- a/authentik/providers/oauth2/api/providers.py
+++ b/authentik/providers/oauth2/api/providers.py
@@ -92,6 +92,7 @@ class OAuth2ProviderSerializer(ProviderSerializer):
             "sub_mode",
             "property_mappings",
             "issuer_mode",
+            "issuer_override",
             "jwt_federation_sources",
             "jwt_federation_providers",
         ]

--- a/authentik/providers/oauth2/migrations/0038_oauth2provider_issuer_override.py
+++ b/authentik/providers/oauth2/migrations/0038_oauth2provider_issuer_override.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("authentik_providers_oauth2", "0037_accesstoken_actor_authorizationcode_actor_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="oauth2provider",
+            name="issuer_override",
+            field=models.TextField(
+                blank=True,
+                default="",
+                help_text=(
+                    "Use this exact value as the issuer instead of deriving one from Issuer "
+                    "mode. Leave empty to use Issuer mode. Set this when several providers must "
+                    "share a single issuer, for example an application whose desktop and mobile "
+                    "clients ship their own fixed client IDs and therefore need one provider "
+                    "each, while the application itself only trusts a single issuer."
+                ),
+            ),
+        ),
+    ]

--- a/authentik/providers/oauth2/models.py
+++ b/authentik/providers/oauth2/models.py
@@ -317,6 +317,17 @@ class OAuth2Provider(WebfingerProvider, Provider):
         default=IssuerMode.PER_PROVIDER,
         help_text=_("Configure how the issuer field of the ID Token should be filled."),
     )
+    issuer_override = models.TextField(
+        blank=True,
+        default="",
+        help_text=_(
+            "Use this exact value as the issuer instead of deriving one from Issuer mode. "
+            "Leave empty to use Issuer mode. Set this when several providers must share a "
+            "single issuer, for example an application whose desktop and mobile clients ship "
+            "their own fixed client IDs and therefore need one provider each, while the "
+            "application itself only trusts a single issuer."
+        ),
+    )
 
     signing_key = models.ForeignKey(
         CertificateKeyPair,
@@ -364,6 +375,8 @@ class OAuth2Provider(WebfingerProvider, Provider):
 
     def get_issuer(self, request: HttpRequest) -> str | None:
         """Get issuer, based on request"""
+        if self.issuer_override:
+            return self.issuer_override
         if self.issuer_mode == IssuerMode.GLOBAL:
             return request.build_absolute_uri(reverse("authentik_core:root-redirect"))
         try:

--- a/authentik/providers/oauth2/tests/test_provider_info.py
+++ b/authentik/providers/oauth2/tests/test_provider_info.py
@@ -9,6 +9,7 @@ from authentik.core.models import Application
 from authentik.core.tests.utils import create_test_flow
 from authentik.lib.generators import generate_id
 from authentik.providers.oauth2.models import (
+    IssuerMode,
     OAuth2Provider,
     RedirectURI,
     RedirectURIMatchingMode,
@@ -98,3 +99,49 @@ class TestProviderInfo(OAuthTestCase):
         )
         body = self.get_info()
         self.assertIn("email", body["claims_supported"])
+
+    def test_issuer_override_empty_uses_issuer_mode(self):
+        """An empty issuer_override leaves the existing Issuer mode behaviour untouched"""
+        self.assertEqual(self.provider.issuer_override, "")
+        self.assertTrue(self.get_info()["issuer"].endswith(f"/application/o/{self.app.slug}/"))
+
+    def test_issuer_override(self):
+        """issuer_override is used verbatim in the discovery document"""
+        self.provider.issuer_override = "https://id.local.invalid/"
+        self.provider.save()
+        self.assertEqual(self.get_info()["issuer"], "https://id.local.invalid/")
+
+    def test_issuer_override_takes_precedence_over_issuer_mode(self):
+        """issuer_override wins over Issuer mode rather than being combined with it"""
+        self.provider.issuer_mode = IssuerMode.GLOBAL
+        self.provider.issuer_override = "https://id.local.invalid/"
+        self.provider.save()
+        self.assertEqual(self.get_info()["issuer"], "https://id.local.invalid/")
+
+    def test_issuer_override_shared_between_providers(self):
+        """Two providers with different client IDs can present one issuer.
+
+        This is the case the field exists for: an application whose desktop and
+        mobile clients ship their own fixed client IDs needs one provider each,
+        while the application itself only ever trusts a single issuer.
+        """
+        shared = "https://id.local.invalid/"
+        self.provider.issuer_override = shared
+        self.provider.save()
+
+        second = OAuth2Provider.objects.create(
+            name=generate_id(),
+            client_id=generate_id(),
+            authorization_flow=create_test_flow(),
+            redirect_uris=[RedirectURI(RedirectURIMatchingMode.STRICT, "http://local.invalid")],
+            signing_key=self.keypair,
+            issuer_override=shared,
+        )
+        second.property_mappings.set(ScopeMapping.objects.all())
+        second_app = Application.objects.create(
+            name=generate_id(), slug=generate_id(), provider=second
+        )
+
+        self.assertNotEqual(self.provider.client_id, second.client_id)
+        self.assertNotEqual(self.app.slug, second_app.slug)
+        self.assertEqual(self.get_info()["issuer"], self.get_info(second_app)["issuer"])

--- a/blueprints/schema.json
+++ b/blueprints/schema.json
@@ -12419,6 +12419,11 @@
                     "title": "Issuer mode",
                     "description": "Configure how the issuer field of the ID Token should be filled."
                 },
+                "issuer_override": {
+                    "type": "string",
+                    "title": "Issuer override",
+                    "description": "Use this exact value as the issuer instead of deriving one from Issuer mode. Leave empty to use Issuer mode. Set this when several providers must share a single issuer, for example an application whose desktop and mobile clients ship their own fixed client IDs and therefore need one provider each, while the application itself only trusts a single issuer."
+                },
                 "jwt_federation_sources": {
                     "type": "array",
                     "items": {

--- a/packages/client-ts/src/models/OAuth2Provider.ts
+++ b/packages/client-ts/src/models/OAuth2Provider.ts
@@ -215,6 +215,12 @@ export interface OAuth2Provider {
      */
     issuerMode?: IssuerModeEnum;
     /**
+     * Use this exact value as the issuer instead of deriving one from Issuer mode. Leave empty to use Issuer mode. Set this when several providers must share a single issuer, for example an application whose desktop and mobile clients ship their own fixed client IDs and therefore need one provider each, while the application itself only trusts a single issuer.
+     * @type {string}
+     * @memberof OAuth2Provider
+     */
+    issuerOverride?: string;
+    /**
      *
      * @type {Array<string>}
      * @memberof OAuth2Provider
@@ -380,6 +386,7 @@ export function OAuth2ProviderFromJSONTyped(
         subMode: json["sub_mode"] == null ? undefined : SubModeEnumFromJSON(json["sub_mode"]),
         issuerMode:
             json["issuer_mode"] == null ? undefined : IssuerModeEnumFromJSON(json["issuer_mode"]),
+        issuerOverride: json["issuer_override"] == null ? undefined : json["issuer_override"],
         jwtFederationSources:
             json["jwt_federation_sources"] == null ? undefined : json["jwt_federation_sources"],
         jwtFederationProviders:
@@ -435,6 +442,7 @@ export function OAuth2ProviderToJSONTyped(
         logout_method: OAuth2ProviderLogoutMethodEnumToJSON(value["logoutMethod"]),
         sub_mode: SubModeEnumToJSON(value["subMode"]),
         issuer_mode: IssuerModeEnumToJSON(value["issuerMode"]),
+        issuer_override: value["issuerOverride"],
         jwt_federation_sources: value["jwtFederationSources"],
         jwt_federation_providers: value["jwtFederationProviders"],
     };

--- a/packages/client-ts/src/models/OAuth2ProviderRequest.ts
+++ b/packages/client-ts/src/models/OAuth2ProviderRequest.ts
@@ -161,6 +161,12 @@ export interface OAuth2ProviderRequest {
      */
     issuerMode?: IssuerModeEnum;
     /**
+     * Use this exact value as the issuer instead of deriving one from Issuer mode. Leave empty to use Issuer mode. Set this when several providers must share a single issuer, for example an application whose desktop and mobile clients ship their own fixed client IDs and therefore need one provider each, while the application itself only trusts a single issuer.
+     * @type {string}
+     * @memberof OAuth2ProviderRequest
+     */
+    issuerOverride?: string;
+    /**
      *
      * @type {Array<string>}
      * @memberof OAuth2ProviderRequest
@@ -266,6 +272,7 @@ export function OAuth2ProviderRequestFromJSONTyped(
         subMode: json["sub_mode"] == null ? undefined : SubModeEnumFromJSON(json["sub_mode"]),
         issuerMode:
             json["issuer_mode"] == null ? undefined : IssuerModeEnumFromJSON(json["issuer_mode"]),
+        issuerOverride: json["issuer_override"] == null ? undefined : json["issuer_override"],
         jwtFederationSources:
             json["jwt_federation_sources"] == null ? undefined : json["jwt_federation_sources"],
         jwtFederationProviders:
@@ -310,6 +317,7 @@ export function OAuth2ProviderRequestToJSONTyped(
         logout_method: OAuth2ProviderLogoutMethodEnumToJSON(value["logoutMethod"]),
         sub_mode: SubModeEnumToJSON(value["subMode"]),
         issuer_mode: IssuerModeEnumToJSON(value["issuerMode"]),
+        issuer_override: value["issuerOverride"],
         jwt_federation_sources: value["jwtFederationSources"],
         jwt_federation_providers: value["jwtFederationProviders"],
     };

--- a/packages/client-ts/src/models/PatchedOAuth2ProviderRequest.ts
+++ b/packages/client-ts/src/models/PatchedOAuth2ProviderRequest.ts
@@ -161,6 +161,12 @@ export interface PatchedOAuth2ProviderRequest {
      */
     issuerMode?: IssuerModeEnum;
     /**
+     * Use this exact value as the issuer instead of deriving one from Issuer mode. Leave empty to use Issuer mode. Set this when several providers must share a single issuer, for example an application whose desktop and mobile clients ship their own fixed client IDs and therefore need one provider each, while the application itself only trusts a single issuer.
+     * @type {string}
+     * @memberof PatchedOAuth2ProviderRequest
+     */
+    issuerOverride?: string;
+    /**
      *
      * @type {Array<string>}
      * @memberof PatchedOAuth2ProviderRequest
@@ -250,6 +256,7 @@ export function PatchedOAuth2ProviderRequestFromJSONTyped(
         subMode: json["sub_mode"] == null ? undefined : SubModeEnumFromJSON(json["sub_mode"]),
         issuerMode:
             json["issuer_mode"] == null ? undefined : IssuerModeEnumFromJSON(json["issuer_mode"]),
+        issuerOverride: json["issuer_override"] == null ? undefined : json["issuer_override"],
         jwtFederationSources:
             json["jwt_federation_sources"] == null ? undefined : json["jwt_federation_sources"],
         jwtFederationProviders:
@@ -297,6 +304,7 @@ export function PatchedOAuth2ProviderRequestToJSONTyped(
         logout_method: OAuth2ProviderLogoutMethodEnumToJSON(value["logoutMethod"]),
         sub_mode: SubModeEnumToJSON(value["subMode"]),
         issuer_mode: IssuerModeEnumToJSON(value["issuerMode"]),
+        issuer_override: value["issuerOverride"],
         jwt_federation_sources: value["jwtFederationSources"],
         jwt_federation_providers: value["jwtFederationProviders"],
     };

--- a/schema.yml
+++ b/schema.yml
@@ -46266,6 +46266,14 @@ components:
           allOf:
           - $ref: '#/components/schemas/IssuerModeEnum'
           description: Configure how the issuer field of the ID Token should be filled.
+        issuer_override:
+          type: string
+          description: Use this exact value as the issuer instead of deriving one
+            from Issuer mode. Leave empty to use Issuer mode. Set this when several
+            providers must share a single issuer, for example an application whose
+            desktop and mobile clients ship their own fixed client IDs and therefore
+            need one provider each, while the application itself only trusts a single
+            issuer.
         jwt_federation_sources:
           type: array
           items:
@@ -46396,6 +46404,14 @@ components:
           allOf:
           - $ref: '#/components/schemas/IssuerModeEnum'
           description: Configure how the issuer field of the ID Token should be filled.
+        issuer_override:
+          type: string
+          description: Use this exact value as the issuer instead of deriving one
+            from Issuer mode. Leave empty to use Issuer mode. Set this when several
+            providers must share a single issuer, for example an application whose
+            desktop and mobile clients ship their own fixed client IDs and therefore
+            need one provider each, while the application itself only trusts a single
+            issuer.
         jwt_federation_sources:
           type: array
           items:
@@ -52366,6 +52382,14 @@ components:
           allOf:
           - $ref: '#/components/schemas/IssuerModeEnum'
           description: Configure how the issuer field of the ID Token should be filled.
+        issuer_override:
+          type: string
+          description: Use this exact value as the issuer instead of deriving one
+            from Issuer mode. Leave empty to use Issuer mode. Set this when several
+            providers must share a single issuer, for example an application whose
+            desktop and mobile clients ship their own fixed client IDs and therefore
+            need one provider each, while the application itself only trusts a single
+            issuer.
         jwt_federation_sources:
           type: array
           items:

--- a/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderFormForm.ts
@@ -481,6 +481,18 @@ export function renderForm({
                     help=${msg("Configure how the issuer field of the ID Token should be filled.")}
                 >
                 </ak-radio-input>
+                <ak-text-input
+                    name="issuerOverride"
+                    autocomplete="off"
+                    label=${msg("Issuer override", {
+                        id: "provider.oauth2.issuer-override.label",
+                    })}
+                    value=${ifDefined(provider.issuerOverride)}
+                    help=${msg(
+                        "Use this exact value as the issuer instead of deriving one from Issuer mode. Leave empty to use Issuer mode. Set this when several providers must share a single issuer, for example an application whose desktop and mobile clients ship their own fixed client IDs and therefore need one provider each, while the application itself only trusts a single issuer.",
+                        { id: "provider.oauth2.issuer-override.description" },
+                    )}
+                ></ak-text-input>
             </div>
         </ak-form-group>
 


### PR DESCRIPTION
## Details

### What does this PR change?

Adds an optional `issuer_override` field to OAuth2 providers. When set, it is used
verbatim as the issuer, in both the `iss` claim and the discovery document. When
empty — the default — behaviour is unchanged, so no existing provider is affected.

Includes a migration, a serializer field, the web form input, and tests covering
both the override and the unchanged default paths.

### Why is this change needed?

authentik derives an OAuth2 provider's `iss` from `issuer_mode`: either the
installation root, or a per-application path built from the application slug. Both
tie the issuer to the provider, and a provider owns exactly one client_id.

That breaks for any application shipping several first-party clients with fixed,
published client IDs. ownCloud/oCIS is the clearest case: its Web, Desktop, Android
and iOS clients each hardcode a different client_id, so each needs its own provider,
so each is issued a different `iss` — while the oCIS server validates tokens against
exactly one issuer. Three of the four clients are always rejected with
`token has invalid issuer`.

`issuer_mode=global` does not help, because it makes the issuer the installation
root while discovery is only served beneath a per-application path, so the
application can no longer fetch its OIDC metadata.

`issuer_override` already exists on SAML sources (#22177, #24221); this brings the
same escape hatch to OAuth2 providers.

Refs #7251