### PR TITLE
web/flow: elect continuous-login resume leader with a Web Lock

### DIFF
--- a/web/src/flow/tabs/orchestrator.ts
+++ b/web/src/flow/tabs/orchestrator.ts
@@ -1,21 +1,13 @@
-import { globalAK } from "#common/global";
-import { ascii_letters, digits, randomString } from "#common/utils";
-
-import { Broadcast } from "#flow/tabs/broadcast";
-import { AKMultiTabExitEvent } from "#flow/tabs/events";
-import { TabID } from "#flow/tabs/TabID";
-
-import { ConsoleLogger } from "#logger/browser";
-
 /**
- * Multi-tab continuous-login coordination.
+ * @file  Multi-tab continuous-login coordination.
  *
  * When several tabs sit in the same flow (e.g. multiple SP-initiated SAML logins), only one needs
  * the user to authenticate. The tab that completes auth becomes the "leader" and walks every other
  * ("follower") tab through its own resume, one at a time:
  *
- *  1. The leader takes a cross-tab lock ({@link lockKey} in localStorage) so a second finishing tab
- *     won't also start resuming — it suppresses its own exit and bows out.
+ *  1. The leader takes a cross-tab Web Lock ({@link lockKey}) so a second finishing tab won't also
+ *     start resuming — it suppresses its own exit and bows out. The lock is held for the duration of
+ *     the resume loop and released automatically when the leader navigates away or is closed.
  *  2. For each discovered follower the leader mints a one-shot `resumeID`, starts waiting for that
  *     tab's exit, then tells it to continue ({@link Broadcast.resumeTab}).
  *  3. The follower stores the `resumeID`, re-enters its flow, and only echoes it back in an exit
@@ -28,6 +20,16 @@ import { ConsoleLogger } from "#logger/browser";
  * completed auth flow — never from intermediate hops (source stages, the same-origin SAML re-entry).
  */
 
+import { globalAK } from "#common/global";
+import { ascii_letters, digits, randomString } from "#common/utils";
+
+import { Broadcast } from "#flow/tabs/broadcast";
+import { AKMultiTabExitEvent } from "#flow/tabs/events";
+import { TabID } from "#flow/tabs/TabID";
+
+import { ConsoleLogger } from "#logger/browser";
+
+// Name of the cross-tab Web Lock that elects a single resume leader.
 const lockKey = "authentik-tab-locked";
 const logger = ConsoleLogger.prefix("mtab/orchestrate");
 
@@ -122,32 +124,34 @@ export async function multiTabOrchestrateResume() {
         return;
     }
 
-    const lockTabID = localStorage.getItem(lockKey);
-    const tabs = await Broadcast.shared.discoverTabs();
+    // `ifAvailable` returns immediately: a null lock means another tab already won leadership and
+    // is driving the resume, so we bow out. The browser releases the lock for us when the leader
+    // navigates away or is closed, so there is no stale lock to reap and no manual cleanup.
+    await navigator.locks.request(lockKey, { ifAvailable: true }, async (lock) => {
+        if (!lock) {
+            logger.debug("Tabs locked, suppressing same-origin exit.");
+            suppressNextExitForSameOriginNavigation();
+            return;
+        }
 
-    logger.debug("Got list of tabs", tabs);
+        logger.debug("Acquired tab lock, orchestrating resume");
 
-    if (lockTabID && tabs.has(lockTabID)) {
-        logger.debug("Tabs locked, suppressing same-origin exit.");
-        suppressNextExitForSameOriginNavigation();
-        return;
-    }
+        const tabs = await Broadcast.shared.discoverTabs();
 
-    logger.debug("Locking tabs");
-    localStorage.setItem(lockKey, TabID.shared.current);
+        logger.debug("Got list of tabs", tabs);
 
-    for (const tab of tabs) {
-        const resumeID = randomString(32, ascii_letters + digits);
-        const done = waitForTabExit(tab, resumeID);
+        for (const tab of tabs) {
+            const resumeID = randomString(32, ascii_letters + digits);
+            const done = waitForTabExit(tab, resumeID);
 
-        logger.debug("Telling tab to continue", tab);
-        Broadcast.shared.resumeTab(tab, resumeID);
+            logger.debug("Telling tab to continue", tab);
+            Broadcast.shared.resumeTab(tab, resumeID);
 
-        await done;
+            await done;
 
-        logger.debug("Tab done, continuing", tab);
-    }
+            logger.debug("Tab done, continuing", tab);
+        }
 
-    logger.debug("All tabs done.");
-    localStorage.removeItem(lockKey);
+        logger.debug("All tabs done.");
+    });
 }

