### PR TITLE
core, web: inject the interface context as data, not as script

### DIFF
--- a/authentik/core/templates/base/header_js.html
+++ b/authentik/core/templates/base/header_js.html
@@ -1,22 +1,22 @@
 {% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 
-<script data-id="authentik-config">
-    "use strict";
+{% comment %}
+    Server-injected values are rendered as data, not as executable script, so
+    the interface pages can eventually be served under a strict CSP. The web UI
+    reads them back in `web/src/common/global.ts`.
+{% endcomment %}
 
-    window.authentik = {
-        locale: "{{ LANGUAGE_CODE }}",
-        config: JSON.parse('{{ config_json|escapejs }}' || "{}"),
-        brand: JSON.parse('{{ brand_json|escapejs }}' || "{}"),
-        versionFamily: "{{ version_family }}",
-        versionSubdomain: "{{ version_subdomain }}",
-        build: "{{ build }}",
-        api: {
-            base: "{{ base_url }}",
-            relBase: "{{ base_url_rel }}",
-        },
-    };
-</script>
+{{ config_json|json_script:"ak-config" }}
+
+{{ brand_json|json_script:"ak-brand" }}
+
+<meta name="ak-locale" content="{{ LANGUAGE_CODE }}">
+<meta name="ak-version-family" content="{{ version_family }}">
+<meta name="ak-version-subdomain" content="{{ version_subdomain }}">
+<meta name="ak-build" content="{{ build }}">
+<meta name="ak-base-url" content="{{ base_url }}">
+<meta name="ak-base-url-rel" content="{{ base_url_rel }}">
 
 <script data-id="authentik-messages" type="application/json">
   [{% for message in messages %}
@@ -26,4 +26,3 @@
     }{% if not forloop.last %},{% endif %}
     {% endfor %}]
 </script>
-

--- a/authentik/core/tests/test_interface_views.py
+++ b/authentik/core/tests/test_interface_views.py
@@ -160,9 +160,9 @@ class TestInterfaceCatchAll(TestCase):
         """The deep-path shell carries the same injected config as the root."""
         response = self.client.get("/if/admin/core/applications")
         self.assertEqual(response.status_code, 200)
-        # base/header_js.html injects window.authentik from the InterfaceView context.
-        self.assertIn(b"window.authentik", response.content)
-        self.assertIn(b'relBase: "/"', response.content)
+        # base/header_js.html injects the interface context as data, not script.
+        self.assertIn(b'id="ak-config"', response.content)
+        self.assertIn(b'<meta name="ak-base-url-rel" content="/">', response.content)
 
     def test_exact_admin_prefix_not_shadowed_by_catchall(self):
         """Ordering: the exact route wins over the catch-all for /if/admin/."""
@@ -185,7 +185,7 @@ class TestInterfaceCatchAll(TestCase):
         self.assertNotIn(resolve("/api/v3/core/users/").url_name, ("if-admin-path", "if-user-path"))
 
     def test_web_path_reflected_in_shell_context(self):
-        """When web.path is non-root, the shell advertises it via relBase.
+        """When web.path is non-root, the shell advertises it as ak-base-url-rel.
 
         Routing under web.path is resolved at import time in the root urlconf, so
         only the request-time context value is exercised here; deployment-prefix
@@ -194,7 +194,7 @@ class TestInterfaceCatchAll(TestCase):
         with CONFIG.patch("web.path", "/auth/"):
             response = self.client.get("/if/user/settings")
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'relBase: "/auth/"', response.content)
+        self.assertIn(b'<meta name="ak-base-url-rel" content="/auth/">', response.content)
 
 
 class TestInterfaceFavicon(TestCase):

--- a/authentik/core/views/interface.py
+++ b/authentik/core/views/interface.py
@@ -1,6 +1,5 @@
 """Interface views"""
 
-from json import dumps
 from typing import Any
 
 from django.contrib.auth.mixins import AccessMixin
@@ -56,9 +55,10 @@ class InterfaceView(TemplateView):
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         brand = CurrentBrandSerializer(self.request.brand, context={"request": self.request})
-        kwargs["config_json"] = dumps(ConfigView.get_config(self.request).data)
+        # Rendered by `json_script`, which serializes and escapes on its own.
+        kwargs["config_json"] = ConfigView.get_config(self.request).data
         kwargs["ui_theme"] = brand.data["ui_theme"]
