### PR TITLE
core/api: accept and require user/group on source connection creation

### DIFF
--- a/authentik/core/api/sources.py
+++ b/authentik/core/api/sources.py
@@ -133,7 +133,6 @@ class UserSourceConnectionSerializer(SourceSerializer):
             "last_updated",
         ]
         extra_kwargs = {
-            "user": {"read_only": True},
             "created": {"read_only": True},
             "last_updated": {"read_only": True},
         }
@@ -174,7 +173,6 @@ class GroupSourceConnectionSerializer(SourceSerializer):
             "last_updated",
         ]
         extra_kwargs = {
-            "group": {"read_only": True},
             "created": {"read_only": True},
             "last_updated": {"read_only": True},
         }

--- a/authentik/sources/ldap/tests/test_api.py
+++ b/authentik/sources/ldap/tests/test_api.py
@@ -12,7 +12,11 @@ from authentik.blueprints.tests import apply_blueprint
 from authentik.core.tests.utils import create_test_admin_user, create_test_user
 from authentik.lib.generators import generate_id
 from authentik.sources.ldap.api.sources import LDAPSourceSerializer
-from authentik.sources.ldap.models import LDAPSource, LDAPSourcePropertyMapping
+from authentik.sources.ldap.models import (
+    LDAPSource,
+    LDAPSourcePropertyMapping,
+    UserLDAPSourceConnection,
+)
 from authentik.sources.ldap.tests.mock_ad import mock_ad_connection
 
 
@@ -139,6 +143,36 @@ class LDAPAPITests(APITestCase):
             additional_user_dn="ou=users",
             additional_group_dn="ou=groups",
         )
+
+
+    def test_user_connection_create(self):
+        """User connection creation: user is required and must be persisted (#25672/#25673)"""
+        user = create_test_admin_user()
+        self.client.force_login(user)
+        source = self._create_debug_source()
+        identifier = "S-1-5-21-3638675543-1746918860-1899855899-1109"
+        # Missing user must be rejected with 400, not crash with a 500
+        res = self.client.post(
+            reverse("authentik_api:userldapsourceconnection-list"),
+            data={
+                "source": str(source.pk),
+                "identifier": identifier,
+            },
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertIn("user", loads(res.content.decode()))
+        # A posted user must be accepted and persisted
+        res = self.client.post(
+            reverse("authentik_api:userldapsourceconnection-list"),
+            data={
+                "source": str(source.pk),
+                "identifier": identifier,
+                "user": user.pk,
+            },
+        )
+        self.assertEqual(res.status_code, 201)
+        connection = UserLDAPSourceConnection.objects.get(source=source)
+        self.assertEqual(connection.user, user)
 
     @apply_blueprint("system/sources-ldap.yaml")
     def test_debug_denied_for_anonymous(self):


### PR DESCRIPTION
> Built by breken, your AI support engineer - breken.ai - this one's on us.

## Problem

Creating an LDAP User Connection from the admin UI fails end to end: the UI collects the selected user, but the POST to `/api/v3/sources/user_connections/ldap/` arrives without `user`, and the API responds with a 500 instead of creating the connection or rejecting the request cleanly. (#25672, #25673)

## Root cause

`UserSourceConnectionSerializer` (and `GroupSourceConnectionSerializer`) in `authentik/core/api/sources.py` marked the `user` / `group` fields `read_only` via `extra_kwargs`. That one setting breaks both ends:

1. **The UI "drops" the field (#25672):** a read-only field never lands in the request schema, so `UserLDAPSourceConnectionRequest` in the generated API client has no `user` property. The admin form collects the selection, but the generated request serializer strips it before the request goes out.
2. **The API 500s (#25673):** with `user` read-only, DRF neither requires nor accepts it, so a create runs with no user and hits the database's `NOT NULL` constraint on `user_id` - `IntegrityError` up as a 500 instead of a 400 telling the caller what's missing.

## Fix

Remove the `read_only` override for `user` / `group` in the two base serializers. DRF then generates a normal required `PrimaryKeyRelatedField`:

- missing `user` -> `400 {"user": ["This field is required."]}` (no more 500)
- posted `user` -> validated against `User` and persisted

This also covers the kerberos, oauth, plex, saml, and telegram connection viewsets, which all build on the same base serializers and had the same latent crash.

`schema.yml` and the generated clients pick `user` / `group` up as writable, required fields on the next `make gen`; no frontend change is needed - the form already collects and submits the value.

## Evidence

New regression test `test_user_connection_create` in `authentik/sources/ldap/tests/test_api.py`:

- POST without `user` -> 400 with a `user` error (previously: 500 `IntegrityError`)
- POST with `user` -> 201 and the connection is persisted with that user

## Verified

- ✅ Missing `user` returns 400, not 500
- ✅ Posted `user` is validated and stored
- ✅ Group connections get the same fix via `GroupSourceConnectionSerializer`
- ⚠️ Full `make gen` client/schema regeneration left to CI

Happy to iterate if you'd like the read-only behavior kept for PATCH while still requiring it on create.