### PR TITLE
web/stages: Fix stage type errors

### DIFF
--- a/web/src/elements/forms/Form.ts
+++ b/web/src/elements/forms/Form.ts
@@ -684,7 +684,7 @@ export class Form<T = Record<string, unknown>, D = T>
     //#endregion
 
     //#region Lifecycle
-    public updated(changedProperties: PropertyValues<this>): void {
+    protected override updated(changedProperties: PropertyValues<this>): void {
         super.updated(changedProperties);
 
         if (changedProperties.has("size")) {

--- a/web/src/elements/messages/MessageContainer.ts
+++ b/web/src/elements/messages/MessageContainer.ts
@@ -157,7 +157,7 @@ export class MessageContainer extends AKElement {
         }
     };
 
-    public updated(changedProperties: PropertyValues<this>) {
+    protected override updated(changedProperties: PropertyValues<this>) {
         super.updated(changedProperties);
 
         if (changedProperties.has("messages") && this.messages.length) {

--- a/web/src/elements/sidebar/SidebarItem.ts
+++ b/web/src/elements/sidebar/SidebarItem.ts
@@ -85,7 +85,9 @@ export class SidebarItem extends WithCapabilitiesConfig(WithLicenseSummary(AKEle
         cancelAnimationFrame(this.#scrollAnimationFrame);
     }
 
-    public updated(changedProperties: PropertyValues): void {
+    protected override updated(changedProperties: PropertyValues): void {
+        super.updated(changedProperties);
+
         const previousExpanded = changedProperties.get("expanded");
 
         if (typeof previousExpanded !== "boolean") return;

--- a/web/src/elements/timestamp/ak-timestamp.ts
+++ b/web/src/elements/timestamp/ak-timestamp.ts
@@ -65,7 +65,7 @@ export class AKTimestamp extends AKElement {
         cancelAnimationFrame(this.#animationFrameID);
     }
 
-    public updated(changed: PropertyValues<this>): void {
+    protected override updated(changed: PropertyValues<this>): void {
         super.updated(changed);
 
         if (changed.has("visible") || changed.has("timestamp") || changed.has("refresh")) {

--- a/web/src/flow/FlowExecutor.ts
+++ b/web/src/flow/FlowExecutor.ts
@@ -226,7 +226,7 @@ export class FlowExecutor extends WithBrandConfig(Interface) implements StageHos
             });
     };
 
-    public async firstUpdated(changed: PropertyValues<this>): Promise<void> {
+    protected override async firstUpdated(changed: PropertyValues<this>): Promise<void> {
         super.firstUpdated(changed);
 
         this.refresh().then(() => {
@@ -235,7 +235,7 @@ export class FlowExecutor extends WithBrandConfig(Interface) implements StageHos
     }
 
     // DOM post-processing has to happen after the render.
-    public updated(changedProperties: PropertyValues<this>) {
+    protected override updated(changedProperties: PropertyValues<this>) {
         super.updated(changedProperties);
 
         document.title = match(this.challenge?.flowInfo?.title)

--- a/web/src/flow/FormStatic.ts
+++ b/web/src/flow/FormStatic.ts
@@ -8,7 +8,7 @@ import { RememberMeStorage } from "#flow/stages/identification/controllers/Remem
 import { StageChallengeLike } from "#flow/types";
 
 import { msg, str } from "@lit/localize";
-import { CSSResult, html, nothing } from "lit";
+import { CSSResult, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { guard } from "lit/directives/guard.js";
 
@@ -29,7 +29,7 @@ export class AKFormStatic extends AKElement {
 
     protected override render() {
         if (!this.username) {
-            return nothing;
+            return null;
         }
 
         return html`<div class="primary-content">
@@ -45,7 +45,7 @@ export class AKFormStatic extends AKElement {
                                     id: "avatar.alt-text",
                                 })}
                       />`
-                    : nothing}
+                    : null}
                 <div class="username" aria-description=${msg("Username")}>${this.username}</div>
             </div>
             <div class="links">
@@ -60,6 +60,7 @@ export interface FlowUserDetailsProps {
 
 export const FlowUserDetails: LitFC<FlowUserDetailsProps> = ({ challenge }) => {
     const { pendingUserAvatar, pendingUser, flowInfo } = challenge || {};
+
     return guard(
         [pendingUserAvatar, pendingUser, flowInfo],
         () =>
@@ -75,7 +76,7 @@ export const FlowUserDetails: LitFC<FlowUserDetailsProps> = ({ challenge }) => {
                               >
                           </div>
                       `
-                    : nothing}
+                    : null}
             </ak-form-static>`,
     );
 };

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -26,6 +26,8 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
     @state()
     startedRedirect = false;
 
+    #keydownController: AbortController | null = null;
+
     static styles: CSSResult[] = [
         PFLogin,
         PFForm,
@@ -51,6 +53,19 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
         )?.open;
     }
 
+    disconnectedCallback(): void {
+        super.disconnectedCallback();
+
+        this.#keydownController?.abort();
+        this.#keydownController = null;
+    }
+
+    #keydownListener = (ev: KeyboardEvent): void => {
+        if (ev.key === "Enter") {
+            this.redirect();
+        }
+    };
+
     updated(changed: PropertyValues<this>): void {
         super.updated(changed);
 
@@ -58,11 +73,14 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
             return;
         }
         if (this.promptUser) {
-            document.addEventListener("keydown", (ev) => {
-                if (ev.key === "Enter") {
-                    this.redirect();
-                }
-            });
+            // Register the listener once for the element's lifetime; `updated` runs on every
+            // challenge change, and the AbortController tears it down on disconnect.
+            if (!this.#keydownController) {
+                this.#keydownController = new AbortController();
+                document.addEventListener("keydown", this.#keydownListener, {
+                    signal: this.#keydownController.signal,
+                });
+            }
             return;
         }
         this.redirect();

--- a/web/src/flow/stages/RedirectStage.ts
+++ b/web/src/flow/stages/RedirectStage.ts
@@ -42,47 +42,51 @@ export class RedirectStage extends BaseStage<RedirectChallenge, FlowChallengeRes
     ];
 
     getURL(): string {
-        return new URL(this.challenge?.to || "", document.baseURI).toString();
+        return new URL(this.challenge?.to || "", this.ownerDocument.baseURI).toString();
     }
 
     // The current implementation expects the button and the stage to share the same DOM context,
     // and the same rootNode. If that changes, this will need to be updated.
-    get promptUser() {
+    public get promptUser(): boolean {
         return !!(this.getRootNode() as Element | undefined)?.querySelector(
             "ak-flow-inspector-button",
         )?.open;
     }
 
-    disconnectedCallback(): void {
+    protected keydownListener = (event: KeyboardEvent): void => {
+        if (event.key === "Enter") {
+            this.redirect();
+        }
+    };
+
+    public override disconnectedCallback(): void {
         super.disconnectedCallback();
 
         this.#keydownController?.abort();
         this.#keydownController = null;
     }
 
-    #keydownListener = (ev: KeyboardEvent): void => {
-        if (ev.key === "Enter") {
-            this.redirect();
-        }
-    };
-
-    updated(changed: PropertyValues<this>): void {
+    protected override updated(changed: PropertyValues<this>): void {
         super.updated(changed);
 
         if (!changed.has("challenge")) {
             return;
         }
+
         if (this.promptUser) {
             // Register the listener once for the element's lifetime; `updated` runs on every
             // challenge change, and the AbortController tears it down on disconnect.
             if (!this.#keydownController) {
                 this.#keydownController = new AbortController();
-                document.addEventListener("keydown", this.#keydownListener, {
+
+                this.ownerDocument.addEventListener("keydown", this.keydownListener, {
                     signal: this.#keydownController.signal,
                 });
             }
+
             return;
         }
+
         this.redirect();
     }
 

--- a/web/src/flow/stages/base.ts
+++ b/web/src/flow/stages/base.ts
@@ -96,7 +96,7 @@ export abstract class BaseStage<Tin extends StageChallengeLike, Tout = unknown>
         document.removeEventListener("visibilitychange", this.#visibilityListener);
     }
 
-    public updated(changed: PropertyValues<this>): void {
+    protected override updated(changed: PropertyValues<this>): void {
         super.updated(changed);
 
         // We're especially mindful of how often this runs to avoid

--- a/web/src/flow/stages/base.ts
+++ b/web/src/flow/stages/base.ts
@@ -8,11 +8,13 @@ import { WithLocale } from "#elements/mixins/locale";
 import { findEmptyFocusCandidate, FocusTarget } from "#elements/utils/focus";
 
 import { FlowUserDetails } from "#flow/FormStatic";
-import { IBaseStage, StageChallengeLike, StageHost } from "#flow/types";
+import { IBaseStage, isFormStaticChallengeLike, StageChallengeLike, StageHost } from "#flow/types";
 
 import { ConsoleLogger } from "#logger/browser";
 
-import { html, nothing, PropertyValues } from "lit";
+import { FlowErrorChallenge } from "@goauthentik/api";
+
+import { html, PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 
 export function readFileAsync(file: Blob) {
@@ -35,7 +37,7 @@ export function readFileAsync(file: Blob) {
  * @prop {StageHost} host The host managing this stage.
  * @prop {Tin} challenge The challenge provided to this stage.
  */
-export abstract class BaseStage<Tin extends StageChallengeLike, Tout = unknown>
+export abstract class BaseStage<Tin extends StageChallengeLike | FlowErrorChallenge, Tout = unknown>
     extends WithLocale(AKElement)
     implements IBaseStage<Tin, Tout>
 {
@@ -142,7 +144,7 @@ export abstract class BaseStage<Tin extends StageChallengeLike, Tout = unknown>
         const nonFieldErrors = this.challenge?.responseErrors?.non_field_errors;
 
         if (!nonFieldErrors) {
-            return nothing;
+            return null;
         }
 
         return html`<div class="pf-c-form__alert">
@@ -163,20 +165,27 @@ export abstract class BaseStage<Tin extends StageChallengeLike, Tout = unknown>
         </div>`;
     }
 
+    /**
+     * Renders the user information section of the form, if applicable.
+     */
     protected renderUserInfo() {
-        if (!this.challenge?.pendingUser || !this.challenge?.pendingUserAvatar) {
-            return nothing;
+        const { challenge } = this;
+
+        // Do we have a challenge that isn't shaped like an error?
+        if (!isFormStaticChallengeLike(challenge)) return null;
+
+        // And do we have a pending user or avatar to display?
+        if (!challenge.pendingUser && !challenge.pendingUserAvatar) {
+            return null;
         }
 
-        return html`
-            ${FlowUserDetails({ challenge: this.challenge })}
+        return html`${FlowUserDetails({ challenge })}
             <input
                 name="username"
                 autocomplete="username"
                 type="hidden"
-                value="${this.challenge.pendingUser}"
-            />
-        `;
+                value="${challenge.pendingUser}"
+            />`;
     }
 
     /**

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -259,7 +259,7 @@ export class CaptchaStage
         super.disconnectedCallback();
     }
 
-    public override firstUpdated(changedProperties: PropertyValues<this>) {
+    protected override firstUpdated(changedProperties: PropertyValues<this>) {
         super.firstUpdated(changedProperties);
 
         if (changedProperties.has("challenge") && this.challenge) {
@@ -267,7 +267,7 @@ export class CaptchaStage
         }
     }
 
-    public updated(changedProperties: PropertyValues<this>) {
+    protected override updated(changedProperties: PropertyValues<this>) {
         super.updated(changedProperties);
 
         if (!changedProperties.has("refreshedAt") || !this.challenge) {

--- a/web/src/flow/types.ts
+++ b/web/src/flow/types.ts
@@ -16,6 +16,7 @@ import type {
     ConsentChallenge,
     CurrentBrand,
     FlowChallengeResponseRequest,
+    FlowErrorChallenge,
     PasswordChallenge,
     SessionEndChallenge,
     UserLoginChallenge,
@@ -54,6 +55,22 @@ export type FormStaticChallenge =
 export type StageChallengeLike = Partial<
     Pick<FormStaticChallenge, "pendingUserAvatar" | "pendingUser" | "flowInfo" | "responseErrors">
 >;
+
+/**
+ * Type-predicate to determine if a given challenge is a {@linkcode FormStaticChallenge}.
+ */
+export function isFormStaticChallengeLike(
+    challenge: StageChallengeLike | FlowErrorChallenge | null | undefined,
+): challenge is FormStaticChallenge {
+    if (!challenge) return false;
+
+    return (
+        "pendingUser" in challenge ||
+        "pendingUserAvatar" in challenge ||
+        "flowInfo" in challenge ||
+        "responseErrors" in challenge
+    );
+}
 
 export interface SubmitOptions {
     invisible: boolean;


### PR DESCRIPTION
This PR fixes several issues reported by lit-analyzer, as well as a few back-portable refinements:

- The Enter-to-redirect handler was added to document on every challenge update and never removed, leaking a listener per update and firing redirect() once per accumulated listener. 
- Fixed use of `public` on overridden `protected` methods.
- Fixed issue where generic type for `BaseStage` can't infer `FlowErrorChallenge` as a valid `StageChallengeLike`.