### PR TITLE
web/admin: fix inconsistent binding tables' edit buttons

### DIFF
--- a/web/src/admin/flows/BoundStagesList.ts
+++ b/web/src/admin/flows/BoundStagesList.ts
@@ -7,12 +7,10 @@ import "#elements/forms/ModalForm";
 
 import { aki } from "#common/api/client";
 
-import { modalInvoker } from "#elements/dialogs";
+import { IconEditButton, IconEditButtonByTagName, modalInvoker } from "#elements/dialogs";
 import { IconPermissionButton } from "#elements/dialogs/components/IconPermissionButton";
-import { CustomFormElementTagName } from "#elements/forms/unsafe";
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
-import { StrictUnsafe } from "#elements/utils/unsafe";
 
 import { StageBindingForm } from "#admin/flows/StageBindingForm";
 import { AKStageWizard } from "#admin/stages/ak-stage-wizard";
@@ -88,25 +86,8 @@ export class BoundStagesList extends Table<FlowStageBinding> {
             item.stageObj?.name,
             item.stageObj?.verboseName,
             html`<div class="ak-c-table__actions">
-                <button
-                    type="button"
-                    class="pf-c-button pf-m-secondary"
-                    ${modalInvoker(() =>
-                        StrictUnsafe<CustomFormElementTagName>(item.stageObj?.component, {
-                            instancePk: item.stageObj?.pk,
-                        }),
-                    )}
-                >
-                    ${msg("Edit Stage")}
-                </button>
-
-                <button
-                    type="button"
-                    class="pf-c-button pf-m-secondary"
-                    ${modalInvoker(StageBindingForm, { instancePk: item.pk })}
-                >
-                    ${msg("Edit Binding")}
-                </button>
+                ${IconEditButtonByTagName(item.stageObj.component, item.stageObj.pk)}
+                ${IconEditButton(StageBindingForm, item.pk, null, undefined, undefined, "fa-link")}
                 ${IconPermissionButton(item.stageObj?.name || "", {
                     model: ModelEnum.AuthentikFlowsFlowstagebinding,
                     objectPk: item.pk,

--- a/web/src/admin/policies/BoundPoliciesList.ts
+++ b/web/src/admin/policies/BoundPoliciesList.ts
@@ -11,7 +11,7 @@ import "#elements/forms/ModalForm";
 import { aki } from "#common/api/client";
 import { PolicyBindingCheckTarget, PolicyBindingCheckTargetToLabel } from "#common/policies/utils";
 
-import { asInstanceInvokerByTagName, modalInvoker } from "#elements/dialogs";
+import { IconEditButton, IconEditButtonByTagName, modalInvoker } from "#elements/dialogs";
 import { IconPermissionButton } from "#elements/dialogs/components/IconPermissionButton";
 import { PaginatedResponse, Table, TableColumn } from "#elements/table/Table";
 import { SlottedTemplateResult } from "#elements/types";
@@ -114,31 +114,15 @@ export class BoundPoliciesList<T extends PolicyBinding = PolicyBinding> extends 
 
     protected getObjectEditButton(item: PolicyBinding): SlottedTemplateResult {
         if (item.policyObj) {
-            return html`<button
-                type="button"
-                class="pf-c-button pf-m-secondary"
-                ${asInstanceInvokerByTagName(item.policyObj?.component, item.policyObj?.pk)}
-            >
-                ${msg("Edit Policy")}
-            </button>`;
+            return IconEditButtonByTagName(item.policyObj.component, item.policyObj.pk);
         }
 
         if (item.groupObj) {
-            return html`<button
-                class="pf-c-button pf-m-secondary"
-                ${GroupForm.asInstanceInvoker(item.groupObj?.pk)}
-            >
-                ${msg("Edit Group")}
-            </button>`;
+            return IconEditButton(GroupForm, item.groupObj.pk);
         }
 
         if (item.userObj) {
-            return html`<button
-                class="pf-c-button pf-m-secondary"
-                ${UserForm.asInstanceInvoker(item.userObj?.pk)}
-            >
-                ${msg("Edit User")}
-            </button>`;
+            return IconEditButton(UserForm, item.userObj.pk);
         }
 
         return null;
@@ -214,20 +198,18 @@ export class BoundPoliciesList<T extends PolicyBinding = PolicyBinding> extends 
             html`${item.timeout}`,
             html`<div class="ak-c-table__actions">
                 ${this.getObjectEditButton(item)}
-                <button
-                    type="button"
-                    class="pf-c-button pf-m-secondary"
-                    ${modalInvoker(() => {
-                        return StrictUnsafe<PolicyBindingForm>(this.bindingEditForm, {
-                            instancePk: item.pk,
-                            allowedTypes: this.allowedTypes,
-                            typeNotices: this.typeNotices,
-                            targetPk: this.target || "",
-                        });
-                    })}
-                >
-                    ${msg("Edit Binding")}
-                </button>
+                ${IconEditButtonByTagName(
+                    this.bindingEditForm,
+                    item.pk,
+                    null,
+                    {
+                        allowedTypes: this.allowedTypes,
+                        typeNotices: this.typeNotices,
+                        targetPk: this.target || "",
+                    },
+                    undefined,
+                    "fa-link",
+                )}
                 ${IconPermissionButton(this.getPolicyUserGroupRowLabel(item), {
                     model: ModelEnum.AuthentikPoliciesPolicybinding,
                     objectPk: item.pk,

--- a/web/src/elements/dialogs/components/IconEditButton.ts
+++ b/web/src/elements/dialogs/components/IconEditButton.ts
@@ -16,6 +16,7 @@ import { html } from "lit-html";
  * @param modalProps Properties to pass to the custom element constructor when the factory is a constructor.
  * @param options Initialization options for the modal dialog.
  */
+// eslint-disable-next-line max-params
 export function IconEditButton<T extends TransclusionElementConstructor>(
     factory: T,
     instancePk?: string | number | null,
@@ -24,6 +25,7 @@ export function IconEditButton<T extends TransclusionElementConstructor>(
         ? LitPropertyRecord<InstanceType<T>>
         : null,
     options?: DialogInit,
+    iconName: string = "fa-edit",
 ): SlottedTemplateResult {
     const noun = (factory as TransclusionElementConstructor).verboseName ?? msg("Entity");
     const label = itemName
@@ -42,8 +44,8 @@ export function IconEditButton<T extends TransclusionElementConstructor>(
         class="pf-c-button pf-m-plain"
         ${modalInvoker(factory, props as unknown as undefined, options)}
     >
-        <pf-tooltip position="top" content=${msg("Edit")}>
-            <i aria-hidden="true" class="fas fa-edit"></i>
+        <pf-tooltip position="top" content=${label}>
+            <i aria-hidden="true" class="fas ${iconName}"></i>
         </pf-tooltip>
     </button>`;
 }

--- a/web/src/elements/dialogs/components/IconEditButtonByTagName.ts
+++ b/web/src/elements/dialogs/components/IconEditButtonByTagName.ts
@@ -16,12 +16,14 @@ import type { LitPropertyRecord, SlottedTemplateResult } from "#elements/types";
  *
  * @see {@link IconEditButton} for the underlying button rendering logic.
  */
+// eslint-disable-next-line max-params
 export function IconEditButtonByTagName<T extends object = object>(
     tagName: string,
     instancePk?: string | number | null,
     itemName?: string | null,
     modalProps?: LitPropertyRecord<T> | null,
     options?: DialogInit,
+    icon?: string,
 ): SlottedTemplateResult {
     const Constructor = lookupElementConstructor(tagName);
 
@@ -31,5 +33,6 @@ export function IconEditButtonByTagName<T extends object = object>(
         itemName,
         modalProps as unknown as undefined,
         options,
+        icon,
     );
 }


### PR DESCRIPTION
thanks @kensternberg-authentik for the inspiration

old:
<img width="1435" height="474" alt="image" src="https://github.com/user-attachments/assets/7b3869e3-bdfe-4b58-afe2-81202b95cd19" />

new:
<img width="1435" height="403" alt="image" src="https://github.com/user-attachments/assets/dd45bd77-1e4e-40a9-a074-defd89d732ff" />
