### PR TITLE
admin/files: make file search case-insensitive

### DIFF
--- a/authentik/admin/files/api.py
+++ b/authentik/admin/files/api.py
@@ -68,7 +68,7 @@ class FileView(APIView):
         # Backend is source of truth - list all files from storage
         manager = get_file_manager(usage)
         files = manager.list_files(manageable_only=params.get("manageable_only", False))
-        search_query = params.get("search", "")
+        search_query = params.get("search", "").lower()
         if search_query:
             files = filter(lambda file: search_query in file.lower(), files)
         files = [

--- a/authentik/admin/files/tests/test_api.py
+++ b/authentik/admin/files/tests/test_api.py
@@ -120,7 +120,7 @@ class TestFileAPI(FileTestFileBackendMixin, TestCase):
             reverse(
                 "authentik_api:files",
                 query={
-                    "search": "ldap.png",
+                    "search": "LDAP.PNG",
                 },
             )
         )


### PR DESCRIPTION
File search lowercased stored filenames but left the query unchanged, so mixed-case queries returned no results.

Fix: Lowercase the query once before filtering + Update existing test with uppercase filename, which should catch this if it ever regresses.

Closes #24916 