### PR TITLE
ci: remove the Google Chrome apt source in setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,6 +21,9 @@ runs:
       if: ${{ contains(inputs.dependencies, 'system') || contains(inputs.dependencies, 'python') }}
       shell: bash
       run: |
+        # The runner image installs Chrome and leaves its apt source behind.
+        # Nothing here installs from it, and a broken index there breaks the
+        # apt-get update below. https://github.com/goauthentik/authentik/pull/25990
         sudo rm -f /etc/apt/sources.list.d/google-chrome.*
         sudo apt-get remove --purge man-db
     - name: Install apt deps

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,7 +20,9 @@ runs:
     - name: Cleanup apt
       if: ${{ contains(inputs.dependencies, 'system') || contains(inputs.dependencies, 'python') }}
       shell: bash
-      run: sudo apt-get remove --purge man-db
+      run: |
+        sudo rm -f /etc/apt/sources.list.d/google-chrome.*
+        sudo apt-get remove --purge man-db
     - name: Install apt deps
       if: ${{ contains(inputs.dependencies, 'system') || contains(inputs.dependencies, 'python') }}
       uses: gerlero/apt-install@c0fa73fe5c4a22deecf6d629565be92a15dd2026


### PR DESCRIPTION
The runner image installs Chrome from a direct .deb, then deletes the apt source that the package creates. It only removes the legacy /etc/apt/sources.list.d/google-chrome.list. Current Chrome packages write google-chrome.sources in deb822 format instead, pointing at https://dl.google.com/linux/chrome-stable/deb/, so the source survives on ubuntu-latest.

Every apt-get update then queries that repository. On 2026-09-09 Google regenerated its Release file at 17:16:59 UTC and the CDN served a stale Packages.gz for about 40 minutes. apt-get update failed with "Hash Sum mismatch" and exit code 100, which broke every job that uses this action with system or python dependencies, on every branch.