-        kwargs["brand_json"] = dumps(brand.data)
+        kwargs["brand_json"] = brand.data
         kwargs["version_family"] = f"{LOCAL_VERSION.major}.{LOCAL_VERSION.minor}"
         kwargs["version_subdomain"] = f"version-{LOCAL_VERSION.major}-{LOCAL_VERSION.minor}"
         kwargs["build"] = authentik_build_hash()

--- a/authentik/flows/templates/if/flow.html
+++ b/authentik/flows/templates/if/flow.html
@@ -20,15 +20,9 @@
 </script>
 {% endif %}
 {% include "base/header_js.html" %}
-<script data-id="flow-config">
-    "use strict";
-
-    window.authentik.flow = {
-        "layout": "{{ flow.layout }}",
-        "background": "{{ flow.background }}",
-        "title": "{{ flow.title }}",
-    };
-</script>
+<meta name="ak-flow-layout" content="{{ flow.layout }}">
+<meta name="ak-flow-background" content="{{ flow.background }}">
+<meta name="ak-flow-title" content="{{ flow.title }}">
 {% endblock %}
 
 {% block interface_stylesheet %}

--- a/web/src/common/global.ts
+++ b/web/src/common/global.ts
@@ -1,3 +1,12 @@
+/**
+ * @file Reader for the values the server injects into the interface documents.
+ *
+ * The server renders them as data — two `json_script` blocks and a handful of
+ * `<meta>` tags — rather than as an executable `window.authentik` assignment,
+ * so the interface pages can eventually be served under a strict CSP. See
+ * `authentik/core/templates/base/header_js.html`.
+ */
+
 import { TargetLanguageTag } from "#common/ui/locale/definitions";
 import { autoDetectLanguage } from "#common/ui/locale/utils";
 
@@ -9,10 +18,7 @@ import {
     FlowLayoutEnum,
 } from "@goauthentik/api";
 
