### PR TITLE
tests: extract hardcoded image names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -347,7 +347,9 @@ updates:
       - /packages/client-rust
       - /packages/client-ts
       - /scripts
+      - /tests
       - /tests/e2e
+      - /tests/integration
       - /tests/openid_conformance
     schedule:
       interval: daily

--- a/tests/compose.yml
+++ b/tests/compose.yml
@@ -1,0 +1,6 @@
+services:
+  # Not started via `docker compose up`. Pinned here purely so Dependabot's
+  # docker-compose ecosystem can see and bump this image; tests/live.py reads
+  # the tag back out via DockerTestCase.pinned_image().
+  traefik:
+    image: docker.io/library/traefik:3.1

--- a/tests/docker.py
+++ b/tests/docker.py
@@ -1,9 +1,12 @@
 """authentik e2e testing utilities"""
 
+from functools import lru_cache
+from pathlib import Path
 from time import sleep
 from typing import Any
 from unittest.case import TestCase
 
+import yaml
 from docker import DockerClient, from_env
 from docker.errors import DockerException
 from docker.models.containers import Container
@@ -11,6 +14,19 @@ from docker.models.networks import Network
 
 from authentik.lib.generators import generate_id
 from authentik.root.test_runner import get_docker_tag
+
+
+@lru_cache
+def _load_compose_services(compose_path: str) -> dict[str, str]:
+    """Parse a compose.yml and return {service_name: image} for services with a
+    static `image:`. Cached per-process since compose files don't change mid-run."""
+    with open(compose_path, encoding="utf-8") as compose_file:
+        manifest = yaml.safe_load(compose_file)
+    return {
+        name: service["image"]
+        for name, service in manifest.get("services", {}).items()
+        if "image" in service
+    }
 
 
 class DockerTestCase(TestCase):
@@ -56,6 +72,15 @@ class DockerTestCase(TestCase):
     def get_container_image(self, base: str) -> str:
         """Try to pull docker image based on git branch, fallback to main if not found."""
         return f"{base}:{get_docker_tag()}"
+
+    def pinned_image(self, service: str, compose_file: str) -> str:
+        """Look up a Dependabot-managed image reference for `service` from a
+        compose.yml, e.g. self.pinned_image("grafana", "e2e/compose.yml")."""
+        compose_path = Path(__file__).parent / compose_file
+        services = _load_compose_services(str(compose_path))
+        if service not in services:
+            raise KeyError(f"No service '{service}' in {compose_path}. Known: {sorted(services)}")
+        return services[service]
 
     def run_container(self, **specs: Any) -> Container:
         if "network_mode" not in specs:

--- a/tests/e2e/compose.yml
+++ b/tests/e2e/compose.yml
@@ -31,7 +31,7 @@ services:
     image: ghcr.io/beryju/saml-test-idp:0.11
     profiles: [pin-only]
   grafana:
-    image: grafana/grafana:7.1.0
+    image: docker.io/grafana/grafana:7.1.0
     profiles: [pin-only]
   oidc-test-client:
     image: ghcr.io/beryju/oidc-test-client:2.1
@@ -51,16 +51,14 @@ services:
   scim2-compliance-test-utility:
     image: ghcr.io/suvera/scim2-compliance-test-utility@sha256:eca913bb73c46892cd1fb2dfd2fef1c5881e6abc5cb0eec7e92fb78c1b933ece
     profiles: [pin-only]
-  # Floating tags: Dependabot cannot bump `latest`. Re-pin to a concrete
-  # upstream version to get real update coverage for these three.
   whoami:
-    image: traefik/whoami:latest
+    image: ghcr.io/traefik/whoami:v1.12
     profiles: [pin-only]
   test-samba-dc:
-    image: ghcr.io/beryju/test-samba-dc:latest
+    image: ghcr.io/beryju/test-samba-dc:v1.0
     profiles: [pin-only]
   openssh-server:
-    image: lscr.io/linuxserver/openssh-server:latest
+    image: ghcr.io/linuxserver/openssh-server:10.3_p1-r1-ls236
     profiles: [pin-only]
   traefik:
     image: docker.io/library/traefik:3.1

--- a/tests/e2e/compose.yml
+++ b/tests/e2e/compose.yml
@@ -21,3 +21,56 @@ services:
       test: ["CMD", "wget", "--spider", "http://localhost:8025"]
       interval: 5s
       start_period: 1s
