### PR TITLE
website/docs: oauth/oidc: document cloudflare browser integrity check and endpoint availability

### DIFF
--- a/website/docs/add-secure-apps/providers/oauth2/index.mdx
+++ b/website/docs/add-secure-apps/providers/oauth2/index.mdx
@@ -70,6 +70,14 @@ sequenceDiagram
 Because of how the OAuth 2.0 provider endpoints are structured, you cannot create applications with the slugs `authorize`, `token`, `device`, `userinfo`, `introspect`, or `revoke`. These slugs conflict with the global OAuth 2.0 endpoints.
 :::
 
+### Reverse proxy and firewall access
+
+OAuth 2.0 and OIDC clients access some endpoints directly from the application server instead of through a user's browser. Ensure that reverse proxies, content delivery networks (CDNs), web application firewalls, and bot protection services permit these server-to-server requests. Interactive challenges on endpoints such as the OpenID configuration and JWKS endpoints can prevent clients from validating tokens and can cause repeated authentication redirects.
+
+If an endpoint returns `403 Forbidden`, inspect the proxy or firewall logs. For example, Cloudflare [Browser Integrity Check](https://developers.cloudflare.com/waf/tools/browser-integrity-check/) can reject clients that use non-standard user agents. Configure a narrowly scoped Cloudflare configuration rule or custom skip rule for the affected endpoint. Do not disable security controls for the entire authentik deployment.
+
+The JWKS endpoint is intentionally publicly accessible and contains public keys that clients use to verify tokens. It does not expose the private signing key.
+
 ### Cross-provider token introspection and revocation
 
 The token introspection and revocation endpoints are global OAuth 2.0 endpoints, but access to tokens is still scoped by provider. A client can introspect or revoke tokens issued by the same OAuth2 provider that authenticated the request.


### PR DESCRIPTION
# Details

### What does this PR change?

Added guidance for ensuring that reverse proxies and firewalls allow server-to-server OAuth/OIDC requests, including how to address Cloudflare Browser Integrity Check failures.

### Why is this change needed?

### How was this tested?

### Linked issues

Closes #8005 

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
