### PR TITLE
web: preserve custom event action labels

### DIFF
--- a/web/src/common/labels.ts
+++ b/web/src/common/labels.ts
@@ -72,10 +72,10 @@ export const EventActionLabelRecord: Record<EventActions, MessageFormatter<strin
     [EventActions.Custom]: () => msg("Custom action"),
 };
 
-export function actionToLabel(action?: EventActions): string {
-    const formatter = action ? EventActionLabelRecord[action] : null;
+export function actionToLabel(action?: string): string {
+    const formatter = action ? EventActionLabelRecord[action as EventActions] : null;
 
-    return formatter?.() || "";
+    return formatter?.() ?? action ?? "";
 }
 
 const SeverityEnumLabelRecord: Record<SeverityEnum, MessageFormatter<string>> = {

--- a/web/test/unit/labels.test.ts
+++ b/web/test/unit/labels.test.ts
@@ -1,0 +1,23 @@
+import { actionToLabel } from "#common/labels";
+
+import { EventActions } from "@goauthentik/api";
+
+import { describe, expect, it } from "vitest";
+
+describe("actionToLabel", () => {
+    it("returns the translated label for a known action", () => {
+        expect(actionToLabel(EventActions.Login)).toBe("Login");
+    });
+
+    it("returns a prefixed custom action unchanged", () => {
+        expect(actionToLabel("custom_example_action")).toBe("custom_example_action");
+    });
+
+    it("returns an arbitrary action unchanged", () => {
+        expect(actionToLabel("Example Custom Action")).toBe("Example Custom Action");
+    });
+
+    it("returns an empty string when the action is missing", () => {
+        expect(actionToLabel()).toBe("");
+    });
+});


### PR DESCRIPTION
## Summary
Restore the raw action fallback when displaying unrecognized event actions in the web UI.
ak_create_event("foo") creates an event with the action custom_foo. After the event label localization refactor in #23063, actions not present in the frontend’s generated enum map rendered as blank titles.
This change:
- Preserves translated labels for recognized built-in actions.
- Displays custom_foo and other unrecognized actions using their raw values.
- Keeps missing actions rendered as an empty string.
- Broadens the formatter input to reflect the arbitrary strings the API can return at runtime.

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [ ] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
