### PR TITLE
core: prefetch token owners and memberships

### DIFF
--- a/authentik/core/api/tokens.py
+++ b/authentik/core/api/tokens.py
@@ -124,7 +124,7 @@ class TokenViewSet(UsedByMixin, ModelViewSet):
     """Token Viewset"""
 
     lookup_field = "identifier"
-    queryset = Token.objects.including_expired().all()
+    queryset = Token.objects.including_expired().prefetch_related("user__groups", "user__roles")
     serializer_class = TokenSerializer
     search_fields = [
         "identifier",

--- a/authentik/core/tests/test_token_api.py
+++ b/authentik/core/tests/test_token_api.py
@@ -11,11 +11,13 @@ from authentik.core.api.tokens import TokenSerializer
 from authentik.core.models import (
     USER_ATTRIBUTE_TOKEN_EXPIRING,
     USER_ATTRIBUTE_TOKEN_MAXIMUM_LIFETIME,
+    Group,
     Token,
     TokenIntents,
 )
 from authentik.core.tests.utils import create_test_admin_user, create_test_user
 from authentik.lib.generators import generate_id
+from authentik.rbac.models import Role
 
 
 class TestTokenAPI(APITestCase):
@@ -198,6 +200,33 @@ class TestTokenAPI(APITestCase):
         self.assertEqual(len(body["results"]), 2)
         self.assertEqual(body["results"][0]["identifier"], token_should.identifier)
         self.assertEqual(body["results"][1]["identifier"], token_should_not.identifier)
+
+    def test_list_owner_details_refresh(self):
+        """Owner details include current memberships, including for expired tokens."""
+        group = Group.objects.create(name=generate_id())
+        role = Role.objects.create(name=generate_id())
+        self.user.groups.add(group)
+        self.user.roles.add(role)
+        token = Token.objects.create(
+            identifier=generate_id(),
+            user=self.user,
+            expires=datetime.now() - timedelta(days=1),
+        )
+        url = reverse("authentik_api:token-list")
+        for member in (True, False):
+            with self.subTest(member=member):
+                response = self.client.get(url, {"identifier": token.identifier})
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(len(response.data["results"]), 1)
+                owner = response.data["results"][0]["user_obj"]
+                self.assertEqual(owner["pk"], self.user.pk)
+                self.assertEqual(owner["groups"], [group.pk] if member else [])
+                self.assertEqual(owner["roles"], [role.pk] if member else [])
+                self.assertEqual(len(owner["groups_obj"]), int(member))
+                self.assertEqual(len(owner["roles_obj"]), int(member))
+                self.assertFalse(owner["is_superuser"])
+            self.user.groups.remove(group)
+            self.user.roles.remove(role)
 
     def test_serializer_no_request(self):
         """Test serializer without request"""


### PR DESCRIPTION
A token list includes details about each token's owner, including their groups and roles. If 1,000 tokens belong to the same person, the endpoint repeatedly asks the database for the same person and their memberships.

This one-line change adds `prefetch_related("user__groups", "user__roles")` to the token view's queryset. Django fetches the page's owners, groups, and roles in batches. Tokens with the same owner share that loaded user object for the request.

The endpoint still returns the same tokens and owner details. The serializers, permission checks, filtering, and pagination are unchanged. Ordinary users still see their own tokens; users with the appropriate permission can see others' tokens. Expired tokens remain included. The loaded objects are local to the request, so changing a membership is reflected in the next request.

### Before and after

Local fixture: 10,000 users, each with a group and role, plus 10,000 tokens sharing one owner and another 10,000 tokens with distinct owners. These are medians of three warmed, paired Django API-client requests against dev PostgreSQL. Each before/after pair uses the same fixture and produces byte-for-byte identical responses. Timing includes rendering, excludes network/browser time, and is specific to this fixture. The page-size limit was temporarily raised to 1,000.

| Owners | Page size | Before | After | Queries before → after |
|---|---:|---:|---:|---:|
| One shared owner | 100 | 522 ms | 236 ms | 1,006 → 410 |
| One shared owner | 1,000 | 6.66 s | 4.79 s | 10,006 → 4,010 |
| Distinct owners | 100 | 853 ms | 693 ms | 1,006 → 509 |
| Distinct owners | 1,000 | 12.93 s | 8.14 s | 10,006 → 5,009 |

This removes repeated owner and membership reads. Other per-token serialization queries remain, so the endpoint's query count still grows with page size. Benchmark data and the page-size setting were rolled back afterward.

### Validation

- One added test checks that an expired token still includes its owner's groups and roles, and that removing those memberships is reflected in the next request. It passes before and after the change and does not assert a fixed query budget. Existing tests cover ordinary-user visibility and access with `view_token` permission; the benchmark compares complete responses for shared and distinct owners.
- Token and user API suites: 60 tests and 4 subtests pass, including existing token creation, ownership-change rejection, and key-access tests.
- Black, Ruff, and the pending-migration check pass. `make gen` succeeds with no schema or generated-client changes.

Made with GPT 6 Astra in Codex, which investigated the bottleneck, wrote the change and tests, ran the benchmarks and checks, and drafted this description under maintainer direction.
