### PR TITLE
policies/geoip: return details for failing impossible travel policies

### DIFF
--- a/authentik/policies/geoip/models.py
+++ b/authentik/policies/geoip/models.py
@@ -1,6 +1,7 @@
 """GeoIP policy"""
 
 from itertools import chain
+from math import isfinite
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -18,6 +19,37 @@ from authentik.policies.models import Policy
 from authentik.policies.types import PolicyRequest, PolicyResult
 
 MAX_DISTANCE_HOUR_KM = 1000
+MIN_LATITUDE = -90
+MAX_LATITUDE = 90
+MIN_LONGITUDE = -180
+MAX_LONGITUDE = 180
+
+
+def valid_coordinates(geoip_data: object) -> tuple[float, float] | None:
+    """Return valid latitude and longitude from GeoIP data."""
+    if not isinstance(geoip_data, dict):
+        return None
+    latitude = geoip_data.get("lat")
+    longitude = geoip_data.get("long")
+    if (
+        isinstance(latitude, bool)
+        or not isinstance(latitude, int | float)
+        or isinstance(longitude, bool)
+        or not isinstance(longitude, int | float)
+    ):
+        return None
+    try:
+        latitude = float(latitude)
+        longitude = float(longitude)
+    except OverflowError:
+        return None
+    if not isfinite(latitude) or not isfinite(longitude):
+        return None
+    if not MIN_LATITUDE <= latitude <= MAX_LATITUDE or not (
+        MIN_LONGITUDE <= longitude <= MAX_LONGITUDE
+    ):
+        return None
+    return latitude, longitude
 
 
 class GeoIPPolicy(Policy):
@@ -75,6 +107,10 @@ class GeoIPPolicy(Policy):
 
         result = PolicyResult(passing, *messages)
         result.source_results = list(chain(static_results, dynamic_results))
+        for source_result in dynamic_results:
+            if source_result.raw_result is not None:
+                result.raw_result = source_result.raw_result
+                break
 
         return result
 
@@ -113,45 +149,55 @@ class GeoIPPolicy(Policy):
     def passes_distance(self, request: PolicyRequest) -> PolicyResult:
         """Check if current policy execution is out of distance range compared
         to previous authentication requests"""
-        # Get previous login event and GeoIP data
         previous_logins = Event.objects.filter(
             action=EventAction.LOGIN,
-            user__pk=request.user.pk,  # context__geo__isnull=False
+            user__pk=request.user.pk,
         ).order_by("-created")[: self.history_login_count]
-        _now = now()
-        geoip_data: GeoIPDict | None = request.context.get("geoip")
-        if not geoip_data:
-            return PolicyResult(False)
-        if not previous_logins.exists():
+        current_coordinates = valid_coordinates(request.context.get("geoip"))
+        if current_coordinates is None:
             return PolicyResult(True)
-        result = False
+        current_time = now()
         for previous_login in previous_logins:
-            if "geo" not in previous_login.context:
+            previous_coordinates = valid_coordinates(previous_login.context.get("geo"))
+            if previous_coordinates is None:
                 continue
-            previous_login_geoip: GeoIPDict = previous_login.context["geo"]
 
-            # Figure out distance
-            dist = distance.geodesic(
-                (previous_login_geoip["lat"], previous_login_geoip["long"]),
-                (geoip_data["lat"], geoip_data["long"]),
-            )
+            dist = distance.geodesic(previous_coordinates, current_coordinates)
             if self.check_history_distance and dist.km >= (
                 self.history_max_distance_km + self.distance_tolerance_km
             ):
                 return PolicyResult(
                     False, _("Distance from previous authentication is larger than threshold.")
                 )
