### PR TITLE
infra: skip expensive checks for documentation-only pull requests

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,0 +1,79 @@
+---
+name: "authentik detect changes"
+description: "Detect which parts of the repository a pull request affects"
+
+outputs:
+  code:
+    description: >-
+      "true" when files outside of prose were changed, or when the event is not
+      a pull request. Jobs that only validate code should be gated on this.
+    value: ${{ steps.aggregate.outputs.code }}
+  bundled-docs:
+    description: >-
+      "true" when documentation compiled into the web bundle was changed. The
+      esbuild MDX plugin resolves `~docs/...` imports to website/docs and
+      compiles them at build time, so a malformed file there fails the web
+      build, not just the docs site.
+    value: ${{ steps.aggregate.outputs.bundled-docs }}
+
+runs:
+  using: composite
+  steps:
+    - name: Collect non-prose changes
+      id: code-files
+      if: "${{ github.event_name == 'pull_request' }}"
+      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # 24d32ffd492484c1d75e0c0b894501ddb9d30d62
+      with:
+        # Deliberately conservative: only prose and the assets it embeds are
+        # ignored. Anything else under website/ (Docusaurus config, lockfiles,
+        # scripts) still runs the full suite, because the server container
+        # copies the whole directory.
+        files_ignore: |
+          **/*.md
+          **/*.mdx
+          website/**/*.gif
+          website/**/*.jpeg
+          website/**/*.jpg
+          website/**/*.png
+          website/**/*.svg
+          website/**/*.webp
+          .github/ISSUE_TEMPLATE/**
+    - name: Collect changes to documentation compiled into the web bundle
+      id: docs-files
+      if: "${{ github.event_name == 'pull_request' }}"
+      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # 24d32ffd492484c1d75e0c0b894501ddb9d30d62
+      with:
+        # web/bundler/mdx-plugin/node.js resolves `~docs/<path>` to
+        # website/docs/<path>, so anything in that tree can reach the bundle,
+        # including partials pulled in by an imported page.
+        files: |
+          website/docs/**
+    - name: Aggregate
+      id: aggregate
+      shell: bash
+      env:
+        EVENT_NAME: "${{ github.event_name }}"
+        # `any_modified` rather than `any_changed`: the latter is ACMR and
+        # ignores deletions, so a pull request that only deletes code would
+        # look like a documentation change.
+        CODE_MODIFIED: "${{ steps.code-files.outputs.any_modified }}"
+        DOCS_MODIFIED: "${{ steps.docs-files.outputs.any_modified }}"
+      run: |
+        # Outside of pull requests (pushes to main/next/version-*) always run
+        # everything, so that container images and artifacts stay in sync with
+        # the branch.
+        if [ "${EVENT_NAME}" != "pull_request" ]; then
+          code=true
+          bundled_docs=true
+        else
+          code="${CODE_MODIFIED}"
+          bundled_docs="${DOCS_MODIFIED}"
+        fi
+        echo "code=${code}" >> "${GITHUB_OUTPUT}"
+        echo "bundled-docs=${bundled_docs}" >> "${GITHUB_OUTPUT}"
+        {
+          echo "| Change | Detected |"
+          echo "| --- | --- |"
+          echo "| Outside of prose | \`${code}\` |"
+          echo "| Docs in the web bundle | \`${bundled_docs}\` |"
+        } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci-aws-cfn.yml
+++ b/.github/workflows/ci-aws-cfn.yml
@@ -22,7 +22,24 @@ env:
   POSTGRES_PASSWORD: "EK-5jnKfjrGRm<77"
 
 jobs:
+  # Determines whether the pull request touches anything besides documentation.
+  # Everything that only validates code is gated on this, so that docs-only
+  # pull requests don't run the full test suite.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: "${{ steps.detect.outputs.code }}"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - id: detect
+        uses: ./.github/actions/detect-changes
   check-changes-applied:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
@@ -48,8 +65,11 @@ jobs:
     if: always()
     needs:
       - check-changes-applied
+      - changes
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # release/v1
         with:
+          # Docs-only pull requests skip every code job; see the `changes` job.
+          allowed-skips: "check-changes-applied"
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci-aws-cfn.yml
+++ b/.github/workflows/ci-aws-cfn.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: "${{ steps.detect.outputs.code }}"
+      bundled-docs: "${{ steps.detect.outputs.bundled-docs }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -28,6 +28,20 @@ permissions:
   id-token: write
 
 jobs:
+  # Determines whether the pull request touches anything besides documentation.
+  # Everything that only validates code is gated on this, so that docs-only
+  # pull requests don't run the full test suite.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: "${{ steps.detect.outputs.code }}"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - id: detect
+        uses: ./.github/actions/detect-changes
   build-compute-tags:
     runs-on: ubuntu-latest
     outputs:
@@ -40,8 +54,10 @@ jobs:
       - id: compute-tags
         uses: ./.github/actions/compute-container-tags
   build:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
     needs:
       - build-compute-tags
+      - changes
     permissions:
       # Needed to upload cache to ghcr.io
       packages: write
@@ -72,6 +88,9 @@ jobs:
       should-cache: "${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}"
       cache-suffix: "-${{ needs.build-compute-tags.outputs.safe-branch-name }}"
   lint:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     strategy:
       fail-fast: false
       matrix:
@@ -114,6 +133,9 @@ jobs:
       - name: run job
         run: make ci-lint-${{ matrix.job }}
   test-gen:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
@@ -130,6 +152,9 @@ jobs:
       - name: ensure schema is up-to-date
         run: git diff --exit-code -- schema.yml blueprints/schema.json packages/client-go packages/client-rust packages/client-ts
   test-migrations:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
@@ -138,6 +163,9 @@ jobs:
       - name: run migrations
         run: uv run python -m lifecycle.migrate
   test-make-seed:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     runs-on: ubuntu-latest
     steps:
       - id: seed
@@ -146,10 +174,13 @@ jobs:
     outputs:
       seed: ${{ steps.seed.outputs.seed }}
   test-migrations-from-stable:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
     name: test-migrations-from-stable - PostgreSQL ${{ matrix.psql }} - Run ${{ matrix.run_id }}/10
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: test-make-seed
+    needs:
+      - test-make-seed
+      - changes
     strategy:
       fail-fast: false
       matrix:
@@ -229,10 +260,13 @@ jobs:
         with:
           flags: unit-migrate
   test-unittest:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
     name: test-unittest - PostgreSQL ${{ matrix.psql }} - Run ${{ matrix.run_id }}/10
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: test-make-seed
+    needs:
+      - test-make-seed
+      - changes
     strategy:
       fail-fast: false
       matrix:
@@ -258,6 +292,9 @@ jobs:
         with:
           flags: unit
   test-integration:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -276,12 +313,14 @@ jobs:
         with:
           flags: integration
   test-e2e:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
     name: test-e2e (${{ matrix.job.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs:
       - build-compute-tags
       - build
+      - changes
     strategy:
       fail-fast: false
       matrix:
@@ -373,6 +412,9 @@ jobs:
         with:
           flags: e2e
   test-openid-conformance:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     name: test-openid-conformance (${{ matrix.job.name }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -434,6 +476,9 @@ jobs:
           name: conformance-certification-${{ matrix.job.name }}
           path: tests/openid_conformance/exports/
   test-rust:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -477,10 +522,13 @@ jobs:
       - test-integration
       - test-e2e
       - test-rust
+      - changes
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # release/v1
         with:
+          # Docs-only pull requests skip every code job; see the `changes` job.
+          allowed-skips: "build, lint, test-gen, test-migrations, test-migrations-from-stable, test-unittest, test-integration, test-e2e, test-rust"
           jobs: ${{ toJSON(needs) }}
   publish:
     if: "${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: "${{ steps.detect.outputs.code }}"
+      bundled-docs: "${{ steps.detect.outputs.bundled-docs }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -22,7 +22,24 @@ env:
   POSTGRES_PASSWORD: "EK-5jnKfjrGRm<77"
 
 jobs:
+  # Determines whether the pull request touches anything besides documentation.
+  # Everything that only validates code is gated on this, so that docs-only
+  # pull requests don't run the full test suite.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: "${{ steps.detect.outputs.code }}"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - id: detect
+        uses: ./.github/actions/detect-changes
   lint-golint:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
@@ -41,6 +58,9 @@ jobs:
           args: --timeout 5000s --verbose
           skip-cache: true
   test-unittest:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
@@ -60,15 +80,20 @@ jobs:
     needs:
       - lint-golint
       - test-unittest
+      - changes
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # release/v1
         with:
+          # Docs-only pull requests skip every code job; see the `changes` job.
+          allowed-skips: "lint-golint, test-unittest"
           jobs: ${{ toJSON(needs) }}
   build-binary:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
     timeout-minutes: 120
     needs:
       - ci-outpost-mark
+      - changes
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-outpost.yml
+++ b/.github/workflows/ci-outpost.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: "${{ steps.detect.outputs.code }}"
+      bundled-docs: "${{ steps.detect.outputs.bundled-docs }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -17,7 +17,24 @@ concurrency:
   cancel-in-progress: "${{ !startsWith(github.ref, 'refs/heads/version-') && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/next' }}"
 
 jobs:
+  # Determines whether the pull request touches anything besides documentation.
+  # Everything that only validates code is gated on this, so that docs-only
+  # pull requests don't run the full test suite.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: "${{ steps.detect.outputs.code }}"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - id: detect
+        uses: ./.github/actions/detect-changes
   lint:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -48,6 +65,9 @@ jobs:
         run: pnpm --dir web run lit-analyse
 
   build:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
+    needs:
+      - changes
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -78,14 +98,19 @@ jobs:
     needs:
       - build
       - lint
+      - changes
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@b5b5b37504aa4183270bd3d855c52a67f212be35 # release/v1
         with:
+          # Docs-only pull requests skip every code job; see the `changes` job.
+          allowed-skips: "build, lint"
           jobs: ${{ toJSON(needs) }}
   test:
+    if: "${{ needs.changes.outputs.code == 'true' }}"
     needs:
       - ci-web-mark
+      - changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci-web.yml
+++ b/.github/workflows/ci-web.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: "${{ steps.detect.outputs.code }}"
+      bundled-docs: "${{ steps.detect.outputs.bundled-docs }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
@@ -65,7 +66,10 @@ jobs:
         run: pnpm --dir web run lit-analyse
 
   build:
-    if: "${{ needs.changes.outputs.code == 'true' }}"
+    # Also runs for documentation that is compiled into the bundle: a malformed
+    # file under website/docs fails this build, so it is the canary that keeps
+    # the skipped server container build honest.
+    if: "${{ needs.changes.outputs.code == 'true' || needs.changes.outputs.bundled-docs == 'true' }}"
     needs:
       - changes
     runs-on: ubuntu-latest

--- a/.github/workflows/qa-codeql.yml
+++ b/.github/workflows/qa-codeql.yml
@@ -10,7 +10,24 @@ on:
     - cron: "30 6 * * 5"
 
 jobs:
+  # Determines whether the pull request touches anything besides documentation.
+  # Everything that only validates code is gated on this, so that docs-only
+  # pull requests don't run the full test suite.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: "${{ steps.detect.outputs.code }}"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - id: detect
+        uses: ./.github/actions/detect-changes
   analyze:
+    if: "${{ !cancelled() && needs.changes.outputs.code != 'false' }}"
+    needs:
+      - changes
     name: Analyze
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/qa-codeql.yml
+++ b/.github/workflows/qa-codeql.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: "${{ steps.detect.outputs.code }}"
+      bundled-docs: "${{ steps.detect.outputs.bundled-docs }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:

--- a/.github/workflows/qa-semgrep.yml
+++ b/.github/workflows/qa-semgrep.yml
@@ -15,7 +15,23 @@ on:
     - cron: '12 15 * * *'
 
 jobs:
+  # Determines whether the pull request touches anything besides documentation.
+  # Everything that only validates code is gated on this, so that docs-only
+  # pull requests don't run the full test suite.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: "${{ steps.detect.outputs.code }}"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - id: detect
+        uses: ./.github/actions/detect-changes
   semgrep:
+    needs:
+      - changes
     name: semgrep/ci
     runs-on: ubuntu-latest
     permissions:
@@ -24,7 +40,7 @@ jobs:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:
       image: semgrep/semgrep
-    if: (github.actor != 'dependabot[bot]')
+    if: "${{ github.actor != 'dependabot[bot]' && !cancelled() && needs.changes.outputs.code != 'false' }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
       - run: semgrep ci

--- a/.github/workflows/qa-semgrep.yml
+++ b/.github/workflows/qa-semgrep.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: "${{ steps.detect.outputs.code }}"
+      bundled-docs: "${{ steps.detect.outputs.bundled-docs }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:

--- a/.github/workflows/translation-extract-compile.yml
+++ b/.github/workflows/translation-extract-compile.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: "${{ steps.detect.outputs.code }}"
+      bundled-docs: "${{ steps.detect.outputs.bundled-docs }}"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:

--- a/.github/workflows/translation-extract-compile.yml
+++ b/.github/workflows/translation-extract-compile.yml
@@ -16,7 +16,24 @@ env:
   POSTGRES_PASSWORD: "EK-5jnKfjrGRm<77"
 
 jobs:
+  # Determines whether the pull request touches anything besides documentation.
+  # Everything that only validates code is gated on this, so that docs-only
+  # pull requests don't run the full test suite.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: "${{ steps.detect.outputs.code }}"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - id: detect
+        uses: ./.github/actions/detect-changes
   compile:
+    needs:
+      - changes
+    if: "${{ !cancelled() && needs.changes.outputs.code != 'false' }}"
     runs-on: ubuntu-latest
     steps:
       - id: generate_token


### PR DESCRIPTION
Detect documentation-only pull requests and skip expensive CI jobs while keeping required checks reported via job-level gates instead of workflow path filters.

Documentation checks and the lightweight dependency review continue to run, while a detection failure runs affected checks rather than silently skipping them.