+
+  # The services below are never started by `docker compose up` (do NOT add the
+  # `pin-only` profile to any CI job's COMPOSE_PROFILES). They exist solely so
+  # Dependabot's docker-compose ecosystem can see and bump these third-party
+  # image references; individual e2e tests read the pinned tag back out of this
+  # file at runtime via DockerTestCase.pinned_image().
+  saml-test-idp:
+    image: ghcr.io/beryju/saml-test-idp:0.11
+    profiles: [pin-only]
+  grafana:
+    image: grafana/grafana:7.1.0
+    profiles: [pin-only]
+  oidc-test-client:
+    image: ghcr.io/beryju/oidc-test-client:2.1
+    profiles: [pin-only]
+  saml-test-sp:
+    image: ghcr.io/beryju/saml-test-sp:1.1
+    profiles: [pin-only]
+  dex:
+    image: ghcr.io/dexidp/dex:v2.44.0
+    profiles: [pin-only]
+  oauth1-test-server:
+    image: ghcr.io/beryju/oauth1-test-server:v1.1
+    profiles: [pin-only]
+  wsfed-test-sp:
+    image: ghcr.io/beryju/wsfed-test-sp:v0.1.2
+    profiles: [pin-only]
+  scim2-compliance-test-utility:
+    image: ghcr.io/suvera/scim2-compliance-test-utility@sha256:eca913bb73c46892cd1fb2dfd2fef1c5881e6abc5cb0eec7e92fb78c1b933ece
+    profiles: [pin-only]
+  # Floating tags: Dependabot cannot bump `latest`. Re-pin to a concrete
+  # upstream version to get real update coverage for these three.
+  whoami:
+    image: traefik/whoami:latest
+    profiles: [pin-only]
+  test-samba-dc:
+    image: ghcr.io/beryju/test-samba-dc:latest
+    profiles: [pin-only]
+  openssh-server:
+    image: lscr.io/linuxserver/openssh-server:latest
+    profiles: [pin-only]
+  traefik:
+    image: docker.io/library/traefik:3.1
+    profiles: [pin-only]
+  nginx:
+    image: docker.io/library/nginx:1.27
+    profiles: [pin-only]
+  envoy:
+    image: docker.io/envoyproxy/envoy:v1.25-latest
+    profiles: [pin-only]
+  caddy:
+    image: docker.io/library/caddy:2.8
+    profiles: [pin-only]

