### PR TITLE
admin/files: reuse serializer for file lists

### DIFF
--- a/authentik/admin/files/api.py
+++ b/authentik/admin/files/api.py
@@ -72,20 +72,18 @@ class FileView(APIView):
         if search_query:
             files = filter(lambda file: search_query in file.lower(), files)
         files = [
-            FileView.FileListSerializer(
-                data={
-                    "name": file,
-                    "url": manager.file_url(file, request),
-                    "mime_type": get_content_type(file),
-                    "themed_urls": manager.themed_urls(file, request),
-                }
-            )
+            {
+                "name": file,
+                "url": manager.file_url(file, request),
+                "mime_type": get_content_type(file),
+                "themed_urls": manager.themed_urls(file, request),
+            }
             for file in files
         ]
-        for file in files:
-            file.is_valid(raise_exception=True)
+        serializer = FileView.FileListSerializer(data=files, many=True)
+        serializer.is_valid(raise_exception=True)
 
-        return Response([file.data for file in files])
+        return Response(serializer.data)
 
     class FileUploadSerializer(PassiveSerializer):
         file = FileField(required=True)


### PR DESCRIPTION
The file picker creates a fresh serializer for every file, repeatedly rebuilding the same field definitions. This changes it to one `many=True` serializer for the whole list, which reuses those definitions while still validating each entry.

File discovery, permissions, search, ordering, MIME types, and URL generation are unchanged. Successful responses contain the same entries and fields, including themed URLs. Validation remains enabled; malformed backend metadata now uses DRF's standard list-validation error structure.

Local timings below measure metadata validation and serialization only, excluding storage listing, URL generation, HTTP, and browser rendering. Half the entries have light/dark URLs and half have no themed URLs. Complete outputs matched at every size. Figures are medians of three runs after warmup through 1,000 entries; 10,000 is one stress run per version. There are no database queries in this measured component.

| Rows | Before | After | Queries before → after |
|---:|---:|---:|---:|
| 50 | 2.41 ms | 0.72 ms | 0 → 0 |
| 100 | 4.96 ms | 1.47 ms | 0 → 0 |
| 500 | 24.78 ms | 6.98 ms | 0 → 0 |
| 1,000 | 50.29 ms | 14.85 ms | 0 → 0 |
| 10,000 | 802.66 ms | 143.22 ms | 0 → 0 |

Validation: the existing file suite passed (49 tests; one skipped). It covers listing, search, themed and ordinary URLs, upload, deletion, and file-manager behavior. No new tests or query-budget assertions were added. Black, Ruff, and `make gen` passed, with no generated API changes. Broader CI remains to run.

The production diff removes two lines overall.

Made with GPT 6 Astra, which assisted with investigation, implementation, validation, benchmarks, and this description.
