### PR TITLE
web/router: path-segment tabs (routed base context)

### DIFF
--- a/authentik/core/sources/flow_manager.py
+++ b/authentik/core/sources/flow_manager.py
@@ -412,7 +412,7 @@ class SourceFlowManager:
             reverse(
                 "authentik_core:if-user",
             )
-            + "#/settings;page-sources"
+            + "settings/sources"
         )
 
     def handle_enroll(

--- a/authentik/core/tests/test_source_flow_manager.py
+++ b/authentik/core/tests/test_source_flow_manager.py
@@ -86,7 +86,7 @@ class TestSourceFlowManager(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
             response.url,
-            reverse("authentik_core:if-user") + "#/settings;page-sources",
+            reverse("authentik_core:if-user") + "settings/sources",
         )
 
     def test_authenticated_auth_forwards_kwargs(self):

--- a/tests/e2e/test_source_oauth_oauth2.py
+++ b/tests/e2e/test_source_oauth_oauth2.py
@@ -61,12 +61,10 @@ class TestSourceOAuth2(SeleniumTestCase):
         url_after_login = self.driver.current_url
 
         user_settings_url = self.if_user_url("/settings")
+        # Tabs are path segments now: `/if/user/settings/<tab>` selects the tab.
+        tab_url = self.if_user_url(f"/settings/{tab_name}")
 
-        # `if_user_url` builds a path now, so the legacy `;{"page": ...}` tail no
-        # longer forms a routable URL — `/settings` is an exact route and the
-        # decorated path falls through to the 404 outlet. `ak-tabs` selects from
-        # the `page` search parameter, so ask for the tab that way.
-        self.driver.get(f"{user_settings_url}?page=page-{tab_name}")
+        self.driver.get(tab_url)
 
         try:
             self.wait.until(ec.url_contains(user_settings_url))
@@ -244,12 +242,11 @@ class TestSourceOAuth2(SeleniumTestCase):
 
         self.login_via_oauth_provider()
 
-        # The source flow manager still redirects to the legacy hash form
-        # (`/if/user/#/settings;page-sources`). The interface's boot shim rewrites
-        # that at load, decoding the bare tab token into the `page` search
-        # parameter — see `translateHashRoute`. Wait for the translation rather
-        # than reading the URL the server handed the browser.
-        post_login_expected_url = self.if_user_url("/settings?page=page-sources")
+        # The source flow manager now redirects straight to the path-segment tab,
+        # so no hash translation is involved. Still waited on rather than read
+        # directly: the redirect chain settles a moment after the OAuth provider
+        # hands control back.
+        post_login_expected_url = self.if_user_url("/settings/sources")
 
         WebDriverWait(self.driver, 30).until(
             ec.url_to_be(post_login_expected_url),

--- a/web/src/admin/Routes.ts
+++ b/web/src/admin/Routes.ts
@@ -45,7 +45,7 @@ export const ROUTES: RouteLike[] = [
         "dashboard-users",
     ),
     new Route(
-        "/administration/system-tasks",
+        "/administration/system-tasks{/*}?",
         async () => {
             await import("#admin/admin-overview/SystemTasksPage");
             return html`<ak-system-tasks></ak-system-tasks>`;
@@ -62,7 +62,7 @@ export const ROUTES: RouteLike[] = [
         "providers",
     ),
     new Route<{ id: string }>(
-        "/core/providers/:id",
+        "/core/providers/:id{/*}?",
         async (args) => {
             await import("#admin/providers/ProviderViewPage");
             return html`<ak-provider-view .providerID=${parseInt(args.id, 10)}></ak-provider-view>`;
@@ -79,7 +79,7 @@ export const ROUTES: RouteLike[] = [
         "applications",
     ),
     new Route<{ slug: string }>(
-        "/core/applications/:slug",
+        "/core/applications/:slug{/*}?",
         async (args) => {
             await import("#admin/applications/ApplicationViewPage");
             return html`<ak-application-view .applicationSlug=${args.slug}></ak-application-view>`;
@@ -96,7 +96,7 @@ export const ROUTES: RouteLike[] = [
         "devices",
     ),
     new Route<{ uuid: string }>(
-        "/endpoints/devices/:uuid",
+        "/endpoints/devices/:uuid{/*}?",
         async (args) => {
             await import("#admin/endpoints/devices/DeviceViewPage");
             return html`<ak-endpoints-device-view
@@ -114,7 +114,7 @@ export const ROUTES: RouteLike[] = [
         "connectors",
     ),
     new Route<{ uuid: string }>(
-        "/endpoints/connectors/:uuid",
+        "/endpoints/connectors/:uuid{/*}?",
         async (args) => {
             await import("#admin/endpoints/connectors/ConnectorViewPage");
             return html`<ak-endpoints-connector-view
@@ -141,7 +141,7 @@ export const ROUTES: RouteLike[] = [
         "sources",
     ),
     new Route<{ slug: string }>(
-        "/core/sources/:slug",
+        "/core/sources/:slug{/*}?",
         async (args) => {
             await import("#admin/sources/SourceViewPage");
             return html`<ak-source-view .sourceSlug=${args.slug}></ak-source-view>`;
@@ -224,7 +224,7 @@ export const ROUTES: RouteLike[] = [
         "groups",
     ),
     new Route<{ uuid: string }>(
-        "/identity/groups/:uuid",
+        "/identity/groups/:uuid{/*}?",
         async (args) => {
             await import("#admin/groups/GroupViewPage");
             return html`<ak-group-view .groupId=${args.uuid}></ak-group-view>`;
@@ -274,7 +274,7 @@ export const ROUTES: RouteLike[] = [
         "initial-permissions",
     ),
     new Route<{ id: string }>(
-        "/identity/roles/:id",
+        "/identity/roles/:id{/*}?",
         async (args) => {
             await import("#admin/roles/ak-role-view");
             return html`<ak-role-view roleId=${args.id}></ak-role-view>`;
@@ -315,7 +315,7 @@ export const ROUTES: RouteLike[] = [
         "flows",
     ),
     new Route<{ slug: string }>(
-        "/flow/flows/:slug",
+        "/flow/flows/:slug{/*}?",
         async (args) => {
             await import("#admin/flows/FlowViewPage");
             return html`<ak-flow-view
@@ -400,7 +400,7 @@ export const ROUTES: RouteLike[] = [
         "outposts",
     ),
     new Route<{ id: string }>(
-        "/outpost/outposts/:id",
+        "/outpost/outposts/:id{/*}?",
         async (args) => {
             await import("#admin/outposts/OutpostViewPage");
             return html`<ak-outpost-view .outpostID=${args.id}></ak-outpost-view>`;

--- a/web/src/admin/Routes.ts
+++ b/web/src/admin/Routes.ts
@@ -248,7 +248,9 @@ export const ROUTES: RouteLike[] = [
         "users",
     ),
     new Route<{ id: string }>(
-        "/identity/users/:id",
+        // The `{/*}?` tail carries the tab path (`/identity/users/22/credentials`)
+        // to this route while `ak-user-view` stays mounted across tab changes.
+        "/identity/users/:id{/*}?",
         async (args) => {
             await import("#admin/users/UserViewPage");
             return html`<ak-user-view .userId=${parseInt(args.id, 10)}></ak-user-view>`;

--- a/web/src/admin/admin-overview/SystemTasksPage.ts
+++ b/web/src/admin/admin-overview/SystemTasksPage.ts
@@ -40,7 +40,7 @@ export class SystemTasksPage extends AKElement {
 
     render(): TemplateResult {
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/applications/ApplicationViewPage.ts
+++ b/web/src/admin/applications/ApplicationViewPage.ts
@@ -296,7 +296,7 @@ export class ApplicationViewPage extends WithLicenseSummary(AKElement) {
         }
 
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 ${this.missingOutpost
                     ? html`
                           <div

--- a/web/src/admin/endpoints/connectors/agent/AgentConnectorViewPage.ts
+++ b/web/src/admin/endpoints/connectors/agent/AgentConnectorViewPage.ts
@@ -86,7 +86,7 @@ export class AgentConnectorViewPage extends AKElement {
         if (!this.connector) {
             return nothing;
         }
-        return html`<ak-tabs>
+        return html`<ak-tabs routed>
             <div
                 role="tabpanel"
                 tabindex="0"

--- a/web/src/admin/endpoints/connectors/fleet/FleetConnectorViewPage.ts
+++ b/web/src/admin/endpoints/connectors/fleet/FleetConnectorViewPage.ts
@@ -86,7 +86,7 @@ export class FleetConnectorViewPage extends AKElement {
         if (!this.connector) {
             return nothing;
         }
-        return html`<ak-tabs>
+        return html`<ak-tabs routed>
             <div
                 role="tabpanel"
                 tabindex="0"

--- a/web/src/admin/endpoints/connectors/gdtc/GoogleChromeConnectorViewPage.ts
+++ b/web/src/admin/endpoints/connectors/gdtc/GoogleChromeConnectorViewPage.ts
@@ -67,7 +67,7 @@ export class GoogleChromeConnectorViewPage extends AKElement {
         if (!this.connector) {
             return nothing;
         }
-        return html`<ak-tabs>
+        return html`<ak-tabs routed>
             <div
                 role="tabpanel"
                 tabindex="0"

--- a/web/src/admin/endpoints/devices/DeviceViewPage.ts
+++ b/web/src/admin/endpoints/devices/DeviceViewPage.ts
@@ -265,7 +265,7 @@ export class DeviceViewPage extends AKElement {
 
     render() {
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/flows/FlowViewPage.ts
+++ b/web/src/admin/flows/FlowViewPage.ts
@@ -77,7 +77,7 @@ export class FlowViewPage extends AKElement {
             return nothing;
         }
         return html`<main part="main">
-            <ak-tabs exportparts="container:tabs">
+            <ak-tabs routed exportparts="container:tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/groups/GroupViewPage.ts
+++ b/web/src/admin/groups/GroupViewPage.ts
@@ -84,7 +84,7 @@ export class GroupViewPage extends WithLicenseSummary(AKElement) {
             return nothing;
         }
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <section
                     role="tabpanel"
                     tabindex="0"
@@ -251,7 +251,7 @@ export class GroupViewPage extends WithLicenseSummary(AKElement) {
 
     protected renderTabRoles(group: Group): TemplateResult {
         return html`
-            <ak-tabs pageIdentifier="groupRoles" vertical>
+            <ak-tabs routed vertical>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/outposts/OutpostViewPage.ts
+++ b/web/src/admin/outposts/OutpostViewPage.ts
@@ -307,7 +307,7 @@ export class OutpostViewPage extends AKElement {
         }
 
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
+++ b/web/src/admin/providers/google_workspace/GoogleWorkspaceProviderViewPage.ts
@@ -88,7 +88,7 @@ export class GoogleWorkspaceProviderViewPage extends AKElement {
             return nothing;
         }
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <section
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
+++ b/web/src/admin/providers/ldap/LDAPProviderViewPage.ts
@@ -78,7 +78,7 @@ export class LDAPProviderViewPage extends WithSession(AKElement) {
             return nothing;
         }
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
+++ b/web/src/admin/providers/microsoft_entra/MicrosoftEntraProviderViewPage.ts
@@ -88,7 +88,7 @@ export class MicrosoftEntraProviderViewPage extends AKElement {
             return nothing;
         }
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
+++ b/web/src/admin/providers/oauth2/OAuth2ProviderViewPage.ts
@@ -161,7 +161,7 @@ export class OAuth2ProviderViewPage extends AKElement {
             return nothing;
         }
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
+++ b/web/src/admin/providers/proxy/ProxyProviderViewPage.ts
@@ -196,7 +196,7 @@ export class ProxyProviderViewPage extends AKElement {
             return nothing;
         }
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/rac/RACProviderViewPage.ts
+++ b/web/src/admin/providers/rac/RACProviderViewPage.ts
@@ -81,7 +81,7 @@ export class RACProviderViewPage extends AKElement {
         }
 
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/radius/RadiusProviderViewPage.ts
+++ b/web/src/admin/providers/radius/RadiusProviderViewPage.ts
@@ -72,7 +72,7 @@ export class RadiusProviderViewPage extends AKElement {
             return nothing;
         }
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/saml/SAMLProviderViewPage.ts
+++ b/web/src/admin/providers/saml/SAMLProviderViewPage.ts
@@ -238,7 +238,7 @@ export class SAMLProviderViewPage extends AKElement {
             return nothing;
         }
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/scim/SCIMProviderViewPage.ts
+++ b/web/src/admin/providers/scim/SCIMProviderViewPage.ts
@@ -102,7 +102,7 @@ export class SCIMProviderViewPage extends AKElement {
         }
 
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/ssf/SSFProviderViewPage.ts
+++ b/web/src/admin/providers/ssf/SSFProviderViewPage.ts
@@ -83,7 +83,7 @@ export class SSFProviderViewPage extends AKElement {
             return nothing;
         }
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/providers/wsfed/WSFederationProviderViewPage.ts
+++ b/web/src/admin/providers/wsfed/WSFederationProviderViewPage.ts
@@ -210,7 +210,7 @@ export class WSFederationProviderViewPage extends AKElement {
             return nothing;
         }
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/rbac/ak-rbac-object-permission-page.ts
+++ b/web/src/admin/rbac/ak-rbac-object-permission-page.ts
@@ -42,7 +42,7 @@ export class ObjectPermissionPage extends AKElement {
 
     render() {
         return this.model === ModelEnum.AuthentikRbacRole
-            ? html`<ak-tabs pageIdentifier="permissionPage" ?vertical=${!this.embedded}>
+            ? html`<ak-tabs routed ?vertical=${!this.embedded}>
                   ${this.renderPermissionsAssignedToRole()}
               </ak-tabs>`
             : html`<div class="pf-c-page__main-section pf-m-no-padding-mobile">

--- a/web/src/admin/roles/ak-role-view.ts
+++ b/web/src/admin/roles/ak-role-view.ts
@@ -81,7 +81,7 @@ export class RoleViewPage extends WithLicenseSummary(AKElement) {
         }
 
         return html`<main part="main">
-            <ak-tabs part="tabs">
+            <ak-tabs routed part="tabs">
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
+++ b/web/src/admin/sources/kerberos/KerberosSourceViewPage.ts
@@ -81,7 +81,7 @@ export class KerberosSourceViewPage extends AKElement {
             return nothing;
         }
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
+++ b/web/src/admin/sources/ldap/LDAPSourceViewPage.ts
@@ -81,7 +81,7 @@ export class LDAPSourceViewPage extends AKElement {
         }
 
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
+++ b/web/src/admin/sources/oauth/OAuthSourceViewPage.ts
@@ -103,7 +103,7 @@ export class OAuthSourceViewPage extends AKElement {
             return nothing;
         }
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/sources/plex/PlexSourceViewPage.ts
+++ b/web/src/admin/sources/plex/PlexSourceViewPage.ts
@@ -58,7 +58,7 @@ export class PlexSourceViewPage extends AKElement {
             return nothing;
         }
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/sources/saml/SAMLSourceViewPage.ts
+++ b/web/src/admin/sources/saml/SAMLSourceViewPage.ts
@@ -62,7 +62,7 @@ export class SAMLSourceViewPage extends AKElement {
             return nothing;
         }
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/sources/scim/SCIMSourceViewPage.ts
+++ b/web/src/admin/sources/scim/SCIMSourceViewPage.ts
@@ -70,7 +70,7 @@ export class SCIMSourceViewPage extends AKElement {
             return nothing;
         }
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/admin/sources/telegram/TelegramSourceViewPage.ts
+++ b/web/src/admin/sources/telegram/TelegramSourceViewPage.ts
@@ -53,7 +53,7 @@ export class TelegramSourceViewPage extends AKElement {
         if (!this.source) {
             return html``;
         }
-        return html` <ak-tabs>
+        return html` <ak-tabs routed>
             <section
                 slot="page-overview"
                 data-tab-title="${msg("Overview")}"

--- a/web/src/admin/users/UserCredentialsTab.ts
+++ b/web/src/admin/users/UserCredentialsTab.ts
@@ -38,7 +38,7 @@ export class UserCredentialsTab extends WithLazyTabs(WithLicenseSummary(AKElemen
             return nothing;
         }
 
-        return html`<ak-tabs pageIdentifier="userCredentialsTokens" vertical>
+        return html`<ak-tabs routed vertical>
             <div
                 role="tabpanel"
                 tabindex="0"

--- a/web/src/admin/users/UserRolesTab.ts
+++ b/web/src/admin/users/UserRolesTab.ts
@@ -27,7 +27,7 @@ export class UserRolesTab extends WithLazyTabs(AKElement) {
             return nothing;
         }
 
-        return html`<ak-tabs pageIdentifier="userRoles" vertical>
+        return html`<ak-tabs routed vertical>
             <div
                 role="tabpanel"
                 tabindex="0"

--- a/web/src/admin/users/UserViewPage.ts
+++ b/web/src/admin/users/UserViewPage.ts
@@ -95,7 +95,7 @@ export class UserViewPage extends WithLazyTabs(
         }
 
         return html`<main>
-            <ak-tabs>
+            <ak-tabs routed>
                 <div
                     role="tabpanel"
                     tabindex="0"

--- a/web/src/elements/Tabs.ts
+++ b/web/src/elements/Tabs.ts
@@ -7,13 +7,17 @@ import {
     PaletteCommandDefinitionInit,
 } from "#elements/commands/shared";
 import { intersectionObserver } from "#elements/decorators/intersection-observer";
+import { navigate, RouterNavigateEvent } from "#elements/router/core/navigation";
 import { getSearchParams, updateSearchParams } from "#elements/router/core/search-params";
 import Styles from "#elements/Tabs.css" with { type: "bundled-text" };
+import { routedTabBaseContext } from "#elements/tabs/tab-context";
+import { activeSlotForPath, tabHref } from "#elements/tabs/tab-path";
 import { ifPresent } from "#elements/utils/attributes";
 import { isFocusable } from "#elements/utils/focus";
 
 import { capitalCase } from "change-case";
 
+import { ContextConsumer, ContextProvider } from "@lit/context";
 import { msg, str } from "@lit/localize";
 import { CSSResult, html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -27,6 +31,29 @@ export class Tabs extends AKElement {
     };
     static styles: CSSResult[] = [Styles];
 
+    /**
+     * Opt into path routing: the active tab becomes a path segment
+     * (`/if/user/settings/sessions`) and switching tabs navigates the router.
+     * The base comes from {@linkcode routedTabBaseContext} — provided by the
+     * router outlet for the page, then refined by each nested group — so no
+     * page wiring is needed. Without this (and without {@linkcode base}), the
+     * group falls back to the legacy `?page=` search parameter.
+     */
+    @property({ type: Boolean })
+    public routed = false;
+
+    /**
+     * An explicit mount path override, e.g. `/if/user/settings`. Rarely needed:
+     * prefer {@linkcode routed} and let the context supply the base. Setting it
+     * implies {@linkcode routed}.
+     */
+    @property({ type: String })
+    public base = "";
+
+    /**
+     * The search parameter used to persist the active tab in the legacy
+     * (non-{@linkcode base}) mode.
+     */
     @property({ type: String })
     public pageIdentifier = "page";
 
@@ -48,6 +75,56 @@ export class Tabs extends AKElement {
     #observer: MutationObserver | null = null;
 
     #commands = new CommandPaletteState<string>();
+
+    //#region Routed base
+
+    /**
+     * The base supplied by the nearest routed ancestor (the outlet, or a parent
+     * tab group), consumed reactively.
+     */
+    #baseConsumer = new ContextConsumer(this, {
+        context: routedTabBaseContext,
+        subscribe: true,
+        callback: () => {
+            if (!this.#pathMode) return;
+
+            this.activeTabName = this.#slotFromLocation();
+            this.#publishChildBase();
+        },
+    });
+
+    /**
+     * Provides this group's active-panel path to its subtree, so a nested
+     * `<ak-tabs routed>` derives its base with no wiring.
+     */
+    #childBaseProvider = new ContextProvider(this, {
+        context: routedTabBaseContext,
+        initialValue: "",
+    });
+
+    #publishChildBase(): void {
+        this.#childBaseProvider.setValue(
+            this.activeTabName ? this.#hrefForSlot(this.activeTabName) : this.#effectiveBase,
+        );
+    }
+
+    /**
+     * The mount path this group tracks against: an explicit {@linkcode base}
+     * wins, else the context value from the nearest routed ancestor.
+     */
+    get #effectiveBase(): string {
+        return this.base || this.#baseConsumer.value || "";
+    }
+
+    /**
+     * Whether the active tab is tracked as a path segment rather than a search
+     * parameter.
+     */
+    get #pathMode(): boolean {
+        return this.routed || Boolean(this.base);
+    }
+
+    //#endregion
 
     #updateTabs = (): void => {
         this.tabs = new Map(
@@ -93,6 +170,36 @@ export class Tabs extends AKElement {
         this.#commands.set(commands);
     };
 
+    //#region Navigation
+
+    /**
+     * The active slot for the current location, or `null` when the tabs are not
+     * yet known. Falls back to the first tab when the path names no known tab.
+     */
+    #slotFromLocation(): string | null {
+        return activeSlotForPath(this.#effectiveBase, window.location.pathname, [
+            ...this.tabs.keys(),
+        ]);
+    }
+
+    #hrefForSlot(slotName: string): string {
+        return tabHref(this.#effectiveBase, slotName, this.tabs.keys().next().value ?? null);
+    }
+
+    #onNavigate = (): void => {
+        if (!this.#pathMode) return;
+
+        const nextSlot = this.#slotFromLocation();
+
+        if (!nextSlot || nextSlot === this.activeTabName) return;
+
+        this.activeTabName = nextSlot;
+        this.#publishChildBase();
+        this.dispatchActivateEvent();
+    };
+
+    //#endregion
+
     public override connectedCallback(): void {
         super.connectedCallback();
 
@@ -100,20 +207,30 @@ export class Tabs extends AKElement {
 
         this.addEventListener("focus", this.#delegateFocusListener);
 
-        if (!this.activeTabName) {
-            const params = getSearchParams();
-            const tabParam = params[this.pageIdentifier];
+        window.addEventListener("popstate", this.#onNavigate);
+        window.addEventListener(RouterNavigateEvent.eventName, this.#onNavigate);
 
-            if (
-                tabParam &&
-                typeof tabParam === "string" &&
-                this.querySelector(`[slot='${tabParam}']`)
-            ) {
-                this.activeTabName = tabParam;
-            } else {
-                this.#updateTabs();
-                this.activeTabName = this.tabs.keys().next().value || null;
-            }
+        if (this.activeTabName) return;
+
+        this.#updateTabs();
+
+        if (this.#pathMode) {
+            this.activeTabName = this.#slotFromLocation();
+            this.#publishChildBase();
+            return;
+        }
+
+        const params = getSearchParams();
+        const tabParam = params[this.pageIdentifier];
+
+        if (
+            tabParam &&
+            typeof tabParam === "string" &&
+            this.querySelector(`[slot='${tabParam}']`)
+        ) {
+            this.activeTabName = tabParam;
+        } else {
+            this.activeTabName = this.tabs.keys().next().value || null;
         }
     }
 
@@ -130,6 +247,10 @@ export class Tabs extends AKElement {
     public override disconnectedCallback(): void {
         this.#observer?.disconnect();
         this.#commands.clear();
+
+        window.removeEventListener("popstate", this.#onNavigate);
+        window.removeEventListener(RouterNavigateEvent.eventName, this.#onNavigate);
+
         super.disconnectedCallback();
     }
 
@@ -156,17 +277,25 @@ export class Tabs extends AKElement {
             return;
         }
 
-        const firstTab = this.tabs.keys().next().value || null;
+        if (this.#pathMode) {
+            navigate(this.#hrefForSlot(nextTabName));
+        } else {
+            const firstTab = this.tabs.keys().next().value || null;
 
-        // We avoid adding the tab parameter to the URL if it's the first tab
-        // to both reduce URL length and ensure that tests do not have to deal with
-        // unnecessary URL parameters.
+            // We avoid adding the tab parameter to the URL if it's the first tab
+            // to both reduce URL length and ensure that tests do not have to deal with
+            // unnecessary URL parameters.
 
-        updateSearchParams({
-            [this.pageIdentifier]: nextTabName === firstTab ? null : nextTabName,
-        });
+            updateSearchParams({
+                [this.pageIdentifier]: nextTabName === firstTab ? null : nextTabName,
+            });
+        }
 
         this.activeTabName = nextTabName;
+
+        if (this.#pathMode) {
+            this.#publishChildBase();
+        }
 
         this.dispatchActivateEvent();
     }
@@ -198,24 +327,52 @@ export class Tabs extends AKElement {
         }
     };
 
+    #onTabClick(event: MouseEvent, slotName: string): void {
+        // A modified click (new tab, download) or a non-primary button is left
+        // to the browser so real links keep working; the top outlet's anchor
+        // interceptor claims the rest, but activate directly as a fallback.
+        if (event.button !== 0) return;
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+        event.preventDefault();
+        this.activateTab(slotName);
+    }
+
     renderTab(slotName: string, tabPanel: Element): TemplateResult {
-        return html` <li
-            part="tab-item"
-            class="pf-c-tabs__item ${slotName === this.activeTabName ? CURRENT_CLASS : ""}"
-        >
-            <button
-                type="button"
-                role="tab"
-                part="tab-button"
-                id=${`${slotName}-tab`}
-                name=${slotName}
-                aria-selected=${slotName === this.activeTabName ? "true" : "false"}
-                aria-controls=${ifPresent(slotName)}
-                class="pf-c-tabs__link"
-                @click=${() => this.activateTab(slotName)}
-            >
-                <span class="pf-c-tabs__item-text">${tabPanel.getAttribute("aria-label")}</span>
-            </button>
+        const current = slotName === this.activeTabName;
+        const label = tabPanel.getAttribute("aria-label");
+
+        // Path mode renders a real in-interface link (accessible, middle-click
+        // opens the tab's URL); legacy mode keeps the button-driven behavior.
+        const control = this.#pathMode
+            ? html`<a
+                  href=${this.#hrefForSlot(slotName)}
+                  role="tab"
+                  part="tab-button"
+                  id=${`${slotName}-tab`}
+                  aria-selected=${current ? "true" : "false"}
+                  aria-controls=${ifPresent(slotName)}
+                  class="pf-c-tabs__link"
+                  @click=${(event: MouseEvent) => this.#onTabClick(event, slotName)}
+              >
+                  <span class="pf-c-tabs__item-text">${label}</span>
+              </a>`
+            : html`<button
+                  type="button"
+                  role="tab"
+                  part="tab-button"
+                  id=${`${slotName}-tab`}
+                  name=${slotName}
+                  aria-selected=${current ? "true" : "false"}
+                  aria-controls=${ifPresent(slotName)}
+                  class="pf-c-tabs__link"
+                  @click=${() => this.activateTab(slotName)}
+              >
+                  <span class="pf-c-tabs__item-text">${label}</span>
+              </button>`;
+
+        return html` <li part="tab-item" class="pf-c-tabs__item ${current ? CURRENT_CLASS : ""}">
+            ${control}
         </li>`;
     }
 

--- a/web/src/elements/router/core/RouterView.ts
+++ b/web/src/elements/router/core/RouterView.ts
@@ -192,7 +192,7 @@ export class RouterView extends AKElement {
     #basePath(match: RouteMatch<RouteLike>): string {
         const tail = match.parameters["0"];
 
-        if (tail == null) return this.#join(match.pathname);
+        if (tail === undefined) return this.#join(match.pathname);
 
         const consumed = match.pathname.slice(0, match.pathname.length - tail.length);
 

--- a/web/src/elements/router/core/RouterView.ts
+++ b/web/src/elements/router/core/RouterView.ts
@@ -26,6 +26,7 @@ import {
     RouterNavigateEvent,
 } from "#elements/router/core/navigation";
 import { type RouteLike } from "#elements/router/core/Route";
+import { routedTabBaseContext } from "#elements/tabs/tab-context";
 import { type SlottedTemplateResult } from "#elements/types";
 
 import {
@@ -36,6 +37,7 @@ import {
     startBrowserTracingPageLoadSpan,
 } from "@sentry/browser";
 
+import { ContextProvider } from "@lit/context";
 import { msg } from "@lit/localize";
 import { html, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -86,6 +88,14 @@ export class RouterView extends AKElement {
 
     #sentryClient = getClient();
     #pageLoadSpan: Span | null = null;
+
+    /**
+     * Publishes the current page's mount path to routed `<ak-tabs>` descendants.
+     */
+    #tabBaseProvider = new ContextProvider(this, {
+        context: routedTabBaseContext,
+        initialValue: "",
+    });
 
     constructor() {
         super();
@@ -147,22 +157,46 @@ export class RouterView extends AKElement {
     //#region Matching
 
     /**
-     * Strip the interface prefix, preserving the leading slash the matcher
-     * requires: `/if/user/settings` → `/settings`, `/if/user/` → `/`. A
-     * pathname outside the prefix is returned unchanged so it falls through to
-     * the 404 branch.
+     * Strip the prefix, preserving the leading slash the matcher requires:
+     * `/if/user/settings` → `/settings`, `/if/user/` → `/`. Matching is
+     * segment-aware so a prefix without a trailing slash (a nested outlet's
+     * base, e.g. `…/users/22`) never captures a sibling that merely shares its
+     * text (`…/users/220`). A pathname outside the prefix is returned unchanged
+     * so it falls through to the 404 branch.
      */
     #strip(pathname: string): string {
-        if (!pathname.startsWith(this.prefix)) return pathname;
+        const base = this.prefix.replace(/\/+$/, "");
 
-        return `/${pathname.slice(this.prefix.length).replace(/^\/+/, "")}`;
+        if (pathname === base) return "/";
+        if (pathname.startsWith(`${base}/`)) {
+            return `/${pathname.slice(base.length + 1).replace(/^\/+/, "")}`;
+        }
+
+        return pathname;
     }
 
     /**
-     * Join a route-relative path onto the prefix for navigation.
+     * Join a route-relative path onto the prefix for navigation, normalizing to
+     * exactly one separator regardless of whether the prefix ends in a slash.
      */
     #join(path: string): string {
-        return `${this.prefix}${path.replace(/^\/+/, "")}`;
+        return `${this.prefix.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+    }
+
+    /**
+     * The absolute path consumed to reach a match, excluding its wildcard tail —
+     * the mount path a tabbed page hands to its nested outlet. `/settings` and
+     * `/settings/sessions` (a subtree route) both resolve to base
+     * `/if/user/settings`; the tail (`sessions`) belongs to the nested outlet.
+     */
+    #basePath(match: RouteMatch<RouteLike>): string {
+        const tail = match.parameters["0"];
+
+        if (tail == null) return this.#join(match.pathname);
+
+        const consumed = match.pathname.slice(0, match.pathname.length - tail.length);
+
+        return this.#join(consumed.replace(/\/+$/, "") || "/");
     }
 
     #syncRoute = (): void => {
@@ -176,6 +210,11 @@ export class RouterView extends AKElement {
         }
 
         const next = matchRoute(stripped, this.routes);
+
+        // Publish the mount path (minus any tab tail) so routed `<ak-tabs>` under
+        // this outlet can consume it as their base. Refreshed even when the route
+        // is unchanged, so re-entering the same page restores a correct base.
+        this.#tabBaseProvider.setValue(next ? this.#basePath(next) : "");
 
         // Skip re-resolving when the route and its path parameters are unchanged
         // (a search-param-only change — a tab, a table filter). Reassigning would

--- a/web/src/elements/router/core/RouterView.ts
+++ b/web/src/elements/router/core/RouterView.ts
@@ -19,7 +19,7 @@ import { sentryReporting } from "#common/sentry/tracing";
 import { AKElement } from "#elements/Base";
 import { getRouterConfig } from "#elements/router/core/config";
 import { applyHashRedirect } from "#elements/router/core/hash-shim";
-import { matchRoute, type RouteMatch } from "#elements/router/core/matcher";
+import { matchRoute, type RouteMatch, sameRouteMatch } from "#elements/router/core/matcher";
 import {
     createClickInterceptor,
     navigate,
@@ -175,7 +175,15 @@ export class RouterView extends AKElement {
             stripped = this.#strip(window.location.pathname);
         }
 
-        this.current = matchRoute(stripped, this.routes);
+        const next = matchRoute(stripped, this.routes);
+
+        // Skip re-resolving when the route and its path parameters are unchanged
+        // (a search-param-only change — a tab, a table filter). Reassigning would
+        // hand `until()` a new promise and flash the loading state over a view
+        // that is already mounted.
+        if (sameRouteMatch(this.current, next)) return;
+
+        this.current = next;
     };
 
     //#endregion

--- a/web/src/elements/router/core/matcher.ts
+++ b/web/src/elements/router/core/matcher.ts
@@ -51,10 +51,28 @@ export function matchRoute<R extends RoutePatternLike>(
 }
 
 /**
- * Whether two matches resolve to the same rendered view: the same route with the
- * same path parameters. {@linkcode matchRoute} returns a fresh object every call,
- * so a search-param-only navigation (a tab, a table filter) yields an equal-but-
- * new match — comparing structurally lets a consumer skip re-rendering it.
+ * `URLPattern` names unnamed groups — `*` and `(.*)` — with sequential integer
+ * keys. A route that matches a subtree (`/users/:id{/*}?`) captures the tail
+ * this way, and that tail is sub-navigation the *mounted* view owns (its tabs),
+ * not the identity of the mount. Named groups (`:id`) identify the mount.
+ */
+const WILDCARD_GROUP_KEY = /^\d+$/;
+
+function identifyingKeys(parameters: Record<string, string | undefined>): string[] {
+    return Object.keys(parameters).filter((key) => !WILDCARD_GROUP_KEY.test(key));
+}
+
+/**
+ * Whether two matches resolve to the same mounted view: the same route with the
+ * same *identifying* (named) path parameters. {@linkcode matchRoute} returns a
+ * fresh object every call, so a search-only navigation (a table filter) or a
+ * wildcard-tail change (a tab, in a subtree route) yields an equal-but-new match
+ * — comparing structurally lets the outlet skip re-resolving it, which would
+ * otherwise tear down and reload an already-mounted view.
+ *
+ * The wildcard tail is deliberately excluded: a subtree route stays mounted
+ * while its tabs move through the tail, and the nested outlet inside it handles
+ * the tail. A change to a named parameter (a different `:id`) still remounts.
  */
 export function sameRouteMatch<R extends RoutePatternLike>(
     a: RouteMatch<R> | null,
@@ -64,8 +82,8 @@ export function sameRouteMatch<R extends RoutePatternLike>(
     if (a === null || b === null) return false;
     if (a.route !== b.route) return false;
 
-    const aKeys = Object.keys(a.parameters);
-    const bKeys = Object.keys(b.parameters);
+    const aKeys = identifyingKeys(a.parameters);
+    const bKeys = identifyingKeys(b.parameters);
 
     if (aKeys.length !== bKeys.length) return false;
 

--- a/web/src/elements/router/core/matcher.ts
+++ b/web/src/elements/router/core/matcher.ts
@@ -49,3 +49,25 @@ export function matchRoute<R extends RoutePatternLike>(
 
     return null;
 }
+
+/**
+ * Whether two matches resolve to the same rendered view: the same route with the
+ * same path parameters. {@linkcode matchRoute} returns a fresh object every call,
+ * so a search-param-only navigation (a tab, a table filter) yields an equal-but-
+ * new match — comparing structurally lets a consumer skip re-rendering it.
+ */
+export function sameRouteMatch<R extends RoutePatternLike>(
+    a: RouteMatch<R> | null,
+    b: RouteMatch<R> | null,
+): boolean {
+    if (a === b) return true;
+    if (a === null || b === null) return false;
+    if (a.route !== b.route) return false;
+
+    const aKeys = Object.keys(a.parameters);
+    const bKeys = Object.keys(b.parameters);
+
+    if (aKeys.length !== bKeys.length) return false;
+
+    return aKeys.every((key) => a.parameters[key] === b.parameters[key]);
+}

--- a/web/src/elements/router/core/matcher.unit.test.ts
+++ b/web/src/elements/router/core/matcher.unit.test.ts
@@ -1,4 +1,4 @@
-import { matchRoute, type RoutePatternLike } from "./matcher.js";
+import { matchRoute, type RoutePatternLike, sameRouteMatch } from "./matcher.js";
 
 import { describe, expect, it } from "vitest";
 
@@ -33,5 +33,39 @@ describe("matchRoute", () => {
 
     it("returns null when nothing matches", () => {
         expect(matchRoute("/nope", [route("/users/:id")])).toBeNull();
+    });
+});
+
+describe("sameRouteMatch", () => {
+    const users = route("/users/:id");
+    const groups = route("/groups/:id");
+
+    it("treats two null matches as the same", () => {
+        expect(sameRouteMatch(null, null)).toBe(true);
+    });
+
+    it("treats null vs a match as different", () => {
+        expect(sameRouteMatch(null, matchRoute("/users/42", [users]))).toBe(false);
+    });
+
+    it("is true for fresh matches of the same route and params (a search-only change)", () => {
+        expect(
+            sameRouteMatch(matchRoute("/users/42", [users]), matchRoute("/users/42", [users])),
+        ).toBe(true);
+    });
+
+    it("is false when the path parameters differ", () => {
+        expect(
+            sameRouteMatch(matchRoute("/users/1", [users]), matchRoute("/users/2", [users])),
+        ).toBe(false);
+    });
+
+    it("is false when the matched route differs", () => {
+        expect(
+            sameRouteMatch(
+                matchRoute("/users/1", [users, groups]),
+                matchRoute("/groups/1", [users, groups]),
+            ),
+        ).toBe(false);
     });
 });

--- a/web/src/elements/router/core/matcher.unit.test.ts
+++ b/web/src/elements/router/core/matcher.unit.test.ts
@@ -68,4 +68,33 @@ describe("sameRouteMatch", () => {
             ),
         ).toBe(false);
     });
+
+    it("ignores the wildcard tail so a subtree route stays mounted across its tabs", () => {
+        const subtree = route("/users/:id{/*}?");
+
+        // Same `:id`, different tail (a tab change) — same mount.
+        expect(
+            sameRouteMatch(
+                matchRoute("/users/22", [subtree]),
+                matchRoute("/users/22/credentials", [subtree]),
+            ),
+        ).toBe(true);
+        expect(
+            sameRouteMatch(
+                matchRoute("/users/22/credentials", [subtree]),
+                matchRoute("/users/22/credentials/tokens", [subtree]),
+            ),
+        ).toBe(true);
+    });
+
+    it("still remounts a subtree route when its named parameter changes", () => {
+        const subtree = route("/users/:id{/*}?");
+
+        expect(
+            sameRouteMatch(
+                matchRoute("/users/22/credentials", [subtree]),
+                matchRoute("/users/23/credentials", [subtree]),
+            ),
+        ).toBe(false);
+    });
 });

--- a/web/src/elements/tabs/tab-context.ts
+++ b/web/src/elements/tabs/tab-context.ts
@@ -1,0 +1,13 @@
+import { createContext } from "@lit/context";
+
+/**
+ * The absolute mount path a routed tab group lives under, e.g.
+ * `/if/user/settings`.
+ *
+ * The router's outlet provides it for the current page; each `<ak-tabs routed>`
+ * consumes it as its base and, in turn, provides its active panel's path to its
+ * own subtree — so a nested tab group derives its base with no page wiring. A
+ * dispatcher page (provider/source/connector view) is transparent to this: the
+ * value flows through it to the type-specific view's tabs.
+ */
+export const routedTabBaseContext = createContext<string>(Symbol("authentik-routed-tab-base"));

--- a/web/src/elements/tabs/tab-path.ts
+++ b/web/src/elements/tabs/tab-path.ts
@@ -1,0 +1,69 @@
+/**
+ * @file Pure path helpers for path-routed tabs.
+ *
+ * A tab panel is a slotted child named `page-<segment>`; its URL is the tab
+ * group's mount path plus that segment (`/if/user/settings` + `sessions` →
+ * `/if/user/settings/sessions`). These functions map between the two and pick
+ * the active tab from a location. No DOM, no globals — unit-testable in Node.
+ */
+
+/**
+ * The `slot` prefix every tab panel carries. The URL segment is the slot name
+ * with this removed.
+ */
+export const SLOT_PREFIX = "page-";
+
+export const slotToSegment = (slot: string): string => slot.slice(SLOT_PREFIX.length);
+export const segmentToSlot = (segment: string): string => `${SLOT_PREFIX}${segment}`;
+
+/**
+ * The active tab slot for a location, or `null` when the group has no tabs.
+ *
+ * The first tab is the default: the bare base (and any path outside the group's
+ * subtree) resolves to it. A path whose first segment past the base names a
+ * known tab selects that tab; an unknown segment falls back to the first.
+ *
+ * @param base The group's mount path, e.g. `/if/user/settings`.
+ * @param pathname The current `location.pathname`.
+ * @param slots The group's slot names, in tab order.
+ */
+export function activeSlotForPath(
+    base: string,
+    pathname: string,
+    slots: readonly string[],
+): string | null {
+    const first = slots[0] ?? null;
+    const normalizedBase = base.replace(/\/+$/, "");
+
+    if (pathname.startsWith(`${normalizedBase}/`)) {
+        const [segment] = pathname
+            .slice(normalizedBase.length + 1)
+            .split("/")
+            .filter(Boolean);
+
+        if (segment) {
+            const slot = segmentToSlot(segment);
+
+            if (slots.includes(slot)) return slot;
+        }
+    }
+
+    return first;
+}
+
+/**
+ * The URL a tab links to: the bare `base` for the first (default) tab,
+ * `base/segment` otherwise. Keeping the default at the bare base mirrors the
+ * legacy behavior of omitting the first tab's parameter.
+ *
+ * @param base The group's mount path.
+ * @param slotName The tab's slot name.
+ * @param firstSlot The group's first slot, the default tab.
+ */
+export function tabHref(base: string, slotName: string, firstSlot: string | null): string {
+    const normalizedBase = base.replace(/\/+$/, "");
+
+    if (slotName === firstSlot) return normalizedBase;
+
+    return `${normalizedBase}/${slotToSegment(slotName)}`;
+}

--- a/web/src/elements/tabs/tab-path.unit.test.ts
+++ b/web/src/elements/tabs/tab-path.unit.test.ts
@@ -1,0 +1,102 @@
+import { activeSlotForPath, segmentToSlot, slotToSegment, tabHref } from "./tab-path.js";
+
+import { describe, expect, it } from "vitest";
+
+describe("slot ↔ segment", () => {
+    it("round-trips a slot through its segment", () => {
+        expect(slotToSegment("page-sessions")).toBe("sessions");
+        expect(segmentToSlot("sessions")).toBe("page-sessions");
+        expect(slotToSegment(segmentToSlot("oauth-access"))).toBe("oauth-access");
+    });
+});
+
+describe("activeSlotForPath", () => {
+    const settings = ["page-details", "page-sessions", "page-consents", "page-sources"];
+
+    it("returns null when there are no tabs", () => {
+        expect(activeSlotForPath("/if/user/settings", "/if/user/settings/sessions", [])).toBeNull();
+    });
+
+    it("selects the first tab at the bare base", () => {
+        expect(activeSlotForPath("/if/user/settings", "/if/user/settings", settings)).toBe(
+            "page-details",
+        );
+    });
+
+    it("tolerates a trailing slash on the base", () => {
+        expect(activeSlotForPath("/if/user/settings/", "/if/user/settings", settings)).toBe(
+            "page-details",
+        );
+    });
+
+    it("selects the tab named by the first segment past the base", () => {
+        expect(activeSlotForPath("/if/user/settings", "/if/user/settings/sessions", settings)).toBe(
+            "page-sessions",
+        );
+    });
+
+    it("falls back to the first tab for an unknown segment", () => {
+        expect(activeSlotForPath("/if/user/settings", "/if/user/settings/nope", settings)).toBe(
+            "page-details",
+        );
+    });
+
+    it("falls back to the first tab for a path outside the group's subtree", () => {
+        expect(activeSlotForPath("/if/user/settings", "/if/user/library", settings)).toBe(
+            "page-details",
+        );
+    });
+
+    it("uses only the first segment, so a nested group owns the rest", () => {
+        // The outer group at `/…/users/22` sees `credentials/tokens` and selects
+        // credentials; the `tokens` segment belongs to the nested group.
+        const outer = ["page-overview", "page-credentials", "page-roles"];
+
+        expect(
+            activeSlotForPath(
+                "/if/admin/identity/users/22",
+                "/if/admin/identity/users/22/credentials/tokens",
+                outer,
+            ),
+        ).toBe("page-credentials");
+    });
+
+    it("resolves the nested group from its own deeper base", () => {
+        const inner = ["page-sessions", "page-tokens", "page-consent"];
+
+        expect(
+            activeSlotForPath(
+                "/if/admin/identity/users/22/credentials",
+                "/if/admin/identity/users/22/credentials/tokens",
+                inner,
+            ),
+        ).toBe("page-tokens");
+    });
+});
+
+describe("tabHref", () => {
+    const settings = ["page-details", "page-sessions"];
+    const [first] = settings;
+
+    it("links the first (default) tab to the bare base", () => {
+        expect(tabHref("/if/user/settings", "page-details", first)).toBe("/if/user/settings");
+    });
+
+    it("links a non-default tab to base/segment", () => {
+        expect(tabHref("/if/user/settings", "page-sessions", first)).toBe(
+            "/if/user/settings/sessions",
+        );
+    });
+
+    it("normalizes a trailing slash on the base", () => {
+        expect(tabHref("/if/user/settings/", "page-sessions", first)).toBe(
+            "/if/user/settings/sessions",
+        );
+    });
+
+    it("builds a nested tab href from the deeper base", () => {
+        expect(
+            tabHref("/if/admin/identity/users/22/credentials", "page-tokens", "page-sessions"),
+        ).toBe("/if/admin/identity/users/22/credentials/tokens");
+    });
+});

--- a/web/src/elements/user/sources/SourceSettingsOAuth.ts
+++ b/web/src/elements/user/sources/SourceSettingsOAuth.ts
@@ -57,9 +57,7 @@ export class SourceSettingsOAuth extends BaseUserSettings {
 
         return html`<a
             class="pf-c-button pf-m-primary"
-            href="${this.configureURL}${AndNext(
-                toUserInterface("settings", { page: "page-sources" }),
-            )}"
+            href="${this.configureURL}${AndNext(toUserInterface("settings/sources"))}"
         >
             ${msg("Connect")}
         </a>`;

--- a/web/src/elements/user/sources/SourceSettingsSAML.ts
+++ b/web/src/elements/user/sources/SourceSettingsSAML.ts
@@ -56,9 +56,7 @@ export class SourceSettingsSAML extends BaseUserSettings {
 
         return html`<a
             class="pf-c-button pf-m-primary"
-            href="${this.configureURL}${AndNext(
-                toUserInterface("settings", { page: "page-sources" }),
-            )}"
+            href="${this.configureURL}${AndNext(toUserInterface("settings/sources"))}"
         >
             ${msg("Connect")}
         </a>`;

--- a/web/src/user/Routes.ts
+++ b/web/src/user/Routes.ts
@@ -38,7 +38,9 @@ export const ROUTES: RouteLike[] = [
         "requests.fulfill",
     ),
     new Route(
-        "/settings",
+        // The `{/*}?` tail lets the tab segment (`/settings/sessions`) resolve to
+        // this route while the page stays mounted across tab changes.
+        "/settings{/*}?",
         async () => {
             await import("#user/user-settings/UserSettingsPage");
 

--- a/web/src/user/Routes.ts
+++ b/web/src/user/Routes.ts
@@ -18,7 +18,7 @@ export const DEFAULT_PATH = "/library";
 export const ROUTES: RouteLike[] = [
     new Route("/library", () => html`<ak-library></ak-library>`, "library"),
     new Route(
-        "/requests",
+        "/requests{/*}?",
         async () => {
             await import("#user/requests/AccessRequestsPage");
 

--- a/web/src/user/requests/AccessRequestsPage.ts
+++ b/web/src/user/requests/AccessRequestsPage.ts
@@ -66,9 +66,7 @@ export class AccessRequestsPage extends AKElement {
                 ${(this.toReview?.pagination.count || 0) > 0
                     ? html`<div class="pf-c-banner pf-m-info">
                           ${msg("Requests to review: ")}
-                          <a href=${toUserInterface("requests", { page: "page-for-review" })}
-                              >${msg("Review")}</a
-                          >
+                          <a href=${toUserInterface("requests/for-review")}>${msg("Review")}</a>
                       </div>`
                     : nothing}
                 <ak-tabs

--- a/web/src/user/requests/AccessRequestsPage.ts
+++ b/web/src/user/requests/AccessRequestsPage.ts
@@ -72,6 +72,7 @@ export class AccessRequestsPage extends AKElement {
                       </div>`
                     : nothing}
                 <ak-tabs
+                    routed
                     role="main"
                     aria-label=${msg("Access requests")}
                     ${AKSkipToContent.ref}

--- a/web/src/user/user-settings/UserSettingsPage.ts
+++ b/web/src/user/user-settings/UserSettingsPage.ts
@@ -129,6 +129,7 @@ export class UserSettingsPage extends WithLicenseSummary(WithSession(AKElement))
         return html`<div class="pf-c-page">
             <div class="pf-c-page__main">
                 <ak-tabs
+                    routed
                     vertical
                     role="main"
                     aria-label=${msg("User settings")}

--- a/web/src/user/user-settings/details/UserPassword.ts
+++ b/web/src/user/user-settings/details/UserPassword.ts
@@ -27,9 +27,7 @@ export class UserSettingsPassword extends AKElement {
             <div class="pf-c-card__title">${msg("Change your password")}</div>
             <div class="pf-c-card__body">
                 <a
-                    href="${ifDefined(this.configureUrl)}${AndNext(
-                        toUserInterface("settings", { page: "page-details" }),
-                    )}"
+                    href="${ifDefined(this.configureUrl)}${AndNext(toUserInterface("settings"))}"
                     class="pf-c-button pf-m-primary"
                 >
                     ${msg("Change password")}

--- a/web/src/user/user-settings/mfa/MFADevicesPage.ts
+++ b/web/src/user/user-settings/mfa/MFADevicesPage.ts
@@ -85,7 +85,7 @@ export class MFADevicesPage extends Table<Device> {
                             <a
                                 role="menuitem"
                                 href="${ifDefined(stage.configureUrl)}${AndNext(
-                                    toUserInterface("settings", { page: "page-credentials" }),
+                                    toUserInterface("settings/credentials"),
                                 )}"
                                 class="pf-c-dropdown__menu-item"
                             >

--- a/web/test/browser/102-passkeys.test.ts
+++ b/web/test/browser/102-passkeys.test.ts
@@ -6,7 +6,9 @@ import { series } from "@goauthentik/core/promises";
 
 import { snakeCase } from "change-case";
 
-const CREDENTIALS_SETTINGS = `/if/user/#/settings;${JSON.stringify({ page: "page-credentials" })}`;
+// Tabs are path segments now: the `page-credentials` panel lives at
+// `/if/user/settings/credentials`, not behind a legacy hash tab token.
+const CREDENTIALS_SETTINGS = "/if/user/settings/credentials";
 
 test.describe("Passkeys", () => {
     const usernames = new Map<string, string>();

--- a/web/test/browser/110-user-routing.test.ts
+++ b/web/test/browser/110-user-routing.test.ts
@@ -37,6 +37,29 @@ test.describe("User interface routing", () => {
         });
     });
 
+    test("Settings tabs are path segments", async ({ session, navigator, page }) => {
+        await test.step("Deep-load a specific tab by path", async () => {
+            await session.login({ to: `${SETTINGS_PATHNAME}/sessions` });
+        });
+
+        await test.step("The tab named in the path is selected", async () => {
+            await expect(
+                page.getByRole("tab", { name: "Sessions" }),
+                "Sessions tab is selected from the path",
+            ).toHaveAttribute("aria-selected", "true");
+        });
+
+        await test.step("Switching tabs writes the segment to the path", async () => {
+            await page.getByRole("tab", { name: "Credentials" }).click();
+            await navigator.waitForPathname(`${SETTINGS_PATHNAME}/credentials`);
+        });
+
+        await test.step("The default tab drops back to the bare settings path", async () => {
+            await page.getByRole("tab", { name: "User details" }).click();
+            await navigator.waitForPathname(SETTINGS_PATHNAME);
+        });
+    });
+
     test("Back and forward traverse pushState navigations", async ({
         session,
         navigator,
@@ -117,9 +140,10 @@ test.describe("User interface routing", () => {
         });
 
         // Shim-only compatibility (see the plan's compatibility decision): the boot
-        // shim translates the legacy hash to the correct *page* and carries `?page=`
-        // forward, but this plan adds no `?page`→`activateTab` bridge, so the tab is
-        // NOT auto-selected until `ak-tabs` flips with the admin interface. Assert the
+        // shim translates the legacy hash to the page and carries `?page=` forward,
+        // but tabs are now tracked as path segments, not `?page=`. The shim is not
+        // extended to translate a legacy `?page=` into a path segment, so the tab is
+        // NOT auto-selected — a deliberate compatibility boundary. Assert the
         // page-level redirect only.
         await test.step("The settings page renders at the translated path", async () => {
             await expect(


### PR DESCRIPTION
## Details

This PR moves tabs from `?page=` search params to real path segments — `/if/user/settings/sessions`, `/if/admin/identity/users/22/credentials/tokens`. The page stays mounted across tab changes, so switching no longer flashes a page-wide spinner, deep-linking to any tab works, and nesting composes with no per-page wiring.

The base path travels by Lit context rather than by props: the router outlet publishes the current page's mount path, and each `<ak-tabs routed>` consumes it, then provides its own active panel's path to its subtree. A dispatcher page — provider, source, connector — is transparent to it. In the router core, `sameRouteMatch` now compares only the named route params and ignores the wildcard tail, which is what keeps a subtree route mounted while its tabs move through that tail. Without `routed`, `ak-tabs` keeps the `?page=` behavior permanently, for in-page guidance tabs that aren't navigation.

Rolled out to every tabbed view page. The connected-sources redirect now targets `/if/user/settings/sources`, superseding #25010, which is closed.

Stacked on #25008.

## Testing

`matcher` and `tab-path` unit tests, a new browser test asserting the settings tabs track the path, `lint:types`, ESLint, and the production build are all green. Verified live for flat tabs, two-level nesting, and the dispatcher case: deep load selects the right tab, clicking writes the path, the default tab drops to the bare base, and back/forward restore.



---

Replaces #25108, which a bad force-push collapsed onto its own base; GitHub read head-equals-base as a merge and closed it. Same branch, same commits — no review had been left on the original.
