### PR TITLE
website/integrations: document Homarr credentials account linking

### DIFF
--- a/website/integrations/dashboards/homarr/index.mdx
+++ b/website/integrations/dashboards/homarr/index.mdx
@@ -63,6 +63,7 @@ To keep local Homarr account login available, set `AUTH_PROVIDERS=oidc,credentia
 If you want Homarr to skip the login page and send users directly to authentik, also add `AUTH_OIDC_AUTO_LOGIN=true`.
 
 If you are intentionally linking existing Homarr accounts by email during an OIDC provider migration, and the email addresses from your IdP are verified, also add `AUTH_OIDC_ENABLE_DANGEROUS_ACCOUNT_LINKING=true`.
+If you are intentionally linking an existing Homarr credentials account to an OIDC identity with the same email address, also add `AUTH_OIDC_ENABLE_DANGEROUS_CREDENTIALS_LINKING=true`. The email address from your IdP must be verified (`email_verified: true`).
 
 Restart the Homarr service for the changes to take effect.
 

--- a/website/integrations/dashboards/homarr/index.mdx
+++ b/website/integrations/dashboards/homarr/index.mdx
@@ -29,6 +29,12 @@ This documentation lists only the settings that you need to change from their de
 
 To support the integration of Homarr with authentik, you need to create an application/provider pair in authentik.
 
+### Create an email verification scope mapping _(optional)_
+
+Homarr requires the email scope to return `email_verified: True` when linking an existing credentials account by email. Because the default authentik email scope mapping returns `email_verified: False`, create a custom scope mapping if you plan to enable credentials account linking.
+
+Refer to [Email scope verification](/docs/add-secure-apps/providers/oauth2/#email-scope-verification) for instructions on how to create the required custom scope mapping. Use `email` as the **Scope name**.
+
 ### Create an application and provider
 
 1. Log in to authentik as an administrator and open the authentik Admin interface.
@@ -39,6 +45,7 @@ To support the integration of Homarr with authentik, you need to create an appli
         - Note the **Client ID** and **Client Secret** values because they will be required later.
         - Add a **Redirect URI** of type `Strict` `Authorization` as `https://homarr.company/api/auth/callback/oidc`.
         - Select any available signing key.
+        - If you created a custom email scope mapping, add it under **Advanced protocol settings** > **Selected Scopes** and remove `authentik default OAuth Mapping: OpenID 'email'`.
     - **Configure Bindings** _(optional)_: you can create a [binding](/docs/add-secure-apps/bindings-overview/) (policy, group, or user) to manage the listing and access to applications on a user's **Application Dashboard** page.
 3. Click **Submit** to save the new application and provider.
 
@@ -63,13 +70,16 @@ To keep local Homarr account login available, set `AUTH_PROVIDERS=oidc,credentia
 If you want Homarr to skip the login page and send users directly to authentik, also add `AUTH_OIDC_AUTO_LOGIN=true`.
 
 If you are intentionally linking existing Homarr accounts by email during an OIDC provider migration, and the email addresses from your IdP are verified, also add `AUTH_OIDC_ENABLE_DANGEROUS_ACCOUNT_LINKING=true`.
-If you are intentionally linking an existing Homarr credentials account to an OIDC identity with the same email address, also add `AUTH_OIDC_ENABLE_DANGEROUS_CREDENTIALS_LINKING=true`. The email address from your IdP must be verified (`email_verified: true`).
+
+To link an existing Homarr credentials account to an OIDC identity with the same email address, configure the custom email scope mapping above and add `AUTH_OIDC_ENABLE_DANGEROUS_CREDENTIALS_LINKING=true`.
 
 Restart the Homarr service for the changes to take effect.
 
 ## Configuration verification
 
 To confirm that authentik is properly configured with Homarr, open Homarr and log in with authentik. You should be redirected to authentik for authentication and then redirected back to Homarr.
+
+If you enabled credentials account linking, confirm that you are signed in to the existing Homarr account and that its boards and permissions are preserved.
 
 ## Resources
 


### PR DESCRIPTION
## What

Adds a missing note to the Homarr integration guide about linking an OIDC identity to an existing Homarr **credentials** (local) account.

## Why

The guide only documented `AUTH_OIDC_ENABLE_DANGEROUS_ACCOUNT_LINKING`, which does not cover the case of linking a pre-existing local/credentials Homarr user to an OIDC identity. Homarr provides a separate variable for this specific scenario, `AUTH_OIDC_ENABLE_DANGEROUS_CREDENTIALS_LINKING`, which was missing from the docs. Without it, logging in via OIDC creates a duplicate user instead of merging with the existing local account, even when the IdP correctly sends `email_verified: true`.

## Change

Added the following note to the Homarr configuration section:

> If you are intentionally linking an existing Homarr credentials account to an OIDC identity with the same email address, also add `AUTH_OIDC_ENABLE_DANGEROUS_CREDENTIALS_LINKING=true`. The email address from your IdP must be verified (`email_verified: true`).

## Testing

Verified against a running Homarr instance with an existing credentials user and an authentik OIDC provider: with this variable set and a verified email, OIDC login correctly links to the existing local account instead of creating a new one.
