### PR TITLE
rbac: add cleanup task for orphaned object permissions

### DIFF
--- a/authentik/rbac/apps.py
+++ b/authentik/rbac/apps.py
@@ -1,6 +1,8 @@
 """authentik rbac app config"""
 
 from authentik.blueprints.apps import ManagedAppConfig
+from authentik.lib.utils.time import fqdn_rand
+from authentik.tasks.schedules.common import ScheduleSpec
 
 
 class AuthentikRBACConfig(ManagedAppConfig):
@@ -10,3 +12,14 @@ class AuthentikRBACConfig(ManagedAppConfig):
     label = "authentik_rbac"
     verbose_name = "authentik RBAC"
     default = True
+
+    @property
+    def tenant_schedule_specs(self) -> list[ScheduleSpec]:
+        from authentik.rbac.tasks import clean_orphaned_object_permissions
+
+        return [
+            ScheduleSpec(
+                actor=clean_orphaned_object_permissions,
+                crontab=f"{fqdn_rand('clean_orphaned_object_permissions')} {fqdn_rand('clean_orphaned_object_permissions', 24)} * * *",  # noqa: E501
+            ),
+        ]

--- a/authentik/rbac/tasks.py
+++ b/authentik/rbac/tasks.py
@@ -1,0 +1,20 @@
+"""authentik RBAC tasks"""
+
+from django.utils.translation import gettext_lazy as _
+from dramatiq import actor
+from guardian.utils import clean_orphan_obj_perms
+
+from authentik.tasks.middleware import CurrentTask
+
+ORPHANED_PERMISSIONS_BATCH_SIZE = 1000
+ORPHANED_PERMISSIONS_MAX_DURATION = 60 * 30
+
+
+@actor(description=_("Remove object-level permissions whose object no longer exists."))
+def clean_orphaned_object_permissions():
+    self = CurrentTask.get_task()
+    removed = clean_orphan_obj_perms(
+        batch_size=ORPHANED_PERMISSIONS_BATCH_SIZE,
+        max_duration_secs=ORPHANED_PERMISSIONS_MAX_DURATION,
+    )
+    self.info(f"Removed {removed} orphaned object permission(s)")

--- a/authentik/rbac/tests/test_tasks.py
+++ b/authentik/rbac/tests/test_tasks.py
@@ -1,0 +1,39 @@
+"""Test RBAC tasks"""
+
+from guardian.models import RoleModelPermission, RoleObjectPermission
+from rest_framework.test import APITestCase
+
+from authentik.core.tests.utils import create_test_admin_user
+from authentik.lib.generators import generate_id
+from authentik.rbac.models import Role
+from authentik.rbac.tasks import clean_orphaned_object_permissions
+
+
+class TestRBACTasks(APITestCase):
+    """Test RBAC tasks"""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.superuser = create_test_admin_user()
+        self.role = Role.objects.create(name=generate_id())
+
+    def test_clean_orphaned_object_permissions(self):
+        """Test that object permissions of deleted objects are removed"""
+        deleted = Role.objects.create(name=generate_id())
+        kept = Role.objects.create(name=generate_id())
+        self.role.assign_perms("authentik_rbac.view_role", obj=deleted)
+        self.role.assign_perms("authentik_rbac.view_role", obj=kept)
+        self.role.assign_perms("authentik_rbac.view_role")
+        deleted_pk = str(deleted.pk)
+        deleted.delete()
+
+        clean_orphaned_object_permissions.send()
+
+        self.assertFalse(RoleObjectPermission.objects.filter(object_pk=deleted_pk).exists())
+        self.assertTrue(RoleObjectPermission.objects.filter(object_pk=str(kept.pk)).exists())
+        self.assertTrue(
+            RoleModelPermission.objects.filter(
+                role=self.role,
+                permission__codename="view_role",
+            ).exists()
+        )


### PR DESCRIPTION
Relates to #25373