### PR TITLE
events: fetch notification events in the same query

### DIFF
--- a/authentik/events/api/notifications.py
+++ b/authentik/events/api/notifications.py
@@ -47,7 +47,7 @@ class NotificationViewSet(
 ):
     """Notification Viewset"""
 
-    queryset = Notification.objects.all()
+    queryset = Notification.objects.select_related("event")
     serializer_class = NotificationSerializer
     filterset_fields = [
         "severity",

--- a/authentik/events/tests/test_api.py
+++ b/authentik/events/tests/test_api.py
@@ -122,6 +122,28 @@ class TestEventsAPI(APITestCase):
         notification.refresh_from_db()
         self.assertTrue(notification.seen)
 
+    def test_notification_list_events(self):
+        """List event details and eventless notifications only for the recipient."""
+        recipient = create_test_user()
+        event = Event.new(EventAction.LOGIN)
+        event.save()
+        body = generate_id()
+        notifications = [
+            Notification.objects.create(
+                user=user, event=linked_event, body=body, severity=NotificationSeverity.NOTICE
+            )
+            for user, linked_event in ((recipient, event), (recipient, None), (self.user, event))
+        ]
+        self.client.force_login(recipient)
+        response = self.client.get(reverse("authentik_api:notification-list"), {"body": body})
+        self.assertEqual(response.status_code, 200)
+        results = {row["pk"]: row for row in response.json()["results"]}
+        self.assertCountEqual(results, [str(n.pk) for n in notifications[:2]])
+        linked_event = results[str(notifications[0].pk)]["event"]
+        self.assertEqual(linked_event["pk"], str(event.pk))
+        self.assertEqual(linked_event["action"], EventAction.LOGIN)
+        self.assertIsNone(results[str(notifications[1].pk)]["event"])
+
     def test_transport(self):
         """Test transport API"""
         response = self.client.post(


### PR DESCRIPTION
A notification list includes the event behind each notification. Today, the endpoint first fetches the notifications, then makes a separate database query for each event. A page of 1,000 notifications with events therefore makes 1,000 extra database trips.

This one-line change adds `select_related("event")` to the notification view's queryset, fetching the notifications and their events together.

**The page still returns the same notifications and event details.** The event is optional, so Django uses a left outer join: notifications without an event remain in the response with `event: null`. The serializer, permission filters, pagination, and mark-all-seen action are unchanged.

### Before and after

Local fixture: 10,000 events with approximately 1 KB of context each, 10,000 notifications with events, and another 10,000 notifications where half have no event. Times are medians of three warmed, paired Django API-client requests against dev PostgreSQL. Each pair uses the same fixture and produces byte-for-byte identical responses. Timing includes rendering but excludes network/browser time. The maximum page size was temporarily raised to 1,000.

| Notifications | Page size | Before | After | Queries before → after |
|---|---:|---:|---:|---:|
| All have events | 100 | 68.0 ms | 38.6 ms | 106 → 6 |
| All have events | 1,000 | 509.6 ms | 102.9 ms | 1,006 → 6 |
| Half have no event | 100 | 44.7 ms | 33.5 ms | 57 → 6 |
| Half have no event | 1,000 | 251.2 ms | 76.6 ms | 503 → 6 |

The mixed fixture is ordered by notification ID, so individual pages contain slightly more or fewer than half with events. These timings are specific to this fixture. Benchmark data and the page-size setting were rolled back afterward.

### Validation

- One 22-line behavior test checks event details, notifications without events, and exclusion of another recipient's notifications. It passes before and after the change and does not assert a query budget.
- Event API and notification tests: 18 tests and 2 subtests pass, including the existing mark-all-seen test.
- Black, Ruff, and the pending-migration check pass.
- `make gen` succeeds with no schema or generated-client changes.

Made with GPT 6 Astra in Codex, which investigated the bottleneck, wrote the change and test, ran the benchmarks and checks, and drafted this description under maintainer direction.
