### PR TITLE
core, web/test: exercise the login flow's compatibility mode from Playwright

### DIFF
--- a/authentik/flows/templates/if/flow.html
+++ b/authentik/flows/templates/if/flow.html
@@ -8,7 +8,7 @@
 {% block head_before %}
 {{ block.super }}
 <link rel="prefetch" href="{{ flow_background_url }}" />
-{% if flow.compatibility_mode and not inspector %}
+{% if compatibility_mode and not inspector %}
 {% comment %}
     @see {@link web/types/webcomponents.d.ts} for type definitions.
 {% endcomment %}

--- a/authentik/flows/tests/test_interface_compat.py
+++ b/authentik/flows/tests/test_interface_compat.py
@@ -1,0 +1,53 @@
+"""Compatibility-mode rendering of the flow interface"""
+
+from django.urls import reverse
+
+from authentik.core.tests.utils import create_test_flow
+from authentik.flows.tests import FlowTestCase
+
+SHADY_DOM_MARKER = b'data-id="shady-dom"'
+
+
+class TestFlowInterfaceCompatibility(FlowTestCase):
+    """The ShadyDOM shim is emitted for compatibility mode, from the flow or `?compat`"""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.flow = create_test_flow()
+
+    def flow_url(self, query: str = "") -> str:
+        url = reverse("authentik_core:if-flow", kwargs={"flow_slug": self.flow.slug})
+        return f"{url}{query}"
+
+    def test_off_by_default(self):
+        """A flow without compatibility mode renders no shim"""
+        response = self.client.get(self.flow_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(SHADY_DOM_MARKER, response.content)
+
+    def test_flow_setting_enables(self):
+        """The flow's own setting still turns the shim on"""
+        self.flow.compatibility_mode = True
+        self.flow.save()
+
+        response = self.client.get(self.flow_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(SHADY_DOM_MARKER, response.content)
+
+    def test_query_parameter_enables(self):
+        """`?compat` turns the shim on without touching the flow"""
+        response = self.client.get(self.flow_url("?compat"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(SHADY_DOM_MARKER, response.content)
+
+        self.flow.refresh_from_db()
+        self.assertFalse(
+            self.flow.compatibility_mode,
+            "The query parameter must not persist onto the flow",
+        )
+
+    def test_inspector_still_wins(self):
+        """The inspector suppresses the shim, as it did for the flow setting"""
+        response = self.client.get(self.flow_url("?compat&inspector"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(SHADY_DOM_MARKER, response.content)

--- a/authentik/flows/views/interface.py
+++ b/authentik/flows/views/interface.py
@@ -33,6 +33,11 @@ class FlowInterfaceView(InterfaceView):
         kwargs["flow"] = flow
         kwargs["flow_background_url"] = flow.background_url(self.request)
         kwargs["inspector"] = "inspector" in self.request.GET
+        # `?compat` forces the ShadyDOM shim on for a single page load, the way
+        # `?sfe` forces the simplified executor. The flow's own setting still wins
+        # when it is enabled; this only adds a way to exercise the compatibility
+        # path without flipping a shared flow, which every other session sees.
+        kwargs["compatibility_mode"] = flow.compatibility_mode or "compat" in self.request.GET
         return super().get_context_data(**kwargs)
 
     def compat_needs_sfe(self) -> bool:

--- a/web/test/browser/103-login-compatibility.test.ts
+++ b/web/test/browser/103-login-compatibility.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "#e2e";
+import { GOOD_PASSWORD, GOOD_USERNAME, SessionFixture } from "#e2e/fixtures/SessionFixture";
+
+/**
+ * Compatibility mode serves the flow with the ShadyDOM shim forced on, which
+ * renders every component into the light DOM instead of a shadow root. It is a
+ * genuinely different rendering path — nested CSS was silently dropped there
+ * once (#24968), taking the login layout with it — so the login flow is worth
+ * exercising through it.
+ *
+ * `?compat` forces the shim for one page load. The alternative is switching
+ * `compatibility_mode` on the default authentication flow, which every worker
+ * in this suite authenticates through, and `prerequisites.setup.ts` explains
+ * why that kind of shared-flow edit does not belong in a test.
+ */
+const COMPAT_PATHNAME = `${SessionFixture.pathname}?compat`;
+
+test.describe("Login in compatibility mode", () => {
+    test("Authenticates through the ShadyDOM-rendered flow", async ({ session, page }) => {
+        await test.step("Open the flow with the shim forced on", async () => {
+            await page.goto(COMPAT_PATHNAME);
+
+            await expect(
+                page.locator('script[data-id="shady-dom"]'),
+                "Server emits the ShadyDOM shim",
+            ).toBeAttached();
+        });
+
+        await test.step("The polyfill takes over rendering", async () => {
+            await expect(
+                session.$identificationStage,
+                "Identification stage renders",
+            ).toBeVisible();
+
+            // `ShadyDOM.inUse` is the only honest signal here. The `force` flag the
+            // shim sets is consumed during initialization, and a polyfilled root
+            // still reports `instanceof ShadowRoot` — neither distinguishes this
+            // path from an ordinary render.
+            const inUse = await page.evaluate(
+                () => (window as unknown as { ShadyDOM?: { inUse?: boolean } }).ShadyDOM?.inUse,
+            );
+
+            expect(inUse, "ShadyDOM polyfill is driving the render").toBe(true);
+        });
+
+        await test.step("Authenticate", async () => {
+            await session.login({
+                username: GOOD_USERNAME,
+                password: GOOD_PASSWORD,
+                to: COMPAT_PATHNAME,
+            });
+        });
+
+        await test.step("Lands on the user library", async () => {
+            await expect(
+                page.getByRole("heading", { level: 1 }),
+                "Authenticated interface renders after the compatibility-mode login",
+            ).toHaveText("Application Dashboard");
+        });
+    });
+});


### PR DESCRIPTION
## Details

This PR ports `TestFlowsLogin.test_login_compatibility_mode` from the Selenium suite to Playwright, and gives the flow interface a `?compat` override so the port doesn't have to mutate shared state.

Compatibility mode forces the ShadyDOM shim, rendering every component into the light DOM. It's a genuinely separate path — #24968 dropped nested CSS there and took the login layout with it — so it's worth covering.

The Python test switched `compatibility_mode` on the default authentication flow and reset it in `tearDown`. That doesn't translate: the Playwright suite runs `fullyParallel` with multiple workers, all authenticating through that same flow, and `prerequisites.setup.ts` already documents why shared-flow edits belong in setup rather than in a test. So `FlowInterfaceView` gains `?compat`, a sibling of the `?inspector` and `?sfe` overrides it already honours, forcing the shim for one page load without touching stored state. The flow's own setting still wins when enabled, and `?inspector` still suppresses the shim.

Stacked on #25453.

## Testing

Four backend tests cover the override: off by default, on from the flow's setting, on from `?compat` without persisting to the flow, and suppressed by `?inspector`.

The ported browser test asserts the shim is served and that `ShadyDOM.inUse` is set. That second assertion took two attempts — a polyfilled root still reports `instanceof ShadowRoot`, and the `force` flag is consumed during initialization, so neither distinguishes this path from an ordinary render. Verified in both directions against a live instance: the test fails without `?compat` and passes with it.
