### PR TITLE
web: fix switches in table toolbars

### DIFF
--- a/web/src/elements/table/Table.ts
+++ b/web/src/elements/table/Table.ts
@@ -50,6 +50,7 @@ import { createRef, ref } from "lit/directives/ref.js";
 import PFButton from "@patternfly/patternfly/components/Button/button.css";
 import PFDropdown from "@patternfly/patternfly/components/Dropdown/dropdown.css";
 import PFPagination from "@patternfly/patternfly/components/Pagination/pagination.css";
+import PFSwitch from "@patternfly/patternfly/components/Switch/switch.css";
 import PFTable from "@patternfly/patternfly/components/Table/table.css";
 import PFToolbar from "@patternfly/patternfly/components/Toolbar/toolbar.css";
 import PFBullseye from "@patternfly/patternfly/layouts/Bullseye/bullseye.css";
@@ -97,6 +98,7 @@ export abstract class Table<T extends object, D = T>
         PFTable,
         PFBullseye,
         PFButton,
+        PFSwitch,
         PFToolbar,
         PFDropdown,
         PFPagination,


### PR DESCRIPTION
Restore the PatternFly switch stylesheet to the shared table styles.

BEFORE:

<img width="1266" height="180" alt="image" src="https://github.com/user-attachments/assets/867dabd7-3d36-4356-9c69-fc31b5665dfb" />

AFTER:

<img width="518" height="75" alt="image" src="https://github.com/user-attachments/assets/e3a5ed4d-2330-4c79-a85a-5313df14639c" />

Closes: #25727