-            # Check if distance between `previous_login` and now is more
-            # than max distance per hour times the amount of hours since the previous login
-            # (round down to the lowest closest time of hours)
-            # clamped to be at least 1 hour
-            rel_time_hours = max(int((_now - previous_login.created).total_seconds() / 3600), 1)
-            if self.check_impossible_travel and dist.km >= (
-                (MAX_DISTANCE_HOUR_KM * rel_time_hours) + self.distance_tolerance_km
-            ):
-                return PolicyResult(False, _("Distance is further than possible."))
-            result = True
-        return PolicyResult(result)
+            elapsed_hours = max(
+                (current_time - previous_login.created).total_seconds() / 3600,
+                1.0,
+            )
+            allowed_distance_km = (
+                MAX_DISTANCE_HOUR_KM * elapsed_hours
+            ) + self.impossible_tolerance_km
+            if self.check_impossible_travel and dist.km >= allowed_distance_km:
+                result = PolicyResult(False, _("Distance is further than possible."))
+                result.raw_result = {
+                    "reason": "impossible_travel_threshold_exceeded",
+                    "distance_km": dist.km,
+                    "allowed_distance_km": allowed_distance_km,
+                    "elapsed_hours": elapsed_hours,
+                    "max_speed_km_per_hour": MAX_DISTANCE_HOUR_KM,
+                    "impossible_tolerance_km": self.impossible_tolerance_km,
+                    "previous_login_at": previous_login.created,
+                    "previous_login_event": previous_login.event_uuid,
+                    "current_geo": {
+                        "lat": current_coordinates[0],
+                        "long": current_coordinates[1],
+                    },
+                    "previous_geo": {
+                        "lat": previous_coordinates[0],
+                        "long": previous_coordinates[1],
+                    },
+                }
+                return result
+        return PolicyResult(True)
 
     class Meta(Policy.PolicyMeta):
         verbose_name = _("GeoIP Policy")

--- a/authentik/policies/geoip/tests.py
+++ b/authentik/policies/geoip/tests.py
@@ -1,5 +1,9 @@
 """geoip policy tests"""
 
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest import mock
+
 from django.test import TestCase
 
 from authentik.core.tests.utils import create_test_user
@@ -9,6 +13,8 @@ from authentik.policies.engine import PolicyRequest, PolicyResult
 from authentik.policies.exceptions import PolicyException
 from authentik.policies.geoip.exceptions import GeoIPNotFoundException
 from authentik.policies.geoip.models import GeoIPPolicy
+from authentik.policies.models import PolicyBinding
+from authentik.policies.process import PolicyProcess
 
 
 class TestGeoIPPolicy(TestCase):
@@ -48,6 +54,17 @@ class TestGeoIPPolicy(TestCase):
     def enrich_context(self):
         self.request.context["asn"] = self.context["asn"]
         self.request.context["geoip"] = self.context["geoip"]
+
+    def create_login(self, geo: object, created: datetime) -> Event:
+        """Create a login event at an explicit timestamp."""
+        event = Event.objects.create(
+            action=EventAction.LOGIN,
+            user=get_user(self.user),
+            context={"geo": geo},
+        )
+        Event.objects.filter(pk=event.pk).update(created=created)
+        event.refresh_from_db()
+        return event
 
     def test_disabled_geoip(self):
         """Test that disabled GeoIP raises PolicyException with GeoIPNotFoundException"""
@@ -129,102 +146,195 @@ class TestGeoIPPolicy(TestCase):
 
         self.assertTrue(result.passing)
 
