### PR TITLE
sources/scim: allow filtering by externalId

### DIFF
--- a/authentik/sources/scim/views/v2/base.py
+++ b/authentik/sources/scim/views/v2/base.py
@@ -76,6 +76,7 @@ class SCIMView(APIView):
                 ("userName", None, None): "user__username",
                 ("active", None, None): "user__is_active",
                 ("name", "familyName", None): "attributes__familyName",
+                ("externalId", None, None): "external_id",
             }
         elif self.model == Group:
             attr_map = {
@@ -84,6 +85,7 @@ class SCIMView(APIView):
                 # `members` is a many-to-many relation, so it has to be filtered on a
                 # concrete field of the related user instead of on the relation itself
                 ("members", None, None): "group__users__uuid",
+                ("externalId", None, None): "external_id",
             }
         try:
             query = get_query(path, attr_map)


### PR DESCRIPTION
## Details

### What does this PR change?

Adds `externalId` as a valid filter for SCIM sources.

### Why is this change needed?

To work around issues with our directory having users with the same username but different domain names or users changing username, we have enabled externalId as a mapping on the Entra side with a matching precedence value.

This causes Entra to make filter requests to the SCIM source that fail (as per my bug #25837) due to the invalid mapping.

In 2026.5 and 2026.8 this caused a `500` error, but changes in 2026.11 (from #25095) will make this a `4XX` error instead.

Adding externalId to the filter allows this to work and allows entra to match the users correctly

### How was this tested?

Running a full re-provision from Entra on a patched version of 2026.8 (See #25837 for the variation of code used there - this was intended to be a a minimal-code-change version of the code that landed in main to test the behaviour with the 4XX errors and then working around it).

I have limited options for testing against a live Entra setup.

### Linked issues

refs #25837

---

## Checklist

-   [X ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [ X] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
