### PR TITLE
web: avoid blob iframe for interactive Turnstile

### DIFF
--- a/web/src/flow/stages/captcha/CaptchaStage.browser.test.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.browser.test.ts
@@ -1,0 +1,54 @@
+import "#flow/stages/captcha/CaptchaStage";
+
+import { CaptchaStage } from "#flow/stages/captcha/CaptchaStage";
+
+import type { CaptchaChallenge } from "@goauthentik/api";
+
+import type { TurnstileObject } from "turnstile-types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mounted = new Set<HTMLElement>();
+
+function mount<T extends HTMLElement>(element: T): T {
+    mounted.add(element);
+    document.body.appendChild(element);
+
+    return element;
+}
+
+afterEach(() => {
+    mounted.forEach((element) => element.remove());
+    mounted.clear();
+    Reflect.deleteProperty(window, "turnstile");
+    document.querySelectorAll("script[data-test-turnstile]").forEach((script) => script.remove());
+});
+
+describe("ak-stage-captcha", () => {
+    it("renders interactive Turnstile challenges without a blob iframe", async () => {
+        const challengeURL = "data:text/javascript,void%200%3B%2F%2F";
+        const providerScript = document.createElement("script");
+
+        providerScript.dataset.testTurnstile = "true";
+        providerScript.src = challengeURL;
+        document.head.appendChild(providerScript);
+        window.turnstile = {} as TurnstileObject;
+
+        const stage = mount(new CaptchaStage());
+
+        stage.challenge = {
+            component: "ak-stage-captcha",
+            interactive: true,
+            jsUrl: challengeURL,
+            siteKey: "test-site-key",
+        } as CaptchaChallenge;
+
+        await stage.updateComplete;
+
+        const iframe = stage.renderRoot.querySelector<HTMLIFrameElement>("#ak-captcha");
+
+        await vi.waitFor(() => {
+            expect(iframe?.contentDocument?.querySelector("#ak-container")).not.toBeNull();
+        });
+        expect(iframe?.getAttribute("src")).toBeNull();
+    });
+});

--- a/web/src/flow/stages/captcha/CaptchaStage.ts
+++ b/web/src/flow/stages/captcha/CaptchaStage.ts
@@ -561,11 +561,12 @@ export class CaptchaStage
 
         if (
             controller instanceof GReCaptchaController ||
-            controller instanceof HCaptchaController
+            controller instanceof HCaptchaController ||
+            controller instanceof TurnstileController
         ) {
-            // reCAPTCHA's & hCaptcha's domain verification can't seem to penetrate the true origin
-            // of the page when loaded from a blob URL, likely due to their double-nested
-            // iframe structure.
+            // reCAPTCHA and hCaptcha cannot reliably verify the page's origin when loaded from
+            // a blob URL, likely due to their double-nested iframe structure. Some embedded
+            // browsers also block blob URL iframe navigations, preventing Turnstile from loading.
             // We fallback to the deprecated `document.write` to get around this.
             this.#iframeSource = "about:blank";
 


### PR DESCRIPTION
<!--
👋 Hi there! Welcome. Please check the contributing guidelines: https://docs.goauthentik.io/docs/developer-docs/#how-can-i-contribute

⚠️ Open this PR from a feature branch, not from main: https://docs.goauthentik.io/developer-docs/contributing/#always-use-feature-branches
-->

## Details

### What does this PR change?

Use authentik's existing `about:blank` and `document.write()` iframe fallback for interactive Turnstile challenges. Add a browser regression test that verifies interactive Turnstile does not load through a blob iframe.

### Why is this change needed?

Some embedded browsers reject iframe navigation to `blob:` URLs. This prevents Turnstile from initializing when authentik renders an interactive CAPTCHA stage, even though Turnstile works on pages using HTTPS-backed frames.

The existing fallback already handles similar iframe and origin limitations for reCAPTCHA and hCaptcha.

This change was prepared with assistance from OpenAI Codex and personally reviewed by the contributor.

### How was this tested?

- Targeted Turnstile browser regression test
- Full Vitest browser project: 34/34 tests passed
- ESLint on the changed files
- TypeScript type checking
- Web precommit checks

### Linked issues

None.

<!--
Use `closes #N` to auto-close an issue on merge. Use `refs #N` for related issues that this PR does not close.
-->

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`) (not applicable; no documented behavior changed)
-   [ ] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