--- a/web/test/browser/999-continuous-login.test.ts
+++ b/web/test/browser/999-continuous-login.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @file Continuous-login multi-tab coordination.
+ *
+ * Continuous login (the `flows_continuous_login` feature flag) lets one authenticated tab resume
+ * every other tab sitting in the same flow, so the user only enters credentials once. This suite
+ * drives two real tabs in a single browser context — they share the BroadcastChannel, the Web Lock,
+ * and the session cookie the orchestrator relies on — authenticates in the first, and asserts the
+ * second completes on its own.
+ *
+ * ISOLATION: the flag is a GLOBAL instance setting, not per-brand, so enabling it perturbs the login
+ * path for every concurrent test. This file therefore:
+ *   - carries the highest numeric prefix, so it is ordered last, and
+ *   - runs serially, enabling the flag in `beforeAll` and restoring it in `afterAll`.
+ * In CI it should run in its own invocation, after the parallel suite. See ./AGENTS.md.
+ */
+
+import { expect, test } from "#e2e";
+import { FormFixture } from "#e2e/fixtures/FormFixture";
+import { NavigatorFixture } from "#e2e/fixtures/NavigatorFixture";
+import { PointerFixture } from "#e2e/fixtures/PointerFixture";
+import { SessionFixture } from "#e2e/fixtures/SessionFixture";
+
+import type { Page } from "@playwright/test";
+
+// The `/admin/settings` route mounted under the `/if/admin/` interface.
+const SETTINGS_PATHNAME = "/if/admin/admin/settings";
+
+const FLOW_PATHNAME = "/if/flow/default-authentication-flow/";
+// Post-login destination shared by both tabs. Same-origin, so the follower resumes through
+// FlowMultitabController's `next`-param branch rather than its own RedirectStage.
+const USER_INTERFACE_PATHNAME = "/if/user/";
+const FLOW_WITH_NEXT = `${FLOW_PATHNAME}?next=${encodeURIComponent(USER_INTERFACE_PATHNAME)}`;
+
+const IDENTIFICATION_STAGE = "ak-stage-identification";
+
+/**
+ * Toggle the global Continuous Login flag through the admin settings UI.
+ *
+ * Runs from `beforeAll`/`afterAll`, where the per-test fixtures aren't injected, so it constructs
+ * the handful it needs against a caller-supplied page and drives the same UI a human would. The
+ * settings write is awaited so the flag is durable before the page closes.
+ */
+async function setContinuousLogin(page: Page, enabled: boolean): Promise<void> {
+    const testName = "continuous-login-setup";
+    const navigator = new NavigatorFixture(page, testName);
+    const session = new SessionFixture({ page, testName, navigator });
+    const form = new FormFixture(page, testName);
+    const pointer = new PointerFixture({ page, testName });
+
+    await session.login({ to: SETTINGS_PATHNAME });
+
+    await form.setFormGroup(/Flags/, true);
+    await form.setInputCheck("Continuous Login", enabled);
+
+    await Promise.all([
+        page.waitForResponse(
+            (response) =>
+                response.url().includes("/admin/settings/") &&
+                ["PUT", "PATCH"].includes(response.request().method()) &&
+                response.ok(),
+        ),
+        pointer.click("Save changes"),
+    ]);
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("Continuous login", () => {
+    test.beforeAll(async ({ browser }) => {
+        const page = await browser.newPage();
+
+        await setContinuousLogin(page, true);
+        await page.close();
+    });
+
+    test.afterAll(async ({ browser }) => {
+        const page = await browser.newPage();
+
+        await setContinuousLogin(page, false);
+        await page.close();
+    });
+
+    test("resumes a pending tab once another tab authenticates", async ({
+        context,
+        page,
+        session,
+    }) => {
+        // Two tabs in the same context: the leader (authenticates) and the follower (waits to be
+        // resumed). They share the BroadcastChannel and Web Lock the orchestrator coordinates over.
+        const leader = page;
+        const follower = await context.newPage();
+
+        await test.step("Open both tabs on the identification stage", async () => {
+            await leader.goto(FLOW_WITH_NEXT);
+            await follower.goto(FLOW_WITH_NEXT);
+
+            // The follower must be fully mounted before the leader completes, or it won't answer
+            // the leader's tab-discovery broadcast and would never be resumed.
+            await expect(
+                leader.locator(IDENTIFICATION_STAGE),
+                "Leader tab shows the identification stage",
+            ).toBeVisible();
+            await expect(
+                follower.locator(IDENTIFICATION_STAGE),
+                "Follower tab shows the identification stage",
+            ).toBeVisible();
+        });
+
+        await test.step("Authenticate in the leader tab", async () => {
+            // `session` is bound to `leader`; it's already on the flow pathname, so login keeps the
+            // `?next=` and drives username/password in place.
+            await session.login({ to: USER_INTERFACE_PATHNAME }, leader);
+        });
+
+        await test.step("Follower resumes without re-entering credentials", async () => {
+            // The follower never had credentials entered. Continuous login is the only thing that
+            // moves it off the identification stage — with the flag off it would sit there.
+            // The leader's resume confirms the follower's departure via a timed fallback before it
+            // navigates itself, so allow more than the default assertion budget here.
+            await follower.waitForURL(`**${USER_INTERFACE_PATHNAME}**`, { timeout: 20_000 });
+
+            await expect(
+                follower.locator(IDENTIFICATION_STAGE),
+                "Follower has left the identification stage",
+            ).toBeHidden();
+        });
+    });
+});


### PR DESCRIPTION
## Details

### What does this PR change?

- Replaces the hand-rolled `localStorage` leader-election lock in the continuous-login tab orchestrator (`web/src/flow/tabs/orchestrator.ts`) with the Web Locks API (`navigator.locks`).
- Adds a Playwright e2e test (`web/test/browser/999-continuous-login.test.ts`) that drives two real tabs and asserts the follower resumes once the leader authenticates.

### Why is this change needed?

The previous lock was a non-atomic check-then-set with an `await discoverTabs()` in the middle, so two tabs finishing auth near-simultaneously could both win leadership and both drive the resume. It also leaked a stale `localStorage` key whenever a leader crashed mid-resume, which was papered over by a tab-liveness heuristic (`tabs.has(lockTabID)`).

`navigator.locks.request(lockKey, { ifAvailable: true }, …)` gives atomic leader election with no double-leader window, and the browser releases the lock automatically on navigation or tab close — removing both the race and the liveness heuristic, along with all the manual `localStorage` bookkeeping. The feature is niche and flag-gated, so no `localStorage` fallback is included.

### How was this tested?

- New `test/browser/999-continuous-login.test.ts` passes locally against a dev instance: two tabs open on the identification stage, the leader authenticates, and the follower reaches `/if/user/` on its own without credentials being entered in it.
- The test enables the **global** `flows_continuous_login` flag through the admin settings UI in `beforeAll` and restores it in `afterAll`. Because the flag is global (not per-brand), the file runs serially and carries the highest numeric prefix so it is ordered last and does not perturb the parallel login suite. It warrants its own CI invocation after the parallel run.
- `npm run lint:types` and eslint are clean on the touched files.

### Linked issues

<!-- Continuous-login multi-tab coordination. Add `refs #N` if there is a tracking issue. -->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [ ] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).

> Stacked on `21994-playwright-ci` (the Playwright fixtures this test depends on); base is that branch, not `main`. The RedirectStage keydown-listener fix is handled in a separate PR.
