### PR TITLE
blueprints, stages/authenticator_sms: translate before interpolating

### DIFF
--- a/authentik/blueprints/api.py
+++ b/authentik/blueprints/api.py
@@ -154,12 +154,8 @@ def check_blueprint_perms(blueprint: Blueprint, user: User, explicit_action: str
             if not user.has_perm(perm):
                 raise PermissionDenied(
                     {
-                        entry.id: _(
-                            "User lacks permission to create {model}".format_map(
-                                {
-                                    "model": full_model,
-                                }
-                            )
+                        entry.id: _("User lacks permission to create {model}").format(
+                            model=full_model
                         )
                     }
                 )

--- a/authentik/stages/authenticator_sms/models.py
+++ b/authentik/stages/authenticator_sms/models.py
@@ -78,7 +78,7 @@ class AuthenticatorSMSStage(ConfigurableStage, FriendlyNamedStage, Stage):
 
     def get_message(self, token: str) -> str:
         """Get SMS message"""
-        return _("Use this code to authenticate in authentik: {token}".format_map({"token": token}))
+        return _("Use this code to authenticate in authentik: {token}").format(token=token)
 
     def send_twilio(self, request: HttpRequest, token: str, device: SMSDevice):
         """send sms via twilio provider"""


### PR DESCRIPTION
## Details

### What does this PR change?

Two call sites interpolate a string and then hand the *result* to `gettext`:

```python
# authentik/blueprints/api.py
_("User lacks permission to create {model}".format_map({"model": full_model}))

# authentik/stages/authenticator_sms/models.py
_("Use this code to authenticate in authentik: {token}".format_map({"token": token}))
```

The `.format_map()` runs before `_()`, so the string that reaches the catalog lookup is
`"User lacks permission to create authentik_providers_saml.samlprovider"`, not the msgid
`"User lacks permission to create {model}"`. It never matches, and the translations that
are already in `locale/` for both of these strings are dead.

This moves the interpolation outside the `_()` call, which is what
`authentik/core/api/applications.py` and `authentik/tenants/api/settings.py` already do:

```python
_("Value for flag {flag_key} needs to be of type {type}.").format(...)
```

### Why is this change needed?

The msgids are extracted and translated in every locale, they just can't be reached. From
`locale/fr_FR/LC_MESSAGES/django.po`:

```
#: authentik/blueprints/api.py
msgid "User lacks permission to create {model}"
msgstr "L'utilisateur manque de permission pour créer {model}"

#: authentik/stages/authenticator_sms/models.py
msgid "Use this code to authenticate in authentik: {token}"
msgstr "Utilisez ce code pour s'authentifier à authentik : {token}"
```

The SMS one is the user-visible half: the OTP text message body always goes out in English,
whatever the brand/user locale is.

### How was this tested?

I don't have a full dev environment on this machine, so I checked the thing that actually
breaks rather than the surrounding view code. `gettext_lazy`/`gettext` end up in
`gettext.GNUTranslations.gettext()` against the compiled `locale/<lang>/LC_MESSAGES/django.mo`,
so I pulled the real `_()` expression out of each file with `ast`, evaluated it with `_` bound
to the repo's own compiled `fr_FR` catalog, and compared against the `msgstr`.

Before:

```
authentik/blueprints/api.py
  expression : _('User lacks permission to create {model}'.format_map({'model': full_model}))
  fr_FR gives: 'User lacks permission to create authentik_providers_saml.samlprovider'
  expected   : "L'utilisateur manque de permission pour créer authentik_providers_saml.samlprovider"
  -> NOT TRANSLATED

authentik/stages/authenticator_sms/models.py
  expression : _('Use this code to authenticate in authentik: {token}'.format_map({'token': token}))
  fr_FR gives: 'Use this code to authenticate in authentik: 123456'
  expected   : "Utilisez ce code pour s'authentifier à authentik : 123456"
  -> NOT TRANSLATED

AssertionError: 2 string(s) never reach the fr_FR catalog
```

After:

```
authentik/blueprints/api.py
  expression : _('User lacks permission to create {model}').format(model=full_model)
  fr_FR gives: "L'utilisateur manque de permission pour créer authentik_providers_saml.samlprovider"
  -> OK

authentik/stages/authenticator_sms/models.py
  expression : _('Use this code to authenticate in authentik: {token}').format(token=token)
  fr_FR gives: "Utilisez ce code pour s'authentifier à authentik : 123456"
  -> OK

all strings translated
```

For no-regression I ran the same comparison against the `en` catalog on both revisions:

```
authentik/blueprints/api.py
  en before: 'User lacks permission to create authentik_providers_saml.samlprovider'
  en after : 'User lacks permission to create authentik_providers_saml.samlprovider'
  identical: True
authentik/stages/authenticator_sms/models.py
  en before: 'Use this code to authenticate in authentik: 123456'
  en after : 'Use this code to authenticate in authentik: 123456'
  identical: True
```

That matters for `authentik/core/tests/test_transactional_applications_api.py`, which asserts
on the literal English text of the blueprints message — the output is byte-identical, so it
should still pass.

One note on `blueprints/api.py`: `_` there is `gettext_lazy`, so `.format()` on the proxy
forces evaluation and returns a plain `str` instead of a lazy object. That's the same shape as
`tenants/api/settings.py`, and both messages are built inside a request, so the active language
is already set. In `authenticator_sms/models.py` the annotation is already `-> str` and both
callers do `str(self.get_message(token))`, so returning a real `str` is if anything more correct.

### Linked issues

None.

---

While grepping for the pattern I found four more instances of it — `policies/password/models.py`,
`providers/oauth2/api/providers.py`, `sources/ldap/api/sources.py`, `sources/oauth/views/callback.py`
(and a handful of `_(f"...")` in `admin/files/validation.py` and `enterprise/`, which xgettext can't
extract at all). I left them out because open PRs are currently touching those files and I didn't
want to hand you conflicts over a one-line change. Happy to fold them in here or send a follow-up,
whichever you prefer.

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`) — I couldn't run this locally, see above for what I did run
-   [ ] The documentation has been updated and formatted (`make docs`) — no docs affected
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).

AI tools used: Claude Code, to sweep the tree for the `_("...".format(...))` pattern and to draft
the ast-based reproduction script. The diff, the verification against the real catalogs, and this
description are mine and I've re-run every output pasted above.
