### PR TITLE
core: explicitly check is_active in auth backends

### DIFF
--- a/authentik/core/auth.py
+++ b/authentik/core/auth.py
@@ -88,4 +88,4 @@ class TokenBackend(InbuiltBackend):
             return None
         token = tokens.first()
         self.set_method("token", request, token=token)
-        return token.user
+        return token.user if self.user_can_authenticate(token.user) else None

--- a/authentik/sources/kerberos/auth.py
+++ b/authentik/sources/kerberos/auth.py
@@ -42,7 +42,7 @@ class KerberosBackend(InbuiltBackend):
             usersourceconnection__source__in=sources, username=username, **filters
         ).first()
 
-        if user is not None:
+        if user is not None and self.user_can_authenticate(user):
             # User found, let's get its connections for the sources that are available
             user_source_connections = UserKerberosSourceConnection.objects.filter(
                 user=user, source__in=sources

--- a/authentik/sources/ldap/auth.py
+++ b/authentik/sources/ldap/auth.py
@@ -38,6 +38,8 @@ class LDAPBackend(InbuiltBackend):
         if LDAP_DISTINGUISHED_NAME not in user.attributes:
             LOGGER.debug("User doesn't have DN set, assuming not LDAP imported.", user=user)
             return None
+        if not self.user_can_authenticate(user):
+            return None
         # Either has unusable password,
         # or has a password, but couldn't be authenticated by ModelBackend.
         # This means we check with a bind to see if the LDAP password has changed


### PR DESCRIPTION
this is not security-relevant as user_login already checks is_active before authenticating

closes #22540 