### PR TITLE
lib/expression: fix PickleError due to resolver match when using ak_call_policy

### DIFF
--- a/authentik/core/tests/utils.py
+++ b/authentik/core/tests/utils.py
@@ -7,6 +7,7 @@ from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpRequest
 from django.test import RequestFactory as BaseRequestFactory
+from django.urls import ResolverMatch
 from django.utils.text import slugify
 
 from authentik.brands.models import Brand
@@ -135,5 +136,10 @@ class RequestFactory(BaseRequestFactory):
         middleware = MessageMiddleware(dummy_get_response)
         middleware.process_request(request)
         request.session.save()
+
+        # Not explicitly required for testing, however a `ResolverMatch` instance
+        # cannot be pickled, which has caused numerous issues in the past
+        # and as such we always inject this here.
+        request.resolver_match = ResolverMatch(dummy_get_response, (), {})
 
         return request

--- a/authentik/lib/expression/evaluator.py
+++ b/authentik/lib/expression/evaluator.py
@@ -2,7 +2,6 @@
 
 import re
 import socket
-from copy import deepcopy
 from ipaddress import ip_address, ip_network
 from smtplib import SMTPException
 from textwrap import indent
@@ -208,7 +207,8 @@ class BaseEvaluator:
         user = self._context.get("user", get_anonymous_user())
         req = PolicyRequest(user)
         if "request" in self._context:
-            req = deepcopy(self._context["request"])
+            current_req: PolicyRequest = self._context["request"]
+            req = current_req.deepcopy()
         req.context.update(kwargs)
         proc = PolicyProcess(PolicyBinding(policy=policy), request=req, connection=None)
         return proc.profiling_wrapper()

--- a/authentik/policies/expression/tests.py
+++ b/authentik/policies/expression/tests.py
@@ -1,11 +1,12 @@
 """evaluator tests"""
 
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 from guardian.shortcuts import get_anonymous_user
 from rest_framework.serializers import ValidationError
 from rest_framework.test import APITestCase
 
 from authentik.core.models import Application
+from authentik.core.tests.utils import RequestFactory
 from authentik.lib.generators import generate_id
 from authentik.policies.exceptions import PolicyException
 from authentik.policies.expression.api import ExpressionPolicySerializer

--- a/authentik/policies/types.py
+++ b/authentik/policies/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import copy, deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -62,6 +63,17 @@ class PolicyRequest:
         if self.http_request:
             text += f" http_request={self.http_request}"
         return text + ">"
+
+    def deepcopy(self) -> PolicyRequest:
+        """Deep copy of this policy request;
+
+        HTTP Request, User and related object are _not_ copied"""
+        new_req = PolicyRequest(self.user)
+        new_req.context = deepcopy(self.context)
+        new_req.http_request = self.http_request
+        new_req.obj = self.obj
+        new_req.debug = copy(self.debug)
+        return new_req
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
closes https://github.com/goauthentik/authentik/issues/25709
introduced with https://github.com/goauthentik/authentik/pull/25462