### PR TITLE
core: fix bulk session revocation

### DIFF
--- a/authentik/core/api/authenticated_sessions.py
+++ b/authentik/core/api/authenticated_sessions.py
@@ -156,7 +156,7 @@ class AuthenticatedSessionViewSet(
         user_pks = query.validated_data.get("user_pks", [])
         count = 0
         for session in chunked_queryset(AuthenticatedSession.objects.filter(user_id__in=user_pks)):
-            admin_authenticated_session_deleted.send(self, session=session, request=request)
+            admin_authenticated_session_deleted.send(self, instance=session, request=request)
             session.delete()
             count += 1
 


### PR DESCRIPTION
Fix bulk session revocation passing session instead of instance to the deletion signal.

Reported-at: https://discord.com/channels/809154715984199690/834526580691959829/1546241556040913019