### PR TITLE
flows: prefetch binding stages and their flows

### DIFF
--- a/authentik/flows/api/bindings.py
+++ b/authentik/flows/api/bindings.py
@@ -42,7 +42,7 @@ class FlowStageBindingSerializer(ModelSerializer):
 class FlowStageBindingViewSet(UsedByMixin, ModelViewSet):
     """FlowStageBinding Viewset"""
 
-    queryset = FlowStageBinding.objects.all()
+    queryset = FlowStageBinding.objects.prefetch_related("stage__flow_set")
     serializer_class = FlowStageBindingSerializer
     filterset_fields = "__all__"
     search_fields = ["stage__name"]

--- a/authentik/flows/tests/test_api.py
+++ b/authentik/flows/tests/test_api.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from authentik.core.tests.utils import create_test_admin_user, create_test_flow
+from authentik.flows.api.bindings import FlowStageBindingSerializer, FlowStageBindingViewSet
 from authentik.flows.api.stages import StageSerializer, StageViewSet
 from authentik.flows.models import Flow, FlowDesignation, FlowStageBinding, Stage
 from authentik.lib.generators import generate_id
@@ -46,6 +47,22 @@ class TestFlowsAPI(APITestCase):
         """Test that stage serializer returns the correct type"""
         dummy = DummyStage.objects.create()
         self.assertIn(dummy, StageViewSet().get_queryset())
+
+    def test_binding_stage_details(self):
+        """Bindings retain the concrete stage type and every flow using the stage."""
+        stage = DummyStage.objects.create(name=generate_id())
+        flows = [create_test_flow(), create_test_flow()]
+        for flow in flows:
+            FlowStageBinding.objects.create(target=flow, stage=stage, order=0)
+        bindings = FlowStageBindingViewSet().get_queryset().filter(stage=stage)
+        data = FlowStageBindingSerializer(bindings, many=True).data
+        self.assertEqual(len(data), 2)
+        for binding in data:
+            self.assertEqual(binding["stage_obj"]["component"], stage.component)
+            self.assertCountEqual(
+                [flow["pk"] for flow in binding["stage_obj"]["flow_set"]],
+                [str(flow.pk) for flow in flows],
+            )
 
     def test_api_diagram(self):
         """Test flow diagram."""


### PR DESCRIPTION
The flow-stage binding list includes details about each stage and all flows using that stage. Today it fetches those details separately for every binding: 100 bindings require 200 extra database queries.

This one-line change adds `prefetch_related("stage__flow_set")`. Django fetches the bindings, their stages, and the stages' flows in three batches. This is local to the request and does not change flow execution or policy evaluation.

The custom `InheritanceForeignKey` already fetches concrete stage subclasses. Prefetching uses that same mechanism, preserving fields such as the stage component; a plain `select_related("stage")` would lose that behavior.

### Measurements

Synthetic fixture with 10,000 identification stages bound to one flow. These measure queryset loading and DRF serialization against dev PostgreSQL, not full endpoint or browser latency. The 50–1,000-row results are medians of three warmed measurements; the 10,000-row stress case is one measurement per version. Every paired output matched exactly. Fixture changes were rolled back.

| Rows | Before | After | Queries before → after |
|---:|---:|---:|---:|
| 50 | 480.34 ms | 38.12 ms | 101 → 3 |
| 100 | 867.71 ms | 41.69 ms | 201 → 3 |
| 500 | 4.62 s | 105.36 ms | 1,001 → 3 |
| 1,000 | 9.30 s | 172.16 ms | 2,001 → 3 |
| 10,000 | 94.82 s | 1.74 s | 20,001 → 3 |

### Validation

One focused test checks a concrete stage shared between two flows, including its component and complete flow list. No fixed query-count assertions. The flow API and inspector suites pass: 10 tests. Black, Ruff, pending migrations, and `make gen` pass; schema and generated clients are unchanged.

Made with GPT 6 Astra in Codex, which investigated, implemented, benchmarked, tested, and drafted this PR under maintainer direction.
