### PR TITLE
core: recover from a desynced setup flag

### DIFF
--- a/authentik/core/setup/utils.py
+++ b/authentik/core/setup/utils.py
@@ -1,0 +1,45 @@
+"""Setup state helpers"""
+
+from structlog.stdlib import get_logger
+
+from authentik.core.apps import Setup
+
+LOGGER = get_logger()
+
+SETUP_FLOW_SLUG = "initial-setup"
+SETUP_ADMIN_USERNAME = "akadmin"
+
+
+def setup_flow_runnable() -> bool:
+    """Check whether the out-of-box-experience flow can still complete.
+
+    The flow locks itself to superusers once it has run, and its policies refuse to
+    plan it once akadmin has a password. Either state means the flow can no longer
+    take an instance through setup."""
+    from authentik.core.models import User
+    from authentik.flows.models import Flow, FlowAuthenticationRequirement
+
+    if Flow.objects.filter(
+        slug=SETUP_FLOW_SLUG, authentication=FlowAuthenticationRequirement.REQUIRE_SUPERUSER
+    ).exists():
+        return False
+    akadmin = User.objects.filter(username=SETUP_ADMIN_USERNAME).first()
+    return not (akadmin and akadmin.has_usable_password())
+
+
+def setup_complete() -> bool:
+    """Check whether this tenant has been set up.
+
+    Setup state is recorded in the tenant's flags, which live in the public schema,
+    while the objects the setup flow mutates live in the tenant schema. Restoring one
+    without the other (a partial backup, or a blueprint export applied to a fresh
+    database) leaves the flag unset on an instance that is demonstrably already set
+    up, which would otherwise strand every visitor on an unusable setup flow. Repair
+    the flag instead, matching the heuristic used by the 0058_setup migration."""
+    if Setup.get():
+        return True
+    if setup_flow_runnable():
+        return False
+    LOGGER.info("Setup flag is unset but setup can no longer run, marking tenant as set up")
+    Setup.set(True)
+    return True

--- a/authentik/core/setup/views.py
+++ b/authentik/core/setup/views.py
@@ -12,6 +12,8 @@ from structlog.stdlib import get_logger
 
 from authentik.blueprints.models import BlueprintInstance
 from authentik.core.apps import Setup
+from authentik.core.setup.utils import SETUP_FLOW_SLUG, setup_complete
+from authentik.flows.exceptions import FlowNonApplicableException
 from authentik.flows.models import Flow, FlowAuthenticationRequirement, in_memory_stage
 from authentik.flows.planner import FlowPlanner
 from authentik.flows.stage import StageView
@@ -34,15 +36,15 @@ def read_static(path: str) -> str | None:
 
 class SetupView(View):
 
-    setup_flow_slug = "initial-setup"
+    setup_flow_slug = SETUP_FLOW_SLUG
 
     def dispatch(self, request: HttpRequest, *args, **kwargs):
-        if request.method != HTTPMethod.HEAD and Setup.get():
+        if request.method != HTTPMethod.HEAD and setup_complete():
             return redirect(reverse("authentik_core:root-redirect"))
         return super().dispatch(request, *args, **kwargs)
 
     def head(self, request: HttpRequest, *args, **kwargs):
-        if Setup.get():
+        if setup_complete():
             return HttpResponse(status=HTTPStatus.SERVICE_UNAVAILABLE)
         if not Flow.objects.filter(slug=self.setup_flow_slug).exists():
             return HttpResponse(status=HTTPStatus.SERVICE_UNAVAILABLE)
@@ -57,7 +59,14 @@ class SetupView(View):
                 status=HTTPStatus.SERVICE_UNAVAILABLE,
             )
         planner = FlowPlanner(flow)
-        plan = planner.plan(request, {FLOW_CONTEXT_START_BY: "setup"})
+        try:
+            plan = planner.plan(request, {FLOW_CONTEXT_START_BY: "setup"})
+        except FlowNonApplicableException:
+            # The setup flow cannot run, but setup_complete() did not recognize this
+            # instance as set up. Send the visitor somewhere usable rather than
+            # rendering an error at the root of the instance.
+            LOGGER.warning("Setup flow is not applicable, redirecting to authentication")
+            return redirect(reverse("authentik_flows:default-authentication"))
         plan.append_stage(in_memory_stage(PostSetupStageView))
         return plan.to_redirect(request, flow)
 
@@ -86,7 +95,7 @@ class PostSetupStageView(StageView):
                 **{"metadata__labels__blueprints.goauthentik.io/system-oobe": "true"}
             ).update(enabled=False)
             # Make flow inaccessible
