### PR TITLE
web: Close command palette when opening About

### DIFF
--- a/web/src/elements/commands/shared.ts
+++ b/web/src/elements/commands/shared.ts
@@ -158,8 +158,8 @@ export function createCommonCommands(): PaletteCommandDefinitionInit<unknown>[] 
                 id: "command-palette.about-authentik",
             }),
             action: () => {
+                // AboutModal.open resolves when About closes, so don't return its promise.
                 AboutModal.open();
-                return true;
             },
             prefix: msg("View", { id: "command-palette.prefix.view" }),
             group: msg("authentik"),

--- a/web/src/elements/commands/shared.ts
+++ b/web/src/elements/commands/shared.ts
@@ -159,6 +159,7 @@ export function createCommonCommands(): PaletteCommandDefinitionInit<unknown>[] 
             }),
             action: () => {
                 AboutModal.open();
+                return true;
             },
             prefix: msg("View", { id: "command-palette.prefix.view" }),
             group: msg("authentik"),

--- a/web/src/elements/commands/shared.ts
+++ b/web/src/elements/commands/shared.ts
@@ -157,7 +157,9 @@ export function createCommonCommands(): PaletteCommandDefinitionInit<unknown>[] 
             label: msg("About authentik", {
                 id: "command-palette.about-authentik",
             }),
-            action: AboutModal.open,
+            action: () => {
+                AboutModal.open();
+            },
             prefix: msg("View", { id: "command-palette.prefix.view" }),
             group: msg("authentik"),
         },


### PR DESCRIPTION
Opening About returned a promise that resolved only after the dialog closed, leaving the command palette visible behind it.

Closes: #25726