### PR TITLE
root: skip database-calling middlewares for liveness probe

### DIFF
--- a/authentik/brands/middleware.py
+++ b/authentik/brands/middleware.py
@@ -18,6 +18,10 @@ class BrandMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
+        # Skip for liveness probe
+        if request.path == "/-/health/live/":
+            return self.get_response(request)
+
         locale_to_set = None
         if not hasattr(request, "brand"):
             brand = get_brand_for_request(request)

--- a/authentik/events/middleware.py
+++ b/authentik/events/middleware.py
@@ -153,6 +153,10 @@ class AuditMiddleware:
         m2m_changed.disconnect(dispatch_uid=request.request_id)
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
+        # Skip for liveness probe
+        if request.path == "/-/health/live/":
+            return self.get_response(request)
+
         _CTX_REQUEST.set(request)
         self.connect(request)
 

--- a/authentik/root/tests/test_views.py
+++ b/authentik/root/tests/test_views.py
@@ -13,7 +13,10 @@ class TestRoot(TransactionTestCase):
 
     def test_monitoring_live(self):
         """Test LiveView"""
-        self.assertEqual(self.client.get(reverse("health-live")).status_code, 200)
+
+        # The liveness probe should not make any database queries
+        with self.assertNumQueries(0):
+            self.assertEqual(self.client.get(reverse("health-live")).status_code, 200)
 
     def test_monitoring_ready(self):
         """Test ReadyView"""

--- a/authentik/tenants/middleware.py
+++ b/authentik/tenants/middleware.py
@@ -1,4 +1,6 @@
+from django.db import connection
 from django.db.models import Value
+from django.http import HttpRequest, HttpResponse
 from django_tenants.middleware import TenantMainMiddleware
 from django_tenants.utils import get_public_schema_name
 
@@ -6,6 +8,14 @@ from authentik.tenants.models import Domain, Tenant
 
 
 class DefaultTenantMiddleware(TenantMainMiddleware):
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        # Skip for liveness probe
+        if request.path == "/-/health/live/":
+            connection.set_schema_to_public()
+            return self.get_response(request)
+
+        return super().__call__(request)
+
     def get_tenant(self, domain_model: type[Domain], hostname: str) -> Tenant:
         tenant = (
             Tenant.objects.filter(domains__domain=hostname)


### PR DESCRIPTION
This PR is a "fix"/performance improvement of the liveness probe endpoint.

As per Kubernetes best practices liveness probes should not hit any dependencies (like databases):

> When your app has a strict dependency on back-end services, you can implement both a liveness and a readiness probe. The liveness probe passes when the app itself is healthy, but the readiness probe additionally checks that each required back-end service is available. This helps you avoid directing traffic to Pods that can only respond with error messages.
(from https://kubernetes.io/docs/concepts/workloads/pods/probes)

Currently the liveness probe implementation triggers a few database queries (for tenant and brand; from middlewares).

This PR fixes this by skipping (irrelevant) middlewares that do db queries for the liveness probe endpoint. I'll also open another PR with a suggestion for a more "radical" approach (edit: see https://github.com/goauthentik/authentik/pull/25598).

## Details

### What does this PR change?

It adds "skips" to middlewares that trigger database queries when processing a liveness probe endpoint request.

### Why is this change needed?

To remove any (accidental) external dependencies for the liveness probe endpoint.

### How was this tested?

By adding a unit test and manually verifying that the endpoint returns the desired status.

### Disclaimer

I used an AI agent (opencode with Claude Opus and Gemini Flash) to help with the implementation. All the changes were reviewed and tested manually.

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
