### PR TITLE
web: show pre-selected value in paginated search-selects

### DIFF
--- a/web/src/admin/flows/StageBindingForm.ts
+++ b/web/src/admin/flows/StageBindingForm.ts
@@ -140,9 +140,6 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                             args.search = query;
                         }
                         const stages = await aki(StagesApi).stagesAllList(args);
-                        // The list is paginated, so the currently-bound stage may not appear on
-                        // the first page. Merge it in so it renders as selected without the user
-                        // having to search for it first.
                         const selectedStage = this.instance?.stageObj;
                         if (
                             selectedStage &&

--- a/web/src/admin/flows/StageBindingForm.ts
+++ b/web/src/admin/flows/StageBindingForm.ts
@@ -140,6 +140,16 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                             args.search = query;
                         }
                         const stages = await aki(StagesApi).stagesAllList(args);
+                        // The list is paginated, so the currently-bound stage may not appear on
+                        // the first page. Merge it in so it renders as selected without the user
+                        // having to search for it first.
+                        const selectedStage = this.instance?.stageObj;
+                        if (
+                            selectedStage &&
+                            !stages.results.some((stage) => stage.pk === selectedStage.pk)
+                        ) {
+                            return [selectedStage, ...stages.results];
+                        }
                         return stages.results;
                     }}
                     .groupBy=${(items: Stage[]) => {

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -193,6 +193,16 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                             args.search = query;
                         }
                         const policies = await aki(PoliciesApi).policiesAllList(args);
+                        // The list is paginated, so the currently-bound policy may not appear on
+                        // the first page. Merge it in so it renders as selected without the user
+                        // having to search for it first.
+                        const selectedPolicy = this.instance?.policyObj;
+                        if (
+                            selectedPolicy &&
+                            !policies.results.some((policy) => policy.pk === selectedPolicy.pk)
+                        ) {
+                            return [selectedPolicy, ...policies.results];
+                        }
                         return policies.results;
                     }}
                     .renderElement=${(policy: Policy) => policy.name}
@@ -222,6 +232,17 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                             args.search = query;
                         }
                         const groups = await aki(CoreApi).coreGroupsList(args);
+                        // The list is paginated, so the currently-bound group may not appear on
+                        // the first page. Merge it in so it renders as selected without the user
+                        // having to search for it first. The binding carries a PartialGroup, which
+                        // exposes every field this selector reads (pk, name).
+                        const selectedGroup = this.instance?.groupObj;
+                        if (
+                            selectedGroup &&
+                            !groups.results.some((group) => group.pk === selectedGroup.pk)
+                        ) {
+                            return [selectedGroup as Group, ...groups.results];
+                        }
                         return groups.results;
                     }}
                     .renderElement=${(group: Group): string => {
@@ -252,6 +273,17 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                             args.search = query;
                         }
                         const users = await aki(CoreApi).coreUsersList(args);
+                        // The list is paginated, so the currently-bound user may not appear on
+                        // the first page. Merge it in so it renders as selected without the user
+                        // having to search for it first. The binding carries a PartialUser, which
+                        // exposes every field this selector reads (pk, username, name).
+                        const selectedUser = this.instance?.userObj;
+                        if (
+                            selectedUser &&
+                            !users.results.some((user) => user.pk === selectedUser.pk)
+                        ) {
+                            return [selectedUser as User, ...users.results];
+                        }
                         return users.results;
                     }}
                     .renderElement=${(user: User) => user.username}

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -193,9 +193,6 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                             args.search = query;
                         }
                         const policies = await aki(PoliciesApi).policiesAllList(args);
-                        // The list is paginated, so the currently-bound policy may not appear on
-                        // the first page. Merge it in so it renders as selected without the user
-                        // having to search for it first.
                         const selectedPolicy = this.instance?.policyObj;
                         if (
                             selectedPolicy &&
@@ -232,10 +229,6 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                             args.search = query;
                         }
                         const groups = await aki(CoreApi).coreGroupsList(args);
-                        // The list is paginated, so the currently-bound group may not appear on
-                        // the first page. Merge it in so it renders as selected without the user
-                        // having to search for it first. The binding carries a PartialGroup, which
-                        // exposes every field this selector reads (pk, name).
                         const selectedGroup = this.instance?.groupObj;
                         if (
                             selectedGroup &&
@@ -273,10 +266,6 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                             args.search = query;
                         }
                         const users = await aki(CoreApi).coreUsersList(args);
-                        // The list is paginated, so the currently-bound user may not appear on
-                        // the first page. Merge it in so it renders as selected without the user
-                        // having to search for it first. The binding carries a PartialUser, which
-                        // exposes every field this selector reads (pk, username, name).
                         const selectedUser = this.instance?.userObj;
                         if (
                             selectedUser &&


### PR DESCRIPTION
This PR fixes an issue where editing a policy or stage binding would show an empty selector instead of the currently bound object.

`ak-search-select` only auto-selects an object that appears in the fetched API page. Those lists are paginated (~20/page), so when the bound policy/stage sorts onto a later page, `.selected` never matched it and the field rendered blank — the value only appeared after the user typed enough to pull it into the list.

The fix merges the binding instance's embedded object (`policyObj` / `stageObj` / `groupObj` / `userObj`) into the fetched results when the current page doesn't already include it, so the selection renders immediately. This mirrors the existing pattern in `TokenForm`. Applied to the policy, group, and user selectors in `PolicyBindingForm` and the stage selector in `StageBindingForm`.

Fixes #25406
