### PR TITLE
metrics: fix stale multiprocess gauge values

### DIFF
--- a/authentik/enterprise/apps.py
+++ b/authentik/enterprise/apps.py
@@ -11,9 +11,12 @@ GAUGE_LICENSE_USAGE = Gauge(
     "authentik_enterprise_license_usage",
     "Enterprise license usage (percentage per user type).",
     ["user_type"],
+    multiprocess_mode="livemostrecent",
 )
 GAUGE_LICENSE_EXPIRY = Gauge(
-    "authentik_enterprise_license_expiry_seconds", "Duration until license expires, in seconds."
+    "authentik_enterprise_license_expiry_seconds",
+    "Duration until license expires, in seconds.",
+    multiprocess_mode="livemostrecent",
 )
 
 

--- a/authentik/enterprise/signals.py
+++ b/authentik/enterprise/signals.py
@@ -20,6 +20,9 @@ def monitoring_set_enterprise(sender, **kwargs):
     """set enterprise gauges"""
     summary = LicenseKey.cached_summary()
     if summary.status == LicenseUsageStatus.UNLICENSED:
+        GAUGE_LICENSE_USAGE.labels(user_type="internal").set(0)
+        GAUGE_LICENSE_USAGE.labels(user_type="external").set(0)
+        GAUGE_LICENSE_EXPIRY.set(0)
         return
     percentage_internal = (
         0

--- a/authentik/enterprise/tests/test_metrics.py
+++ b/authentik/enterprise/tests/test_metrics.py
@@ -1,10 +1,13 @@
 """Enterprise metrics tests"""
 
+from unittest import mock
+
 from django.test import TestCase
 from prometheus_client import REGISTRY
 
 from authentik.core.models import User
 from authentik.core.tests.utils import create_test_user
+from authentik.enterprise.models import LicenseUsageStatus
 from authentik.enterprise.tests import enterprise_test
 from authentik.root.monitoring import monitoring_set
 
@@ -30,3 +33,24 @@ class TestEnterpriseMetrics(TestCase):
             ),
             0,
         )
+
+    def test_unlicensed_metrics_are_reset(self):
+        """Removing a license replaces previously exported values with zero."""
+        from authentik.enterprise import signals
+
+        summary = mock.Mock(status=LicenseUsageStatus.UNLICENSED)
+        usage_children = {
+            "internal": mock.Mock(),
+            "external": mock.Mock(),
+        }
+        with (
+            mock.patch.object(signals.LicenseKey, "cached_summary", return_value=summary),
+            mock.patch.object(signals, "GAUGE_LICENSE_USAGE") as usage_gauge,
+            mock.patch.object(signals, "GAUGE_LICENSE_EXPIRY") as expiry_gauge,
+        ):
+            usage_gauge.labels.side_effect = lambda user_type: usage_children[user_type]
+            signals.monitoring_set_enterprise(sender=self)
+
+        usage_children["internal"].set.assert_called_once_with(0)
+        usage_children["external"].set.assert_called_once_with(0)
+        expiry_gauge.set.assert_called_once_with(0)

