### PR TITLE
feat(ldap-outpost): Render map[string]any as proper ldap attrs

### DIFF
--- a/internal/outpost/ldap/utils/utils.go
+++ b/internal/outpost/ldap/utils/utils.go
@@ -56,6 +56,18 @@ func AttributesToLDAP(
 	for attrKey, attrValue := range attrs {
 		entry := &ldap.EntryAttribute{Name: keyFormatter(attrKey)}
 		switch t := attrValue.(type) {
+		case map[string]any:
+			// When finding a nested map: generate prefixed entries in the form of
+			// key--subkey.
+			prefixedFormatter := func(key string) string {
+				return keyFormatter(attrKey + "--" + key)
+			}
+			nestedAttrs := AttributesToLDAP(t, prefixedFormatter, valueFormatter)
+			for _, attr := range nestedAttrs {
+				if len(attr.Values) > 0 {
+					attrList = append(attrList, attr)
+				}
+			}
 		case []string:
 			entry.Values = valueFormatter(t)
 		case *[]string:
@@ -75,7 +87,11 @@ func AttributesToLDAP(
 				entry.Values = valueFormatter([]string{*v})
 			}
 		}
-		attrList = append(attrList, entry)
+		// Nested map produce empty entries (as a result of recursion, skip adding
+		// empty entries to the resultset)
+		if len(entry.Values) > 0 {
+			attrList = append(attrList, entry)
+		}
 	}
 	return attrList
 }

--- a/internal/outpost/ldap/utils/utils_test.go
+++ b/internal/outpost/ldap/utils/utils_test.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"slices"
+	"strings"
 	"testing"
 
+	"beryju.io/ldap"
 	"github.com/stretchr/testify/assert"
 	api "goauthentik.io/packages/client-go"
 )
@@ -102,4 +105,69 @@ func TestAKAttrsToLDAP_Mixed(t *testing.T) {
 	assert.Equal(t, 1, len(mapped))
 	assert.Equal(t, "foo", mapped[0].Name)
 	assert.Equal(t, []string{"foo", "6"}, mapped[0].Values)
+}
+
+func TestAKNestedAttrsToLDAP_onelevel(t *testing.T) {
+	d := map[string]any{
+		"bar": map[string]any{
+			"baz": "quux",
+		},
+	}
+	mapped := AttributesToLDAP(d, func(key string) string {
+		return AttributeKeySanitize(key)
+	}, func(value []string) []string {
+		return value
+	})
+	assert.Equal(t, 1, len(mapped))
+	assert.Equal(t, "bar--baz", mapped[0].Name)
+	assert.Equal(t, []string{"quux"}, mapped[0].Values)
+}
+
+func TestAKNestedAttrsToLDAP_multiple_levels(t *testing.T) {
+	d := map[string]any{
+		"foo": map[string]any{
+			"bar": map[string]any{
+				"baz": "quux",
+			},
+		},
+	}
+	mapped := AttributesToLDAP(d, func(key string) string {
+		return AttributeKeySanitize(key)
+	}, func(value []string) []string {
+		return value
+	})
+	assert.Equal(t, 1, len(mapped))
+	assert.Equal(t, "foo--bar--baz", mapped[0].Name)
+	assert.Equal(t, []string{"quux"}, mapped[0].Values)
+}
+
+func TestAKNestedAttrsToLDAP_more_than_one_attr(t *testing.T) {
+	d := map[string]any{
+		"root": "value",
+		"lorem": map[string]any{
+			"ipsum": "dolor",
+		},
+		"foo": map[string]any{
+			"bar": map[string]any{
+				"baz": "quux",
+			},
+		},
+	}
+	mapped := AttributesToLDAP(d, func(key string) string {
+		return AttributeKeySanitize(key)
+	}, func(value []string) []string {
+		return value
+	})
+	assert.Equal(t, 3, len(mapped))
+
+	slices.SortFunc(mapped, func(a, b *ldap.EntryAttribute) int {
+		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+	})
+
+	assert.Equal(t, "foo--bar--baz", mapped[0].Name)
+	assert.Equal(t, []string{"quux"}, mapped[0].Values)
+	assert.Equal(t, "lorem--ipsum", mapped[1].Name)
+	assert.Equal(t, []string{"dolor"}, mapped[1].Values)
+	assert.Equal(t, "root", mapped[2].Name)
+	assert.Equal(t, []string{"value"}, mapped[2].Values)
 }


### PR DESCRIPTION
## Details

When finding map[string]any values, instead of generating an ldap value with the string representation of the go map value it generates ldap keys in the form of:

```
origKey--subKey: value
```

These new "virtual" keys are also searchable as the LDAP search filters are executed after the entry generation phase.

### What does this PR change?

TL;DR:

Old:

```
address: map[country:DE locality:foo postalCode:123456 state:bar street:baz]
```

New:
```
address--country: DE
address--locality: foo
address--postalCode: 123456
address--state: bar
address--street: baz
```

### How was this tested?

Unit tests are included in the PR

### Linked issues

Closes: goauthentik/authentik#16954

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).

No AI was used in this changeset.