### PR TITLE
fix(policies): shield http_request from ak_call_policy deepcopy

### DIFF
--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -208,7 +208,11 @@ class BaseEvaluator:
         user = self._context.get("user", get_anonymous_user())
         req = PolicyRequest(user)
         if "request" in self._context:
-            req = deepcopy(self._context["request"])
+            request = self._context["request"]
+            # `http_request` is a live Django HttpRequest which may carry an
+            # unpicklable `resolver_match`; pass the same instance through
+            # instead of deep-copying it.
+            req = deepcopy(request, memo={id(request.http_request): request.http_request})
         req.context.update(kwargs)
         proc = PolicyProcess(PolicyBinding(policy=policy), request=req, connection=None)
         return proc.profiling_wrapper()

--- a/authentik/policies/expression/tests.py
+++ b/authentik/policies/expression/tests.py
@@ -1,6 +1,7 @@
 """evaluator tests"""
 
 from django.test import RequestFactory, TestCase
+from django.urls import ResolverMatch
 from guardian.shortcuts import get_anonymous_user
 from rest_framework.serializers import ValidationError
 from rest_framework.test import APITestCase
@@ -129,6 +130,26 @@ class TestEvaluator(TestCase):
         proc = PolicyProcess(PolicyBinding(policy=expr2), request=self.request, connection=None)
         res = proc.profiling_wrapper()
         self.assertEqual(res.messages, (True, False))
+
+    def test_call_policy_with_resolver_match(self):
+        """test ak_call_policy when http_request carries an unpicklable resolver_match"""
+        expr = ExpressionPolicy.objects.create(
+            name=generate_id(),
+            execution_logging=True,
+            expression="return True",
+        )
+        expr2 = ExpressionPolicy.objects.create(
+            name=generate_id(),
+            execution_logging=True,
+            expression=f"return ak_call_policy('{expr.name}').passing",
+        )
+        # Real requests (e.g. the policy test dialog) have resolver_match set by
+        # URL resolution; RequestFactory requests do not, which is why the
+        # deepcopy regression in #25462 was not caught.
+        self.http_request.resolver_match = ResolverMatch(lambda: None, (), {})
+        proc = PolicyProcess(PolicyBinding(policy=expr2), request=self.request, connection=None)
+        res = proc.profiling_wrapper()
+        self.assertTrue(res.passing)
 
     def test_call_policy_test_like(self):
         """test ak_call_policy without `obj` set, as if it was when testing policies"""


### PR DESCRIPTION
Fixes #25709.

## Root cause

#25462 changed `expr_func_call_policy` to `deepcopy` the calling policy request so `ak_call_policy(name, **kwargs)` no longer pollutes the shared request context. Correct fix - but `PolicyRequest.http_request` is a live Django `HttpRequest`, and on any request that went through URL resolution (including the built-in expression policy test dialog) it carries `resolver_match`. `ResolverMatch` is deliberately unpicklable, so the `deepcopy` raises `PicklingError: Cannot pickle ResolverMatch` and every expression policy that composes reusable policies via `ak_call_policy()` fails closed.

The existing tests never caught this because `RequestFactory` requests have no `resolver_match`.

## Fix

Keep the deepcopy (the pollution fix from #25462 is preserved) but pre-seed the deepcopy memo with the original `http_request` instance, so the child policy request references the same `HttpRequest` instead of cloning it:

```python
req = deepcopy(request, memo={id(request.http_request): request.http_request})
```

The context dict is still deep-copied, so kwargs passed by the caller remain isolated per call.

## Test

New `test_call_policy_with_resolver_match`: attaches a real `ResolverMatch` to the request (mirroring a resolved Django request) and asserts `ak_call_policy()` evaluates the child policy successfully. Fails on 2026.8.1 with the reported `PicklingError`, passes with this change.

> Built by breken, your AI support engineer - breken.ai - this one's on us.