### PR TITLE
lifecycle: fix server prometheus metrics getting registered early with pid instead of worker ID

### DIFF
--- a/lifecycle/gunicorn.conf.py
+++ b/lifecycle/gunicorn.conf.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from tempfile import gettempdir
 from typing import TYPE_CHECKING
 
+from prometheus_client import values
 from prometheus_client.values import MultiProcessValue
 
 from authentik import authentik_full_version
@@ -32,6 +33,19 @@ if TYPE_CHECKING:
 # master process before workers are forked; tell it to defer each tracer's post-fork setup
 # to the post_fork hook below instead (see authentik.lib.tracing.setup_post_fork)
 os.environ[TRACER_DEFER_POSTFORK_ENV_VAR] = "true"
+
+# Install this *before* preload_app loads Django below, so metrics that get constructed
+# pre-fork (e.g. django-prometheus's Counters) share
+# the same MultiProcessValue class as everything else instead of being permanently bound to
+# the master's PID.
+_worker_id: dict[str, int | None] = {"value": None}
+
+
+def _pid_or_worker_id():
+    return _worker_id["value"] if _worker_id["value"] is not None else 0
+
+
+values.ValueClass = MultiProcessValue(_pid_or_worker_id)
 
 setup()
 
@@ -78,9 +92,7 @@ def when_ready(server: "Arbiter"):  # noqa: UP037
 
 def post_fork(server: "Arbiter", worker: DjangoUvicornWorker):  # noqa: UP037
     """Tell prometheus to use worker number instead of process ID for multiprocess"""
-    from prometheus_client import values
-
-    values.ValueClass = MultiProcessValue(lambda: worker._worker_id)
+    _worker_id["value"] = worker._worker_id
 
     from authentik.lib.debug import start_pyroscope
 

--- a/lifecycle/gunicorn.conf.py
+++ b/lifecycle/gunicorn.conf.py
@@ -41,11 +41,9 @@ os.environ[TRACER_DEFER_POSTFORK_ENV_VAR] = "true"
 _worker_id: dict[str, int | None] = {"value": None}
 
 
-def _pid_or_worker_id():
-    return _worker_id["value"] if _worker_id["value"] is not None else 0
-
-
-values.ValueClass = MultiProcessValue(_pid_or_worker_id)
+values.ValueClass = MultiProcessValue(
+    lambda: _worker_id["value"] if _worker_id["value"] is not None else 0
+)
 
 setup()
 


### PR DESCRIPTION
Since a lot of metrics get created quite early they get registered before we configure prometheus for multi-process and as such they use the PID which clobbers /dev/shm in the container.

assisted by claude

ref https://github.com/goauthentik/authentik/issues/10768 https://github.com/goauthentik/authentik/issues/25876 https://github.com/goauthentik/authentik/issues/16757 https://github.com/goauthentik/authentik/issues/22979 https://github.com/goauthentik/authentik/issues/22856