-const convertedSymbol = Symbol("ak-converted");
-
 export interface GlobalAuthentik {
-    [convertedSymbol]?: boolean;
     locale: TargetLanguageTag;
     flow?: {
         layout: FlowLayoutEnum;
@@ -30,43 +36,86 @@ export interface GlobalAuthentik {
     };
 }
 
-export interface AuthentikWindow {
-    authentik: GlobalAuthentik;
+/**
+ * Read a server-injected `<meta>` value, if the document carries one.
+ */
+function readMeta(name: string): string | null {
+    const element = document.querySelector<HTMLMetaElement>(`meta[name="${name}"]`);
+
+    return element?.content || null;
 }
 
-export function globalAK(): GlobalAuthentik {
-    const ak = (window as unknown as AuthentikWindow).authentik;
+/**
+ * Parse a server-injected `json_script` block, if the document carries one.
+ *
+ * A malformed block is treated as absent: the interface still boots on the
+ * fallbacks below, which is strictly better than failing to render at all.
+ */
+function readJSONScript(id: string): unknown {
+    const element = document.getElementById(id);
 
-    if (!ak) {
-        const apiBase = new URL(import.meta.env.AK_API_BASE_PATH || window.location.origin);
+    if (!element?.textContent) return null;
 
-        return {
-            locale: autoDetectLanguage(),
-            config: ConfigFromJSON({
-                capabilities: [],
-            }),
-            brand: CurrentBrandFromJSON({
-                ui_footer_links: [],
-            }),
-            versionFamily: "",
-            versionSubdomain: "",
-            build: "",
-            api: {
-                base: apiBase.toString(),
-                relBase: apiBase.pathname,
-            },
+    try {
+        return JSON.parse(element.textContent);
+    } catch (_error) {
+        return null;
+    }
+}
+
+function readServerContext(): GlobalAuthentik {
+    const fallbackAPIBase = new URL(import.meta.env.AK_API_BASE_PATH || window.location.origin);
+
+    const context: GlobalAuthentik = {
+        locale: autoDetectLanguage(readMeta("ak-locale") ?? undefined),
+        // `ConfigFromJSON`/`CurrentBrandFromJSON` pass a nullish value straight
+        // through, so the empty shapes stand in when nothing was injected.
+        config: ConfigFromJSON(readJSONScript("ak-config") ?? { capabilities: [] }),
+        brand: CurrentBrandFromJSON(readJSONScript("ak-brand") ?? { ui_footer_links: [] }),
+        versionFamily: readMeta("ak-version-family") ?? "",
+        versionSubdomain: readMeta("ak-version-subdomain") ?? "",
+        build: readMeta("ak-build") ?? "",
+        api: {
+            base: readMeta("ak-base-url") ?? fallbackAPIBase.toString(),
+            relBase: readMeta("ak-base-url-rel") ?? fallbackAPIBase.pathname,
+        },
+    };
+
+    const flowLayout = readMeta("ak-flow-layout");
+
+    if (flowLayout) {
+        context.flow = {
+            layout: flowLayout as FlowLayoutEnum,
+            title: readMeta("ak-flow-title") ?? undefined,
+            background: readMeta("ak-flow-background") ?? undefined,
         };
     }
 
-    if (!ak[convertedSymbol]) {
-        ak.locale = autoDetectLanguage(ak.locale);
-        ak.brand = CurrentBrandFromJSON(ak.brand);
-        ak.config = ConfigFromJSON(ak.config);
+    return context;
+}
 
-        ak[convertedSymbol] = true;
-    }
+let serverContext: GlobalAuthentik | null = null;
 
-    return ak;
+/**
+ * Re-read the server context from the document, replacing the memoized value.
+ *
+ * Only useful to tests that swap the injected markup; the values are static for
+ * the lifetime of a document.
+ */
+export function refreshServerContext(): GlobalAuthentik {
+    serverContext = readServerContext();
+
+    return serverContext;
+}
+
+/**
+ * The values the server injected into this document.
+ *
+ * Memoized rather than evaluated at import, so this module stays importable
+ * without a document — Node unit tests included.
+ */
+export function globalAK(): GlobalAuthentik {
+    return (serverContext ??= readServerContext());
 }
 
 export function docLink(urlLike: string | URL, base = import.meta.env.AK_DOCS_URL): string {

--- a/web/src/common/sentry/apply.browser.test.ts
+++ b/web/src/common/sentry/apply.browser.test.ts
@@ -2,13 +2,16 @@ import { getClient } from "@sentry/browser";
 import { describe, expect, it } from "vitest";
 
 describe("sentry/apply", () => {
-    it("boots without a server-injected global", async () => {
+    it("boots without a server-injected context", async () => {
         // `globalAK` falls back to `ConfigFromJSON({ capabilities: [] })` when the
-        // server didn't inject `window.authentik`, and `errorReporting` comes back
+        // document carries no `ak-config` block, and `errorReporting` comes back
         // undefined despite `Config` typing it as required. Reading through it
         // unguarded throws here — in the first import of every entrypoint, taking
         // the whole interface down rather than just Sentry.
-        delete (window as Partial<Window & { authentik: unknown }>).authentik;
+        expect(
+            document.getElementById("ak-config"),
+            "The test document carries no injected configuration",
+        ).toBeNull();
 
         await expect(import("#common/sentry/apply")).resolves.toBeDefined();
 

--- a/web/src/elements/router/core/config.ts
+++ b/web/src/elements/router/core/config.ts
@@ -2,7 +2,7 @@
  * @file Router configuration injected by each entrypoint at boot.
  *
  * The router core never reads globals. Each entrypoint calls {@linkcode initRouter}
- * once at boot with the deployment base path (read from `window.authentik.api.relBase`
+ * once at boot with the deployment base path (read from the injected `ak-base-url-rel`
  * **at the entrypoint**) and the interface name. The core only ever receives values.
  */
 


### PR DESCRIPTION
## Details

This PR moves the server-injected interface values from executable inline script to data, so the interface pages can eventually be served under a strict CSP.

`base/header_js.html` built a `window.authentik = {...}` assignment out of `JSON.parse('{{ config_json|escapejs }}')`, and the flow template appended a second inline script that mutated it. Both now render as data: `config` and `brand` as `json_script` blocks — which serialize and escape on their own, so `interface.py` hands them the objects rather than pre-dumped strings — and the scalars as `<meta>` tags (locale, version family and subdomain, build, base URL, and the flow's layout, title, and background). The messages block was already `type="application/json"`.

`globalAK()` reads them back from the DOM. Its return shape is unchanged, so its 23 call sites are untouched. It memoizes on first read instead of evaluating at import, which keeps `#common/global` importable without a document, and a malformed `json_script` block is treated as absent so the interface still boots on the same fallbacks it already uses when nothing is injected.



---

Replaces #25453, closed the same way as #25108 by a bad force-push. Same branch, same commit — no review had been left on the original.