-    def test_history(self):
-        """Test history checks"""
-        Event.objects.create(
-            action=EventAction.LOGIN,
-            user=get_user(self.user),
-            context={
-                # Random location in Canada
-                "geo": {"lat": 55.868351, "long": -104.441011},
-            },
-        )
-        # Random location in Poland
-        self.request.context["geoip"] = {"lat": 50.950613, "long": 20.363679}
-
-        policy = GeoIPPolicy.objects.create(check_history_distance=True)
-
-        result: PolicyResult = policy.passes(self.request)
-        self.assertFalse(result.passing)
-
-    def test_history_no_data(self):
-        """Test history checks (with no geoip data in context)"""
-        Event.objects.create(
-            action=EventAction.LOGIN,
-            user=get_user(self.user),
-            context={
-                # Random location in Canada
-                "geo": {"lat": 55.868351, "long": -104.441011},
-            },
+    def test_distance_missing_or_invalid_current_geoip(self):
+        """Missing and invalid current coordinates pass as not evaluable."""
+        policy = GeoIPPolicy.objects.create(check_impossible_travel=True)
+        invalid_geoip = (
+            None,
+            {},
+            {"lat": 0},
+            {"lat": "0", "long": 0},
+            {"lat": 0, "long": "0"},
+            {"lat": True, "long": 0},
+            {"lat": 91, "long": 0},
+            {"lat": 0, "long": -181},
+            {"lat": 10**1000, "long": 0},
+            {"lat": 0, "long": 10**1000},
+            {"lat": float("nan"), "long": 0},
+            {"lat": 0, "long": float("inf")},
         )
 
-        policy = GeoIPPolicy.objects.create(check_history_distance=True)
+        for geoip_data in invalid_geoip:
+            with self.subTest(geoip_data=geoip_data):
+                self.request.context["geoip"] = geoip_data
+                self.assertTrue(policy.passes(self.request).passing)
 
-        result: PolicyResult = policy.passes(self.request)
-        self.assertFalse(result.passing)
-
-    def test_history_impossible_travel_failing(self):
-        """Test history checks"""
-        Event.objects.create(
-            action=EventAction.LOGIN,
-            user=get_user(self.user),
-            context={
-                # Random location in Canada
-                "geo": {"lat": 55.868351, "long": -104.441011},
-            },
-        )
-        # Random location in Poland
-        self.request.context["geoip"] = {"lat": 50.950613, "long": 20.363679}
-
+    def test_distance_no_history(self):
+        """A distance policy passes when there is no login history."""
+        self.request.context["geoip"] = {"lat": 0, "long": 0}
         policy = GeoIPPolicy.objects.create(check_impossible_travel=True)
 
-        result: PolicyResult = policy.passes(self.request)
-        self.assertFalse(result.passing)
+        self.assertTrue(policy.passes(self.request).passing)
 
-    def test_history_impossible_travel_passing(self):
-        """Test history checks"""
-        Event.objects.create(
-            action=EventAction.LOGIN,
-            user=get_user(self.user),
-            context={
-                # Random location in Canada
-                "geo": {"lat": 55.868351, "long": -104.441011},
-            },
-        )
-        # Same location
-        self.request.context["geoip"] = {"lat": 55.868351, "long": -104.441011}
-
+    def test_distance_only_invalid_history(self):
+        """A distance policy passes when no historical coordinates are usable."""
+        current_time = datetime(2026, 1, 1, tzinfo=UTC)
+        for geo in (None, {}, {"lat": 0}, {"lat": 100, "long": 0}):
+            self.create_login(geo, current_time - timedelta(minutes=30))
+        self.request.context["geoip"] = {"lat": 0, "long": 0}
         policy = GeoIPPolicy.objects.create(check_impossible_travel=True)
 
-        result: PolicyResult = policy.passes(self.request)
-        self.assertTrue(result.passing)
+        with mock.patch("authentik.policies.geoip.models.now", return_value=current_time):
+            self.assertTrue(policy.passes(self.request).passing)
 
-    def test_history_no_geoip(self):
-        """Test history checks (previous login with no geoip data)"""
-        Event.objects.create(
-            action=EventAction.LOGIN,
-            user=get_user(self.user),
-            context={},
+    def test_distance_invalid_history_is_skipped(self):
+        """Invalid recent history does not hide an older impossible login."""
+        current_time = datetime(2026, 1, 1, tzinfo=UTC)
+        violating_login = self.create_login(
+            {"lat": 0, "long": 20}, current_time - timedelta(minutes=30)
         )
-        # Random location in Poland
-        self.request.context["geoip"] = {"lat": 50.950613, "long": 20.363679}
-
-        policy = GeoIPPolicy.objects.create(check_history_distance=True)
-
-        result: PolicyResult = policy.passes(self.request)
-        self.assertFalse(result.passing)
-
-    def test_impossible_travel_no_geoip(self):
-        """Test impossible travel checks (previous login with no geoip data)"""
-        Event.objects.create(
-            action=EventAction.LOGIN,
-            user=get_user(self.user),
-            context={},
-        )
-        # Random location in Poland
-        self.request.context["geoip"] = {"lat": 50.950613, "long": 20.363679}
-
+        self.create_login({"lat": "invalid", "long": 0}, current_time - timedelta(minutes=10))
+        self.request.context["geoip"] = {"lat": 0, "long": 0}
         policy = GeoIPPolicy.objects.create(check_impossible_travel=True)
 
-        result: PolicyResult = policy.passes(self.request)
+        with mock.patch("authentik.policies.geoip.models.now", return_value=current_time):
+            result = policy.passes(self.request)
+
         self.assertFalse(result.passing)
+        self.assertEqual(result.raw_result["previous_login_event"], violating_login.event_uuid)
+
+    def test_distance_checks_every_usable_login(self):
+        """A passing recent login does not hide an older impossible login."""
+        current_time = datetime(2026, 1, 1, tzinfo=UTC)
+        violating_login = self.create_login(
+            {"lat": 0, "long": 20}, current_time - timedelta(minutes=30)
+        )
+        self.create_login({"lat": 0, "long": 0}, current_time - timedelta(minutes=10))
+        self.request.context["geoip"] = {"lat": 0, "long": 0}
+        policy = GeoIPPolicy.objects.create(check_impossible_travel=True)
+
+        with mock.patch("authentik.policies.geoip.models.now", return_value=current_time):
+            result = policy.passes(self.request)
+
+        self.assertFalse(result.passing)
+        self.assertEqual(result.raw_result["previous_login_event"], violating_login.event_uuid)
+
+    def test_impossible_travel_same_location(self):
+        """Travel from the same location passes."""
+        current_time = datetime(2026, 1, 1, tzinfo=UTC)
+        self.create_login({"lat": 10, "long": 10}, current_time - timedelta(minutes=5))
+        self.request.context["geoip"] = {"lat": 10, "long": 10}
+        policy = GeoIPPolicy.objects.create(check_impossible_travel=True)
+
+        with mock.patch("authentik.policies.geoip.models.now", return_value=current_time):
+            self.assertTrue(policy.passes(self.request).passing)
+
+    def test_impossible_travel_uses_fractional_hours(self):
+        """An interval just below two hours is not floored to one hour."""
+        current_time = datetime(2026, 1, 1, tzinfo=UTC)
+        self.create_login({"lat": 0, "long": 18}, current_time - timedelta(minutes=119))
+        self.request.context["geoip"] = {"lat": 0, "long": 0}
+        policy = GeoIPPolicy.objects.create(
+            check_impossible_travel=True, impossible_tolerance_km=100
+        )
+
+        with mock.patch("authentik.policies.geoip.models.now", return_value=current_time):
+            self.assertTrue(policy.passes(self.request).passing)
+
+    def test_impossible_travel_one_hour_minimum_and_boundary(self):
+        """Short intervals use one hour and equality rejects travel."""
+        current_time = datetime(2026, 1, 1, tzinfo=UTC)
+        self.create_login({"lat": 0, "long": 10}, current_time - timedelta(minutes=30))
+        self.request.context["geoip"] = {"lat": 0, "long": 0}
+        policy = GeoIPPolicy.objects.create(
+            check_impossible_travel=True, impossible_tolerance_km=100
+        )
+
+        with (
+            mock.patch("authentik.policies.geoip.models.now", return_value=current_time),
+            mock.patch(
+                "authentik.policies.geoip.models.distance.geodesic",
+                return_value=SimpleNamespace(km=1100),
+            ),
+        ):
+            result = policy.passes(self.request)
+
+        self.assertFalse(result.passing)
+        self.assertEqual(result.raw_result["elapsed_hours"], 1.0)
+        self.assertEqual(result.raw_result["allowed_distance_km"], 1100)
+
+    def test_distance_checks_use_separate_tolerances(self):
+        """History and impossible-travel checks use their dedicated tolerances."""
+        current_time = datetime(2026, 1, 1, tzinfo=UTC)
+        self.create_login({"lat": 0, "long": 10}, current_time - timedelta(minutes=30))
+        self.request.context["geoip"] = {"lat": 0, "long": 0}
+        history_policy = GeoIPPolicy.objects.create(
+            check_history_distance=True,
+            history_max_distance_km=1000,
+            distance_tolerance_km=200,
+        )
+        impossible_policy = GeoIPPolicy.objects.create(
+            check_impossible_travel=True,
+            distance_tolerance_km=500,
+            impossible_tolerance_km=0,
+        )
+
+        with mock.patch("authentik.policies.geoip.models.now", return_value=current_time):
+            self.assertTrue(history_policy.passes(self.request).passing)
+            self.assertFalse(impossible_policy.passes(self.request).passing)
+
+    def test_impossible_travel_diagnostics(self):
+        """A rejection identifies the historical event and threshold."""
+        current_time = datetime(2026, 1, 1, tzinfo=UTC)
+        previous_login = self.create_login(
+            {"lat": 0, "long": 20}, current_time - timedelta(minutes=30)
+        )
+        self.request.context["geoip"] = {"lat": 0, "long": 0}
+        policy = GeoIPPolicy.objects.create(
+            check_impossible_travel=True, impossible_tolerance_km=100
+        )
+
+        with mock.patch("authentik.policies.geoip.models.now", return_value=current_time):
+            result = policy.passes(self.request)
+
+        self.assertFalse(result.passing)
+        self.assertEqual(result.messages, ("Distance is further than possible.",))
+        self.assertEqual(result.raw_result["reason"], "impossible_travel_threshold_exceeded")
+        self.assertGreater(result.raw_result["distance_km"], 2200)
+        self.assertEqual(result.raw_result["allowed_distance_km"], 1100)
+        self.assertEqual(result.raw_result["elapsed_hours"], 1.0)
+        self.assertEqual(result.raw_result["max_speed_km_per_hour"], 1000)
+        self.assertEqual(result.raw_result["impossible_tolerance_km"], 100)
+        self.assertEqual(result.raw_result["previous_login_at"], previous_login.created)
+        self.assertEqual(result.raw_result["previous_login_event"], previous_login.event_uuid)
+        self.assertEqual(result.raw_result["current_geo"], {"lat": 0.0, "long": 0.0})
+        self.assertEqual(result.raw_result["previous_geo"], {"lat": 0.0, "long": 20.0})
+
+    def test_impossible_travel_diagnostics_in_execution_event(self):
+        """Execution logging retains sanitized impossible-travel diagnostics."""
+        current_time = datetime(2026, 1, 1, tzinfo=UTC)
+        previous_login = self.create_login(
+            {"lat": 0, "long": 20}, current_time - timedelta(minutes=30)
+        )
+        self.request.context["geoip"] = {"lat": 0, "long": 0}
+        policy = GeoIPPolicy.objects.create(
+            check_impossible_travel=True,
+            impossible_tolerance_km=100,
+            execution_logging=True,
+        )
+
+        with mock.patch("authentik.policies.geoip.models.now", return_value=current_time):
+            result = PolicyProcess(
+                PolicyBinding(policy=policy), self.request, connection=None
+            ).execute()
+
+        event = Event.objects.get(
+            action=EventAction.POLICY_EXECUTION,
+            context__policy_uuid=policy.policy_uuid.hex,
+        )
+        diagnostics = event.context["result"]["raw_result"]
+        self.assertFalse(result.passing)
+        self.assertEqual(diagnostics["reason"], "impossible_travel_threshold_exceeded")
+        self.assertEqual(diagnostics["previous_login_event"], previous_login.event_uuid.hex)
+        self.assertEqual(diagnostics["previous_login_at"], "2025-12-31T23:30:00Z")
+        self.assertEqual(diagnostics["allowed_distance_km"], 1100)

--- a/authentik/policies/geoip/tests.py
+++ b/authentik/policies/geoip/tests.py
@@ -269,11 +269,13 @@ class TestGeoIPPolicy(TestCase):
         self.create_login({"lat": 0, "long": 10}, current_time - timedelta(minutes=30))
         self.request.context["geoip"] = {"lat": 0, "long": 0}
         history_policy = GeoIPPolicy.objects.create(
+            name="history-distance-tolerance",
             check_history_distance=True,
             history_max_distance_km=1000,
             distance_tolerance_km=200,
         )
         impossible_policy = GeoIPPolicy.objects.create(
+            name="impossible-travel-tolerance",
             check_impossible_travel=True,
             distance_tolerance_km=500,
             impossible_tolerance_km=0,

--- a/website/docs/customize/policies/types/geoip.mdx
+++ b/website/docs/customize/policies/types/geoip.mdx
@@ -44,6 +44,10 @@ When distance checks are enabled, authentik evaluates the current login against 
 - **Check impossible travel**: enables an additional check based on travel speed between recent login events.
 - **Impossible travel tolerance**: an additional tolerance, in kilometers, added to the built-in impossible-travel allowance.
 
+The impossible-travel allowance is 1,000 kilometers for the first hour after a historical login. For longer intervals, authentik multiplies 1,000 kilometers by the precise number of elapsed hours, including fractional hours, and then adds the impossible travel tolerance.
+
+Distance checks require valid coordinates for both the current request and a historical login. authentik skips historical events without valid coordinates. If the current coordinates are unavailable, or none of the configured number of recent login events have valid coordinates, the distance checks pass because travel cannot be evaluated.
+
 ## Create a GeoIP policy
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.


### PR DESCRIPTION
## Summary
Fix GeoIP impossible-travel correctness and improve rejection diagnostics.
## Changes
- Treat missing or invalid coordinates as not evaluable instead of impossible travel.
- Skip historical login events without valid coordinates.
- Pass when no usable historical login events exist.
- Evaluate every usable login within the configured history.
- Use fractional elapsed hours while preserving the one-hour minimum.
- Use impossible_tolerance_km for impossible-travel checks.
- Add structured rejection diagnostics to PolicyResult.raw_result.
- Preserve diagnostics in policy execution events.
- Document the updated evaluation behavior.
## Behavior changes
- Missing GeoIP data now passes the distance portion of the policy because travel cannot be determined without two valid locations.
- Fractional hours remove abrupt allowance changes at whole-hour boundaries.
- Installations where distance_tolerance_km and impossible_tolerance_km differ may receive different results because the dedicated impossible-travel tolerance is now used.
## Testing
Added coverage for:
- Missing, malformed, non-finite, and out-of-range coordinates
- Missing or unusable login history
- Multiple historical logins
- Same-location travel
- Fractional elapsed hours
- The one-hour minimum and equality boundary
- Separate distance and impossible-travel tolerances
- Structured diagnostics and event serialization

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [ ] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