-            Flow.objects.filter(slug="initial-setup").update(
+            Flow.objects.filter(slug=SETUP_FLOW_SLUG).update(
                 authentication=FlowAuthenticationRequirement.REQUIRE_SUPERUSER
             )
         return self.executor.stage_ok()

--- a/authentik/core/tests/test_setup.py
+++ b/authentik/core/tests/test_setup.py
@@ -9,7 +9,7 @@ from rest_framework.exceptions import ValidationError
 from authentik.blueprints.tests import apply_blueprint
 from authentik.core.apps import Setup
 from authentik.core.models import Token, TokenIntents, User
-from authentik.flows.models import Flow
+from authentik.flows.models import Flow, FlowAuthenticationRequirement
 from authentik.flows.tests import FlowTestCase
 from authentik.lib.generators import generate_id
 from authentik.root.signals import post_startup, pre_startup
@@ -74,6 +74,66 @@ class TestSetup(FlowTestCase):
         self.assertRedirects(
             res,
             reverse("authentik_core:if-flow", kwargs={"flow_slug": "initial-setup"}),
+            fetch_redirect_response=False,
+        )
+
+    @patch_flag(Setup, False)
+    @apply_blueprint("default/flow-oobe.yaml")
+    @apply_blueprint("system/bootstrap.yaml")
+    def test_setup_flag_lost_flow_locked(self):
+        """The setup flag can be lost while the tenant schema still shows a completed
+        setup, for example when a blueprint export is applied to a fresh database. The
+        flag is repaired instead of stranding visitors on the setup flow."""
+        Flow.objects.filter(slug="initial-setup").update(
+            authentication=FlowAuthenticationRequirement.REQUIRE_SUPERUSER
+        )
+
+        res = self.client.get(reverse("authentik_core:root-redirect"))
+        self.assertEqual(res.status_code, HTTPStatus.FOUND)
+        self.assertRedirects(
+            res,
+            reverse("authentik_flows:default-authentication") + "?next=/",
+            fetch_redirect_response=False,
+        )
+        self.assertTrue(Setup.get())
+
+        res = self.client.head(reverse("authentik_core:setup"))
+        self.assertEqual(res.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    @patch_flag(Setup, False)
+    @apply_blueprint("default/flow-oobe.yaml")
+    @apply_blueprint("system/bootstrap.yaml")
+    def test_setup_flag_lost_password_set(self):
+        """akadmin having a usable password means the setup flow's policies will refuse
+        to plan it, so the instance counts as set up even with the flow unlocked."""
+        user = User.objects.get(username="akadmin")
+        user.set_password(generate_id())
+        user.save()
+
+        res = self.client.get(reverse("authentik_core:setup"))
+        self.assertEqual(res.status_code, HTTPStatus.FOUND)
+        self.assertRedirects(
+            res,
+            reverse("authentik_core:root-redirect"),
+            fetch_redirect_response=False,
+        )
+        self.assertTrue(Setup.get())
+
+    @patch_flag(Setup, False)
+    @apply_blueprint("default/flow-oobe.yaml")
+    @apply_blueprint("system/bootstrap.yaml")
+    def test_setup_flow_non_applicable(self):
+        """A setup flow that cannot be planned redirects to authentication rather than
+        raising, so the root of the instance stays usable."""
+        Flow.objects.filter(slug="initial-setup").update(
+            authentication=FlowAuthenticationRequirement.REQUIRE_AUTHENTICATED
+        )
+
+        res = self.client.get(reverse("authentik_core:setup"))
+        self.assertEqual(res.status_code, HTTPStatus.FOUND)
+        self.assertRedirects(
+            res,
+            reverse("authentik_flows:default-authentication"),
             fetch_redirect_response=False,
         )
 

--- a/authentik/core/views/interface.py
+++ b/authentik/core/views/interface.py
@@ -15,8 +15,8 @@ from authentik.admin.tasks import LOCAL_VERSION
 from authentik.api.v3.config import ConfigView
 from authentik.brands.api import CurrentBrandSerializer
 from authentik.brands.models import Brand
-from authentik.core.apps import Setup
 from authentik.core.models import UserTypes
+from authentik.core.setup.utils import setup_complete
 from authentik.lib.config import CONFIG
 from authentik.policies.denied import AccessDeniedResponse
 
@@ -42,7 +42,7 @@ class RootRedirectView(AccessMixin, RedirectView):
         return None
 
     def dispatch(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        if not Setup.get():
+        if not setup_complete():
             return redirect("authentik_core:setup")
         if not request.user.is_authenticated:
             return self.handle_no_permission()


### PR DESCRIPTION
## Details

This PR fixes a situation where the OOBE flow leaves an instance unreachable at its root.

Setup completion is recorded in the tenant's flags, which live in the public schema, while everything the setup flow mutates — the `initial-setup` flow's authentication requirement, akadmin's password — lives in the tenant schema. Restore one without the other (a partial backup, or a blueprint export from a configured instance applied to a fresh database) and the flag reads "not set up" on an instance that already is.

In that state `RootRedirectView` sends every visitor at `/` to `/setup`, which plans a flow that is then refused, raising a bare `FlowNonApplicableException`. The instance serves `No exception message supplied` at its root and offers no route to the login screen.

`setup_complete()` now falls back to the tenant schema when the flag is unset, reusing the heuristic `0058_setup` already applies at upgrade time, and repairs the flag. `SetupView` also catches `FlowNonApplicableException` and redirects to authentication, so any future desync degrades to a login page rather than an error.