--- a/authentik/flows/apps.py
+++ b/authentik/flows/apps.py
@@ -11,6 +11,7 @@ GAUGE_FLOWS_CACHED = Gauge(
     "authentik_flows_cached",
     "Cached flows",
     ["tenant"],
+    multiprocess_mode="livemostrecent",
 )
 HIST_FLOW_EXECUTION_STAGE_TIME = Histogram(
     "authentik_flows_execution_stage_time",

--- a/authentik/outposts/apps.py
+++ b/authentik/outposts/apps.py
@@ -14,11 +14,13 @@ GAUGE_OUTPOSTS_CONNECTED = Gauge(
     "authentik_outposts_connected",
     "Currently connected outposts",
     ["tenant", "outpost", "uid", "expected"],
+    multiprocess_mode="livesum",
 )
 GAUGE_OUTPOSTS_LAST_UPDATE = Gauge(
     "authentik_outposts_last_update",
     "Last update from any outpost",
     ["tenant", "outpost", "uid", "version"],
+    multiprocess_mode="livemax",
 )
 MANAGED_OUTPOST = "goauthentik.io/outposts/embedded"
 MANAGED_OUTPOST_NAME = "authentik Embedded Outpost"

--- a/authentik/policies/apps.py
+++ b/authentik/policies/apps.py
@@ -12,6 +12,7 @@ GAUGE_POLICIES_CACHED = Gauge(
     "authentik_policies_cached",
     "Cached Policies",
     ["tenant"],
+    multiprocess_mode="livemostrecent",
 )
 HIST_POLICIES_ENGINE_TOTAL_TIME = Histogram(
     "authentik_policies_engine_time_total_seconds",

--- a/authentik/tasks/signals.py
+++ b/authentik/tasks/signals.py
@@ -20,16 +20,19 @@ OLD_GAUGE_WORKERS = Gauge(
     "authentik_admin_workers",
     "Currently connected workers, their versions and if they are the same version as authentik",
     ["version", "version_matched"],
+    multiprocess_mode="livemostrecent",
 )
 GAUGE_WORKERS = Gauge(
     "authentik_tasks_workers",
     "Currently connected workers, their versions and if they are the same version as authentik",
     ["version", "version_matched"],
+    multiprocess_mode="livemostrecent",
 )
 GAUGE_TASKS_QUEUED = Gauge(
     "authentik_tasks_queued",
     "The number of tasks in queue.",
     ["queue_name", "actor_name"],
+    multiprocess_mode="livemostrecent",
 )
 
 
@@ -38,6 +41,11 @@ def monitoring_set_workers(sender, **kwargs):
     """Set worker gauge"""
     worker_version_count = {}
     our_version = parse(authentik_full_version())
+    worker_versions = WorkerStatus.objects.values_list("version", flat=True).distinct()
+    for version in worker_versions:
+        for gauge in (OLD_GAUGE_WORKERS, GAUGE_WORKERS):
+            gauge.labels(version, True).set(0)
+            gauge.labels(version, False).set(0)
     for status in WorkerStatus.objects.filter(last_seen__gt=now() - timedelta(seconds=45)):
         version_matching = parse(status.version) == our_version
         worker_version_count.setdefault(status.version, {"count": 0, "matching": version_matching})

--- a/authentik/tasks/tests/test_signals.py
+++ b/authentik/tasks/tests/test_signals.py
@@ -8,6 +8,7 @@ Pure unit tests — ``Task.objects`` and ``get_broker`` are mocked so no DB
 connection is required.
 """
 
+from types import SimpleNamespace
 from unittest import TestCase, mock
 
 
@@ -91,3 +92,48 @@ class TestMonitoringSetQueuedTasksDoesNotScan(TestCase):
 
         mock_task.objects.filter.assert_called_once_with(state=TaskState.QUEUED)
         mock_gauge.labels.return_value.set.assert_any_call(5)
+
+
+class TestMonitoringSetWorkers(TestCase):
+    """Tests for worker-count gauge refreshes."""
+
+    def test_obsolete_version_labels_are_reset(self):
+        """Inactive versions and their old match state are reset to zero."""
+        from authentik.tasks import signals
+
+        statuses = [SimpleNamespace(version="2026.5.6")]
+        worker_status = mock.Mock()
+        worker_status.objects.values_list.return_value.distinct.return_value = [
+            "2026.5.6",
+            "2026.4.0",
+        ]
+        worker_status.objects.filter.return_value = statuses
+        old_children = {}
+        children = {}
+
+        def old_labels(version, matched):
+            return old_children.setdefault((version, matched), mock.Mock())
+
+        def labels(version, matched):
+            return children.setdefault((version, matched), mock.Mock())
+
+        with (
+            mock.patch.object(signals, "authentik_full_version", return_value="2026.5.6"),
+            mock.patch.object(signals, "WorkerStatus", worker_status),
+            mock.patch.object(signals, "OLD_GAUGE_WORKERS") as old_gauge,
+            mock.patch.object(signals, "GAUGE_WORKERS") as gauge,
+        ):
+            old_gauge.labels.side_effect = old_labels
+            gauge.labels.side_effect = labels
+            signals.monitoring_set_workers(sender=self)
+
+        worker_status.objects.values_list.assert_called_once_with("version", flat=True)
+        worker_status.objects.values_list.return_value.distinct.assert_called_once_with()
+        for gauge_children in (old_children, children):
+            gauge_children[("2026.4.0", True)].set.assert_called_once_with(0)
+            gauge_children[("2026.4.0", False)].set.assert_called_once_with(0)
+            gauge_children[("2026.5.6", False)].set.assert_called_once_with(0)
+            self.assertEqual(
+                gauge_children[("2026.5.6", True)].set.call_args_list,
+                [mock.call(0), mock.call(1)],
+            )

--- a/packages/django-dramatiq-postgres/django_dramatiq_postgres/middleware.py
+++ b/packages/django-dramatiq-postgres/django_dramatiq_postgres/middleware.py
@@ -274,6 +274,7 @@ class MetricsMiddleware(Middleware):
             f"{self.prefix}_tasks_delayed_in_progress",
             "The number of delayed tasks in memory.",
             self.labels,
+            multiprocess_mode="livesum",
         )
         self.messages_durations = Histogram(
             f"{self.prefix}_tasks_duration_milliseconds",


### PR DESCRIPTION
## Details

### What does this PR change?

Adds explicit Prometheus multiprocess modes for queue, worker, license, cache, outpost, and delayed-task gauges. It also resets stale license and worker-version values.

### Why is this change needed?

The default gauge mode exports one value per Gunicorn worker, allowing stale values from workers that did not handle the latest metrics refresh. This caused incorrect queue depths and duplicate process series.

### How was this tested?

Added tests for unlicensed metric resets and obsolete worker-version labels. Black, Ruff, and a standalone multiprocess aggregation regression check passed.

### Linked issues

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).