### PR TITLE
stages/email: handle pretend_user_exists regardless of flow designation

### DIFF
--- a/authentik/stages/email/stage.py
+++ b/authentik/stages/email/stage.py
@@ -20,7 +20,7 @@ from rest_framework.serializers import ValidationError
 from authentik.events.models import Event, EventAction
 from authentik.flows.challenge import Challenge, ChallengeResponse
 from authentik.flows.exceptions import StageInvalidException
-from authentik.flows.models import FlowDesignation, FlowToken
+from authentik.flows.models import FlowToken
 from authentik.flows.planner import PLAN_CONTEXT_IS_RESTORED, PLAN_CONTEXT_PENDING_USER
 from authentik.flows.stage import ChallengeStageView
 from authentik.flows.views.executor import QS_KEY_TOKEN, QS_QUERY
@@ -104,10 +104,11 @@ class EmailStageView(ChallengeStageView):
         """Helper function that sends the actual email. Implies that you've
         already checked that there is a pending user."""
         pending_user = self.get_pending_user()
-        if not pending_user.pk and self.executor.flow.designation == FlowDesignation.RECOVERY:
-            # Pending user does not have a primary key, and we're in a recovery flow,
-            # which means the user entered an invalid identifier, so we pretend to send the
-            # email, to not disclose if the user exists
+        if not pending_user.pk:
+            # Do not create a FlowToken or send email for an unsaved pending user.
+            # This occurs when Identification pretends that an unknown user exists;
+            # persisting a token or conditionally sending mail would either fail or
+            # disclose account existence.
             return
         email = self.executor.plan.context.get(PLAN_CONTEXT_EMAIL_OVERRIDE, None)
         if not email:

--- a/authentik/stages/email/tests/test_stage.py
+++ b/authentik/stages/email/tests/test_stage.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from django.utils.http import urlencode
 
 from authentik.brands.models import Brand
+from authentik.core.models import User
 from authentik.core.tests.utils import RequestFactory, create_test_admin_user, create_test_flow
 from authentik.flows.markers import StageMarker
 from authentik.flows.models import FlowDesignation, FlowStageBinding, FlowToken
@@ -103,6 +104,39 @@ class TestEmailStage(FlowTestCase):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "authentik")
         self.assertEqual(mail.outbox[0].to, [f"{self.user.name} <{self.user.email}>"])
+        self.assertEqual(FlowToken.objects.filter(user=self.user).count(), 1)
+
+    def test_synthetic_pending_user(self):
+        """Test that synthetic users get the sent-email challenge without a token or email."""
+        url = reverse("authentik_api:flow-executor", kwargs={"flow_slug": self.flow.slug})
+
+        for designation in (FlowDesignation.AUTHENTICATION, FlowDesignation.RECOVERY):
+            with self.subTest(designation=designation):
+                self.flow.designation = designation
+                self.flow.save(update_fields=["designation"])
+                pending_user = User(
+                    username="unknown",
+                    email="unknown@example.com",
+                )
+                self.assertIsNone(pending_user.pk)
+
+                plan = FlowPlan(
+                    flow_pk=self.flow.pk.hex,
+                    bindings=[self.binding],
+                    markers=[StageMarker()],
+                )
+                plan.context[PLAN_CONTEXT_PENDING_USER] = pending_user
+
+                session = self.client.session
+                session[SESSION_KEY_PLAN] = plan
+                session.save()
+
+                response = self.client.get(url)
+
+                self.assertEqual(response.status_code, 200)
+                self.assertStageResponse(response, self.flow, component="ak-stage-email")
+                self.assertEqual(FlowToken.objects.filter(flow=self.flow).count(), 0)
+                self.assertEqual(len(mail.outbox), 0)
 
     @patch(
         "authentik.stages.email.models.EmailStage.backend_class",


### PR DESCRIPTION
## Details

### What does this PR change?

### Why is this change needed?

### How was this tested?

### Linked issues

Closes https://github.com/goauthentik/authentik/issues/25878

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
