### PR TITLE
lib: avoid DNS resolution in fqdn_rand

### DIFF
--- a/authentik/lib/tests/test_utils_time.py
+++ b/authentik/lib/tests/test_utils_time.py
@@ -1,11 +1,12 @@
 """Test time utils"""
 
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from authentik.lib.utils.time import timedelta_from_string, timedelta_string_validator
+from authentik.lib.utils.time import fqdn_rand, timedelta_from_string, timedelta_string_validator
 
 
 class TestTimeUtils(TestCase):
@@ -28,3 +29,44 @@ class TestTimeUtils(TestCase):
         """Test Django model field validator"""
         with self.assertRaises(ValidationError):
             timedelta_string_validator("foo")
+
+    @patch("authentik.lib.utils.time.socket.gethostname", return_value="test-host")
+    def test_fqdn_rand_deterministic(self, _gethostname):
+        """Test schedule entropy is stable for a hostname and task"""
+        self.assertEqual(fqdn_rand("test-task"), fqdn_rand("test-task"))
+
+    @patch("authentik.lib.utils.time.socket.gethostname", return_value="test-host")
+    def test_fqdn_rand_range(self, _gethostname):
+        """Test schedule entropy remains within the requested range"""
+        self.assertGreaterEqual(fqdn_rand("test-task"), 0)
+        self.assertLess(fqdn_rand("test-task"), 60)
+        self.assertGreaterEqual(fqdn_rand("test-task", 7), 0)
+        self.assertLess(fqdn_rand("test-task", 7), 7)
+
+    def test_fqdn_rand_does_not_resolve_hostname(self):
+        """Test schedule entropy does not depend on DNS resolver functions"""
+        with (
+            patch("authentik.lib.utils.time.socket.gethostname", return_value="test-host"),
+            patch(
+                "authentik.lib.utils.time.socket.getfqdn",
+                side_effect=AssertionError("getfqdn must not be called"),
+            ) as getfqdn,
+            patch(
+                "authentik.lib.utils.time.socket.getaddrinfo",
+                side_effect=AssertionError("getaddrinfo must not be called"),
+            ) as getaddrinfo,
+            patch(
+                "authentik.lib.utils.time.socket.gethostbyname",
+                side_effect=AssertionError("gethostbyname must not be called"),
+            ) as gethostbyname,
+            patch(
+                "authentik.lib.utils.time.socket.gethostbyaddr",
+                side_effect=AssertionError("gethostbyaddr must not be called"),
+            ) as gethostbyaddr,
+        ):
+            self.assertEqual(fqdn_rand("test-task"), fqdn_rand("test-task"))
+
+        getfqdn.assert_not_called()
+        getaddrinfo.assert_not_called()
+        gethostbyname.assert_not_called()
+        gethostbyaddr.assert_not_called()

--- a/authentik/lib/utils/time.py
+++ b/authentik/lib/utils/time.py
@@ -1,9 +1,9 @@
 """Time utilities"""
 
 import datetime
+import socket
 from hashlib import sha256
 from random import randrange, seed
-from socket import getfqdn
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
@@ -51,8 +51,10 @@ def timedelta_to_string(delta: datetime.timedelta) -> str:
 
 
 def fqdn_rand(task: str, stop: int = 60) -> int:
-    """Get a random number within max based on the FQDN and task name"""
-    entropy = f"{getfqdn()}:{task}"
+    """Get a random number within max based on the hostname and task name"""
+    # Schedule reconciliation can run while holding a database lock; DNS/NSS resolution must not
+    # block this startup path.
+    entropy = f"{socket.gethostname()}:{task}"
     hasher = sha256()
     hasher.update(entropy.encode("utf-8"))
     seed(hasher.hexdigest())


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?
Replaces socket.getfqdn() with non-resolving socket.gethostname() in fqdn_rand() and adds regression tests.

### Why is this change needed?
DNS resolution could block during startup reconciliation while a database row lock was held, causing a cross-worker lock.

#### Detail

A DNS failure does not create the database lock; the lock has already been acquired. However, a DNS lookup that stalls or hangs prevents the transaction from completing and releasing that lock.
The synchronous call chain:

1. embedded_outpost() calls Outpost.objects.update_or_create().
2. Django enters transaction.atomic() and locks the existing row with select_for_update().
3. Django calls obj.save() before leaving the transaction.
4. save() synchronously sends post_save.
5. authentik’s receiver evaluates instance.schedule_specs.
6. Outpost.schedule_specs calls fqdn_rand().

Therefore, fqdn_rand() runs while the row lock is held. If its DNS resolution hangs, update_or_create() cannot finish, the transaction remains open, and other workers attempting to update the same row block behind it. 

### How was this tested?
Added tests for deterministic output, range behavior, and ensuring DNS resolver functions are never called. Black, Ruff, and all six targeted tests pass.


<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [X] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [X] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).

AI was used to determine the issue.
AI wrote all tests.
