### PR TITLE
packages/django-dramatiq-postgres: prevent crashing consumer thread on schedules with unknown actors

### DIFF
--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/models.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/models.py
@@ -14,11 +14,15 @@ from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 from dramatiq.actor import Actor
 from dramatiq.broker import Broker, get_broker
+from dramatiq.errors import ActorNotFound
 from dramatiq.message import Message
+from structlog.stdlib import get_logger
 
 from django_dramatiq_postgres.conf import Conf
 
 CHANNEL_PREFIX = f"{Conf().channel_prefix}.tasks"
+
+LOGGER = get_logger()
 
 
 class ChannelIdentifier(StrEnum):
@@ -164,9 +168,21 @@ class ScheduleBase(models.Model):
         if schedule:
             schedule.send()
 
-    def send(self, broker: Broker | None = None) -> Message[Any]:
+    def send(self, broker: Broker | None = None) -> Message[Any] | None:
         broker = broker or get_broker()
-        actor: Actor[Any, Any] = broker.get_actor(self.actor_name)
+        try:
+            actor: Actor[Any, Any] = broker.get_actor(self.actor_name)
+        except ActorNotFound:
+            # Schedule references an actor that no longer exists. Pause it instead
+            # of raising; schedule reconciliation on startup will clean it up.
+            LOGGER.warning(
+                "Actor for schedule not found, pausing schedule",
+                schedule=self,
+                actor_name=self.actor_name,
+            )
+            self.paused = True
+            self.save(update_fields=["paused"])
+            return None
         return actor.send_with_options(
             args=pickle.loads(self.args),  # nosec
             kwargs=pickle.loads(self.kwargs),  # nosec

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/scheduler.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/scheduler.py
@@ -6,6 +6,7 @@ from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 from django.utils.timezone import now
 from dramatiq.broker import Broker
+from dramatiq.errors import ActorNotFound
 from structlog.stdlib import get_logger
 
 from django_dramatiq_postgres.conf import Conf
@@ -36,7 +37,20 @@ class Scheduler:
 
     def process_schedule(self, schedule: ScheduleBase) -> None:
         schedule.next_run = schedule.compute_next_run()
-        schedule.send(self.broker)
+        try:
+            schedule.send(self.broker)
+        except ActorNotFound:
+            # Schedule references an actor that no longer exists. Pause it instead
+            # of crashing the consumer thread; schedule reconciliation on startup
+            # will clean it up.
+            self.logger.warning(
+                "Actor for schedule not found, pausing schedule",
+                schedule=schedule,
+                actor_name=schedule.actor_name,
+            )
+            schedule.paused = True
+            schedule.save(update_fields=["paused"])
+            return
         schedule.save(update_fields=["next_run"])
 
     def _lock(self) -> pglock.advisory:

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/scheduler.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/scheduler.py
@@ -6,7 +6,6 @@ from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 from django.utils.timezone import now
 from dramatiq.broker import Broker
-from dramatiq.errors import ActorNotFound
 from structlog.stdlib import get_logger
 
 from django_dramatiq_postgres.conf import Conf
@@ -37,19 +36,9 @@ class Scheduler:
 
     def process_schedule(self, schedule: ScheduleBase) -> None:
         schedule.next_run = schedule.compute_next_run()
-        try:
-            schedule.send(self.broker)
-        except ActorNotFound:
-            # Schedule references an actor that no longer exists. Pause it instead
-            # of crashing the consumer thread; schedule reconciliation on startup
-            # will clean it up.
-            self.logger.warning(
-                "Actor for schedule not found, pausing schedule",
-                schedule=schedule,
-                actor_name=schedule.actor_name,
-            )
-            schedule.paused = True
-            schedule.save(update_fields=["paused"])
+        schedule.send(self.broker)
+        if schedule.paused:
+            # send() paused the schedule because its actor doesn't exist
             return
         schedule.save(update_fields=["next_run"])
 


### PR DESCRIPTION
## Details
When a schedule references an unregistered actor, `Scheduler.process_schedule` raises `ActorNotFound`, which kills the dramatiq consumer thread. The worker process stays up and keeps passing health checks, but stops processing tasks entirely.

### What does this PR change?

Catch ActorNotFound in the scheduler, log a warning and pause the schedule instead. Reconciliation on the next startup removes the stale row.

### Linked issues

Closes #25535

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [ ] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