--- a/tests/e2e/test_provider_oauth2_github.py
+++ b/tests/e2e/test_provider_oauth2_github.py
@@ -31,7 +31,7 @@ class TestProviderOAuth2Github(SeleniumTestCase):
         self.client_secret = generate_key()
         super().setUp()
         self.run_container(
-            image="grafana/grafana:7.1.0",
+            image=self.pinned_image("grafana", "e2e/compose.yml"),
             ports={
                 "3000": "3000",
             },

--- a/tests/e2e/test_provider_oauth2_grafana.py
+++ b/tests/e2e/test_provider_oauth2_grafana.py
@@ -40,7 +40,7 @@ class TestProviderOAuth2OAuth(SeleniumTestCase):
         self.app_slug = generate_id(20)
         super().setUp()
         self.run_container(
-            image="grafana/grafana:7.1.0",
+            image=self.pinned_image("grafana", "e2e/compose.yml"),
             ports={
                 "3000": "3000",
             },

--- a/tests/e2e/test_provider_oidc.py
+++ b/tests/e2e/test_provider_oidc.py
@@ -44,7 +44,7 @@ class TestProviderOAuth2OIDC(SeleniumTestCase):
         """Setup client oidc-test-client container which we test OIDC against"""
         sleep(1)
         self.run_container(
-            image="ghcr.io/beryju/oidc-test-client:2.1",
+            image=self.pinned_image("oidc-test-client", "e2e/compose.yml"),
             ports={
                 "9009": "9009",
             },

--- a/tests/e2e/test_provider_oidc_implicit.py
+++ b/tests/e2e/test_provider_oidc_implicit.py
@@ -44,7 +44,7 @@ class TestProviderOAuth2OIDCImplicit(SeleniumTestCase):
         """Setup client oidc-test-client container which we test OIDC against"""
         sleep(1)
         self.run_container(
-            image="ghcr.io/beryju/oidc-test-client:2.1",
+            image=self.pinned_image("oidc-test-client", "e2e/compose.yml"),
             ports={
                 "9009": "9009",
             },

--- a/tests/e2e/test_provider_proxy.py
+++ b/tests/e2e/test_provider_proxy.py
@@ -25,7 +25,7 @@ class TestProviderProxy(SeleniumTestCase):
     def setUp(self):
         super().setUp()
         self.run_container(
-            image="traefik/whoami:latest",
+            image=self.pinned_image("whoami", "e2e/compose.yml"),
             ports={
                 "80": "80",
             },

--- a/tests/e2e/test_provider_proxy_forward.py
+++ b/tests/e2e/test_provider_proxy_forward.py
@@ -23,7 +23,7 @@ class TestProviderProxyForward(SeleniumTestCase):
     def setUp(self):
         super().setUp()
         self.run_container(
-            image="traefik/whoami:latest",
+            image=self.pinned_image("whoami", "e2e/compose.yml"),
             name="ak-whoami",
         )
 
@@ -85,7 +85,7 @@ class TestProviderProxyForward(SeleniumTestCase):
             Path(__file__).parent / "proxy_forward_auth" / "traefik_single" / "config-static.yaml"
         )
         self.run_container(
-            image="docker.io/library/traefik:3.1",
+            image=self.pinned_image("traefik", "e2e/compose.yml"),
             ports={
                 "80": "80",
             },
@@ -127,7 +127,7 @@ class TestProviderProxyForward(SeleniumTestCase):
 
         # Start nginx last so all hosts are resolvable, otherwise nginx exits
         self.run_container(
-            image="docker.io/library/nginx:1.27",
+            image=self.pinned_image("nginx", "e2e/compose.yml"),
             ports={
                 "80": "80",
             },
@@ -163,7 +163,7 @@ class TestProviderProxyForward(SeleniumTestCase):
     def test_envoy(self):
         """Test envoy"""
         self.run_container(
-            image="docker.io/envoyproxy/envoy:v1.25-latest",
+            image=self.pinned_image("envoy", "e2e/compose.yml"),
             ports={
                 "10000": "80",
             },
@@ -207,7 +207,7 @@ class TestProviderProxyForward(SeleniumTestCase):
             Path(__file__).parent / "proxy_forward_auth" / "caddy_single" / "Caddyfile"
         )
         self.run_container(
-            image="docker.io/library/caddy:2.8",
+            image=self.pinned_image("caddy", "e2e/compose.yml"),
             ports={
                 "80": "80",
             },

--- a/tests/e2e/test_provider_rac.py
+++ b/tests/e2e/test_provider_rac.py
@@ -47,7 +47,7 @@ class TestProviderRAC(ChannelsSeleniumTestCase):
     def test_rac_ssh(self):
         """Test SSH RAC"""
         test_ssh = self.run_container(
-            image="lscr.io/linuxserver/openssh-server:latest",
+            image=self.pinned_image("openssh-server", "e2e/compose.yml"),
             ports={
                 "2222": "2222",
             },

--- a/tests/e2e/test_provider_saml.py
+++ b/tests/e2e/test_provider_saml.py
@@ -34,7 +34,7 @@ class TestProviderSAML(SeleniumTestCase):
         if force_post:
             metadata_url += f"&force_binding={SAML_BINDING_POST}"
         self.run_container(
-            image="ghcr.io/beryju/saml-test-sp:1.1",
+            image=self.pinned_image("saml-test-sp", "e2e/compose.yml"),
             ports={
                 "9009": "9009",
             },

--- a/tests/e2e/test_provider_ws_fed.py
+++ b/tests/e2e/test_provider_ws_fed.py
@@ -32,7 +32,7 @@ class TestProviderWSFed(SeleniumTestCase):
             + "?download"
         )
         self.run_container(
-            image="ghcr.io/beryju/wsfed-test-sp:v0.1.2",
+            image=self.pinned_image("wsfed-test-sp", "e2e/compose.yml"),
             ports={
                 "8080": "8080",
             },

--- a/tests/e2e/test_source_ldap_samba.py
+++ b/tests/e2e/test_source_ldap_samba.py
@@ -23,7 +23,7 @@ class TestSourceLDAPSamba(E2ETestCase):
         self.admin_password = generate_key()
         super().setUp()
         self.samba = self.run_container(
-            image="ghcr.io/beryju/test-samba-dc:latest",
+            image=self.pinned_image("test-samba-dc", "e2e/compose.yml"),
             cap_add=["SYS_ADMIN"],
             ports={
                 "389": "389/tcp",

--- a/tests/e2e/test_source_oauth_oauth1.py
+++ b/tests/e2e/test_source_oauth_oauth1.py
@@ -58,7 +58,7 @@ class TestSourceOAuth1(SeleniumTestCase):
         self.source_slug = generate_id()
         super().setUp()
         self.run_container(
-            image="ghcr.io/beryju/oauth1-test-server:v1.1",
+            image=self.pinned_image("oauth1-test-server", "e2e/compose.yml"),
             ports={"5000": "5001"},
             environment={
                 "OAUTH1_CLIENT_ID": self.client_id,

--- a/tests/e2e/test_source_oauth_oauth2.py
+++ b/tests/e2e/test_source_oauth_oauth2.py
@@ -34,7 +34,7 @@ class TestSourceOAuth2(SeleniumTestCase):
         self.slug = generate_id()
         super().setUp()
         self.run_container(
-            image="ghcr.io/dexidp/dex:v2.44.0",
+            image=self.pinned_image("dex", "e2e/compose.yml"),
             ports={"5556": "5556"},
             healthcheck=Healthcheck(
                 test=["CMD", "wget", "--spider", "http://localhost:5556/dex/healthz"],

--- a/tests/e2e/test_source_saml.py
+++ b/tests/e2e/test_source_saml.py
@@ -119,7 +119,7 @@ class TestSourceSAML(SeleniumTestCase):
             verification_kp=keypair,
         )
         self.run_container(
-            image="ghcr.io/beryju/saml-test-idp:0.11",
+            image=self.pinned_image("saml-test-idp", "e2e/compose.yml"),
             ports={"9009": "9009"},
             environment={
                 "IDP_ROOT_URL": f"http://{self.host}:9009",
@@ -193,7 +193,7 @@ class TestSourceSAML(SeleniumTestCase):
             verification_kp=keypair,
         )
         self.run_container(
-            image="ghcr.io/beryju/saml-test-idp:0.11",
+            image=self.pinned_image("saml-test-idp", "e2e/compose.yml"),
             ports={"9009": "9009"},
             environment={
                 "IDP_ROOT_URL": f"http://{self.host}:9009",
@@ -280,7 +280,7 @@ class TestSourceSAML(SeleniumTestCase):
             verification_kp=keypair,
         )
         self.run_container(
-            image="ghcr.io/beryju/saml-test-idp:0.11",
+            image=self.pinned_image("saml-test-idp", "e2e/compose.yml"),
             ports={"9009": "9009"},
             environment={
                 "IDP_ROOT_URL": f"http://{self.host}:9009",
@@ -354,7 +354,7 @@ class TestSourceSAML(SeleniumTestCase):
             verification_kp=keypair,
         )
         self.run_container(
-            image="ghcr.io/beryju/saml-test-idp:0.11",
+            image=self.pinned_image("saml-test-idp", "e2e/compose.yml"),
             ports={"9009": "9009"},
             environment={
                 "IDP_ROOT_URL": f"http://{self.host}:9009",

--- a/tests/e2e/test_source_scim.py
+++ b/tests/e2e/test_source_scim.py
@@ -21,10 +21,7 @@ class TestSourceSCIM(E2ETestCase):
         self.slug = generate_id()
         super().setUp()
         self.run_container(
-            image=(
-                "ghcr.io/suvera/scim2-compliance-test-utility@sha256:eca913bb73"
-                "c46892cd1fb2dfd2fef1c5881e6abc5cb0eec7e92fb78c1b933ece"
-            ),
+            image=self.pinned_image("scim2-compliance-test-utility", "e2e/compose.yml"),
             ports={"8080": "8080"},
             healthcheck=Healthcheck(
                 test=["CMD", "curl", "http://localhost:8080"],

--- a/tests/integration/compose.yml
+++ b/tests/integration/compose.yml
@@ -1,0 +1,6 @@
+services:
+  # Not started via `docker compose up`. Pinned here purely so Dependabot's
+  # docker-compose ecosystem can see and bump this image; the docker-in-docker
+  # integration tests read the tag back out via DockerTestCase.pinned_image().
+  dind:
+    image: docker.io/library/docker:28.5.2-dind-alpine3.22

--- a/tests/integration/test_outpost_docker.py
+++ b/tests/integration/test_outpost_docker.py
@@ -31,7 +31,7 @@ class OutpostDockerTests(DockerTestCase, ChannelsLiveServerTestCase):
         super().setUp()
         self.ssl_folder = mkdtemp()
         self.run_container(
-            image="docker.io/library/docker:28.5.2-dind-alpine3.22",
+            image=self.pinned_image("dind", "integration/compose.yml"),
             network_mode="host",
             privileged=True,
             healthcheck=Healthcheck(

--- a/tests/integration/test_proxy_docker.py
+++ b/tests/integration/test_proxy_docker.py
@@ -31,7 +31,7 @@ class TestProxyDocker(DockerTestCase, ChannelsLiveServerTestCase):
         super().setUp()
         self.ssl_folder = mkdtemp()
         self.run_container(
-            image="docker.io/library/docker:28.5.2-dind-alpine3.22",
+            image=self.pinned_image("dind", "integration/compose.yml"),
             network_mode="host",
             privileged=True,
             healthcheck=Healthcheck(

--- a/tests/live.py
+++ b/tests/live.py
@@ -98,7 +98,7 @@ class SSLLiveMixin(DockerTestCase):
         fd, self._traefik_config = mkstemp()
         write(fd, safe_dump(config).encode())
         traefik = self.run_container(
-            image="docker.io/library/traefik:3.1",
+            image=self.pinned_image("traefik", "compose.yml"),
             command=[
                 "--providers.file.filename=/etc/traefik/dynamic.yml",
                 "--providers.file.watch=true",


### PR DESCRIPTION
we've had container image names hardcoded in python for a long time, the issue being that they almost never get updated

Could've gone with renovate and regex updaters, however I also don't hate this solution