### PR TITLE
web/elements: render selected value in ak-search-select regardless of page

### DIFF
--- a/web/src/admin/flows/StageBindingForm.ts
+++ b/web/src/admin/flows/StageBindingForm.ts
@@ -140,13 +140,6 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                             args.search = query;
                         }
                         const stages = await aki(StagesApi).stagesAllList(args);
-                        const selectedStage = this.instance?.stageObj;
-                        if (
-                            selectedStage &&
-                            !stages.results.some((stage) => stage.pk === selectedStage.pk)
-                        ) {
-                            return [selectedStage, ...stages.results];
-                        }
                         return stages.results;
                     }}
                     .groupBy=${(items: Stage[]) => {
@@ -159,6 +152,7 @@ export class StageBindingForm extends ModelForm<FlowStageBinding, string> {
                     .selected=${(stage: Stage): boolean => {
                         return stage.pk === this.instance?.stage;
                     }}
+                    .selectedObject=${this.instance?.stageObj ?? null}
                 >
                 </ak-search-select>
             </ak-form-element-horizontal>

--- a/web/src/admin/policies/PolicyBindingForm.ts
+++ b/web/src/admin/policies/PolicyBindingForm.ts
@@ -193,18 +193,12 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                             args.search = query;
                         }
                         const policies = await aki(PoliciesApi).policiesAllList(args);
-                        const selectedPolicy = this.instance?.policyObj;
-                        if (
-                            selectedPolicy &&
-                            !policies.results.some((policy) => policy.pk === selectedPolicy.pk)
-                        ) {
-                            return [selectedPolicy, ...policies.results];
-                        }
                         return policies.results;
                     }}
                     .renderElement=${(policy: Policy) => policy.name}
                     .value=${(policy: Policy | null) => policy?.pk}
                     .selected=${(policy: Policy) => policy.pk === this.instance?.policy}
+                    .selectedObject=${this.instance?.policyObj ?? null}
                     blankable
                 >
                 </ak-search-select>
@@ -229,13 +223,6 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                             args.search = query;
                         }
                         const groups = await aki(CoreApi).coreGroupsList(args);
-                        const selectedGroup = this.instance?.groupObj;
-                        if (
-                            selectedGroup &&
-                            !groups.results.some((group) => group.pk === selectedGroup.pk)
-                        ) {
-                            return [selectedGroup as Group, ...groups.results];
-                        }
                         return groups.results;
                     }}
                     .renderElement=${(group: Group): string => {
@@ -243,6 +230,7 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                     }}
                     .value=${(group: Group | null) => String(group?.pk ?? "")}
                     .selected=${(group: Group) => group.pk === this.instance?.group}
+                    .selectedObject=${(this.instance?.groupObj ?? null) as Group | null}
                     blankable
                 >
                 </ak-search-select>
@@ -266,19 +254,13 @@ export class PolicyBindingForm<T extends PolicyBinding = PolicyBinding> extends 
                             args.search = query;
                         }
                         const users = await aki(CoreApi).coreUsersList(args);
-                        const selectedUser = this.instance?.userObj;
-                        if (
-                            selectedUser &&
-                            !users.results.some((user) => user.pk === selectedUser.pk)
-                        ) {
-                            return [selectedUser as User, ...users.results];
-                        }
                         return users.results;
                     }}
                     .renderElement=${(user: User) => user.username}
                     .renderDescription=${(user: User) => html`${user.name}`}
                     .value=${(user: User | null) => user?.pk}
                     .selected=${(user: User) => user.pk === this.instance?.user}
+                    .selectedObject=${(this.instance?.userObj ?? null) as User | null}
                     blankable
                 >
                 </ak-search-select>

--- a/web/src/admin/tokens/TokenForm.ts
+++ b/web/src/admin/tokens/TokenForm.ts
@@ -120,17 +120,7 @@ export class TokenForm extends ModelForm<Token, string> {
                         }
 
                         const users = await aki(CoreApi).coreUsersList(args);
-                        const instanceUser = this.instance?.userObj ?? this.defaultUser;
-
-                        if (!instanceUser) {
-                            return users.results;
-                        }
-
-                        if (users.results.find((user) => user.pk === instanceUser.pk)) {
-                            return users.results;
-                        }
-
-                        return [instanceUser, ...users.results];
+                        return users.results;
                     }}
                     .renderElement=${(user: User): string => {
                         return user.username;
@@ -148,6 +138,7 @@ export class TokenForm extends ModelForm<Token, string> {
 
                         return this.defaultUser?.pk === user.pk;
                     }}
+                    .selectedObject=${this.instance?.userObj ?? this.defaultUser}
                 >
                 </ak-search-select>
             </ak-form-element-horizontal>

--- a/web/src/elements/forms/SearchSelect/SearchSelect.ts
+++ b/web/src/elements/forms/SearchSelect/SearchSelect.ts
@@ -358,8 +358,29 @@ export abstract class SearchSelectBase<T>
         this.dispatchChangeEvent(this.selectedObject);
     }
 
+    /**
+     * The objects to render as options. The current selection is included even when the fetched
+     * page does not contain it (e.g. a paginated list where the selected item sorts onto a later
+     * page), so it always renders instead of falling back to the placeholder. Skipped while the
+     * user is actively searching, so a stale selection doesn't pin itself atop filtered results.
+     */
+    private get renderableObjects(): T[] {
+        const objects = [...(this.objects ?? [])];
+        const selected = this.selectedObject;
+
+        if (
+            !this.query &&
+            selected &&
+            !objects.some((object) => `${this.value(object)}` === `${this.value(selected)}`)
+        ) {
+            objects.unshift(selected);
+        }
+
+        return objects;
+    }
+
     private getGroupedItems(): GroupedOptions {
-        const groupedItems = this.groupBy(this.objects || []);
+        const groupedItems = this.groupBy(this.renderableObjects);
 
         const makeSearchTuples = (items: T[]): SelectOption[] =>
             items.map((item) => [


### PR DESCRIPTION
This PR generalizes the fix from #25609 (now merged) by moving it into the component, so new call sites don't have to remember to work around it.

`ak-search-select` only ever rendered options from the fetched API page, so a selected object that sorted onto a later page of a paginated list had no matching option and the field fell back to its placeholder. #25609 worked around this by merging the current value into each `fetchObjects` result — one copy per call site, easy to forget.

Instead, `getGroupedItems` now includes the component's own `selectedObject` as an option when the fetched page doesn't already contain it (skipped while the user is actively searching, so a stale selection doesn't pin itself atop filtered results). Call sites just pass the object they already have via `.selectedObject` and drop the bespoke merges:

- `PolicyBindingForm` — policy, group, user (removes the merges added in #25609)
- `StageBindingForm` — stage (removes the merge added in #25609)
- `TokenForm` — user (removes the older pre-existing merge)

`ak-provider-search-input` is intentionally left as-is: it has only a pk (no embedded object) and already fetches the single provider by id, which is the correct approach for that case.

Relates to #25406.
