### PR TITLE
providers/oauth2: batch provider list relations

### DIFF
--- a/authentik/providers/oauth2/api/providers.py
+++ b/authentik/providers/oauth2/api/providers.py
@@ -114,7 +114,9 @@ class OAuth2ProviderSetupURLs(PassiveSerializer):
 class OAuth2ProviderViewSet(UsedByMixin, ModelViewSet):
     """OAuth2Provider Viewset"""
 
-    queryset = OAuth2Provider.objects.all()
+    queryset = OAuth2Provider.objects.select_related(
+        "application", "backchannel_application"
+    ).prefetch_related("property_mappings", "jwt_federation_sources", "jwt_federation_providers")
     serializer_class = OAuth2ProviderSerializer
     filterset_fields = [
         "name",

--- a/authentik/providers/oauth2/tests/test_api.py
+++ b/authentik/providers/oauth2/tests/test_api.py
@@ -34,6 +34,24 @@ class TestAPI(APITestCase):
         self.user = create_test_admin_user()
         self.client.force_login(self.user)
 
+    def test_list_application_details(self):
+        """Listing retains mappings and providers without an application."""
+        unassigned = OAuth2Provider.objects.create(
+            name=generate_id(), authorization_flow=self.provider.authorization_flow
+        )
+        self.provider.jwt_federation_providers.add(unassigned)
+        response = self.client.get(reverse("authentik_api:oauth2provider-list"))
+        self.assertEqual(response.status_code, 200)
+        providers = {provider["pk"]: provider for provider in response.data["results"]}
+        self.assertEqual(providers[self.provider.pk]["assigned_application_slug"], self.app.slug)
+        self.assertEqual(providers[self.provider.pk]["assigned_application_name"], self.app.name)
+        self.assertCountEqual(
+            providers[self.provider.pk]["property_mappings"],
+            [mapping.pk for mapping in self.provider.property_mappings.all()],
+        )
+        self.assertIsNone(providers[unassigned.pk]["assigned_application_slug"])
+        self.assertEqual(providers[self.provider.pk]["jwt_federation_providers"], [unassigned.pk])
+
     def test_preview(self):
         """Test Preview API Endpoint"""
         response = self.client.get(


### PR DESCRIPTION
Listing OAuth providers currently fetches application and mapping details separately for every provider. A longer list therefore causes more and more database round trips just to build the response.

This changes the OAuth provider queryset to load assigned applications in the initial query and fetch property mappings and JWT federation relations in batches. It returns the same fields and providers, including providers without an assigned application. It does not change token issuance, authorization checks, or mapping evaluation.

Local before/after measurements cover queryset loading and API serialization, not HTTP or browser rendering. Each provider has an assigned application; the benchmark mapping/federation sets are empty. The API test separately covers populated mappings and a federation provider. Complete serialized outputs matched at every size. Figures are medians of three measured runs after warmup through 1,000 providers; 10,000 is one stress run per version. Fixtures were rolled back.

| Rows | Before | After | Queries before → after |
|---:|---:|---:|---:|
| 50 | 133.49 ms | 12.35 ms | 201 → 4 |
| 100 | 304.68 ms | 24.06 ms | 401 → 4 |
| 500 | 2.87 s | 122.59 ms | 2,001 → 4 |
| 1,000 | 5.19 s | 175.14 ms | 4,001 → 4 |
| 10,000 | 28.53 s | 1.81 s | 40,001 → 4 |

Validation: 10 focused OAuth and core-provider API tests passed. The added 18-line test checks assigned and unassigned providers, populated property mappings, and a JWT federation provider. It does not assert query counts. Black, Ruff, migration checks, and `make gen` passed; no migration or generated API changes resulted. Broader CI remains to run.

Made with GPT 6 Astra, which assisted with investigation, implementation, tests, benchmarks, and this description.
