### PR TITLE
website/docs: document password reset behavior for inactive users

### DIFF
--- a/website/docs/add-secure-apps/flows-stages/flow/flows.mdx
+++ b/website/docs/add-secure-apps/flows-stages/flow/flows.mdx
@@ -72,6 +72,12 @@ Flow: right-click <DownloadLink to="/blueprints/example/flows-recovery-email-mfa
 
 With this recovery flow, the user is sent an email after they've identified themselves. After they click the link in the email, they must verify their configured MFA device, and are prompted for a new password and immediately logged in.
 
+:::warning Inactive users
+Recovery flows do not automatically reject inactive users. Stages such as the Email and User Write stages can still send a recovery email and change the password of an inactive user. A later User Login stage rejects an inactive user, but it does not prevent the earlier recovery actions.
+
+The example recovery blueprints enable **Activate user on success** on the Email stage. As a result, opening a valid recovery link reactivates the user. Disable this setting if reactivation must remain an administrative action. To prevent inactive users from proceeding through recovery, add an explicit policy and Deny stage after identification and before the Email stage. This denial produces a different response for inactive users and can disclose account state. For details, see [Block password recovery for inactive users](../stages/deny/index.mdx#example-block-password-recovery-for-inactive-users).
+:::
+
 There's also <DownloadLink to="/blueprints/example/flows-recovery-email-verification.yaml">a version</DownloadLink> of this flow available without MFA validation at `example/flows-recovery-email-verification.yaml`, which is not recommended.
 
 ## User deletion

--- a/website/docs/add-secure-apps/flows-stages/stages/deny/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/deny/index.mdx
@@ -43,3 +43,31 @@ return ak_client_ip in ip_network("203.0.113.0/24")
 3. Bind that policy to the Deny stage in the flow.
 
 When the policy passes, the Deny stage runs and the flow stops immediately.
+
+### Example: Block password recovery for inactive users
+
+Account deactivation prevents authentication, but it does not automatically prevent recovery stages from sending email or changing a password. To stop inactive users before those actions occur:
+
+1. Add a Deny stage to the recovery flow after the Identification stage and before the Email stage.
+2. Create an [Expression policy](../../../../customize/policies/types/expression/index.mdx) with the following expression:
+
+    ```python
+    pending_user = request.context.get("pending_user")
+
+    return bool(
+        pending_user
+        and pending_user.pk
+        and not pending_user.is_active
+    )
+    ```
+
+3. Bind the policy to the Deny stage binding.
+4. On the Deny stage binding, disable **Evaluate when flow is planned** and enable **Evaluate when stage is run**. The policy must run after the Identification stage adds `pending_user` to the flow context.
+
+The Deny stage runs only when the identified user exists and is inactive. Active users and placeholder users that represent unknown identifiers skip the Deny stage.
+
+:::danger Account state disclosure
+The Deny stage produces a different response for an inactive account than the **Email sent.** challenge that the Email stage displays for unknown and active accounts. An attacker can use this difference to determine that an account exists or is inactive.
+
+Use this configuration only if disclosing account state is acceptable. A Deny stage cannot both stop recovery and preserve the Email stage's indistinguishable response.
+:::

--- a/website/docs/add-secure-apps/flows-stages/stages/email/index.mdx
+++ b/website/docs/add-secure-apps/flows-stages/stages/email/index.mdx
@@ -26,7 +26,7 @@ When an email cannot be delivered immediately, authentik retries delivery throug
 - **From address**: sender address used for flow emails.
 - **Account Recovery Max Attempts**: maximum number of recovery emails allowed in the configured time window.
 - **Account Recovery Cache Timeout**: time window used for recovery-email rate limiting.
-- **Activate user on success**: activate the user after the stage succeeds.
+- **Activate user on success**: set the identified user's `is_active` state to `True` after they return with a valid email token. In a recovery flow, this setting allows an inactive user to reactivate their account through email verification. Disable this setting if reactivation must remain an administrative action. Disabling it does not prevent the user from receiving a recovery email or changing their password.
 - **Token expiry**: how long the email token remains valid.
 - **Subject**: subject line used for the email.
 - **Template**: template used to render the email body.
@@ -59,6 +59,14 @@ return True
 ### Rate limiting
 
 The recovery rate-limiting fields only affect recovery-style email sends. They limit how many recent attempts a user can trigger within the configured time window.
+
+### Recovery and account enumeration
+
+When an Identification stage does not find a user, it can create a placeholder user if **Pretend user exists** is enabled. In a recovery flow, the Email stage shows the same **Email sent.** challenge for this placeholder user without sending an email or creating a recovery token. This behavior prevents the recovery response from disclosing whether the identifier belongs to an account.
+
+An existing inactive user is not a placeholder user. By default, the Email stage sends that user a recovery email and creates a recovery token. Deactivating an account prevents authentication, but it does not automatically prevent the user from recovering their account.
+
+You can use a policy bound to a Deny stage to block inactive users before the Email stage. However, the denial response differs from the response for an unknown or active account and can disclose whether an account exists or is inactive. For configuration details and this security tradeoff, see [Block password recovery for inactive users](../deny/index.mdx#example-block-password-recovery-for-inactive-users).
 
 ### Custom templates
 


### PR DESCRIPTION
## Details

### What does this PR change?

Adds notes to docs about inactive users being reactivated by recovery flow/password reset depending on settings.

### Why is this change needed?

### How was this tested?

### Linked issues

Closes #18391

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
