### PR TITLE
lib/sync/outgoing: prevent duplicate group creation in outgoing providers

### DIFF
--- a/authentik/enterprise/providers/google_workspace/clients/groups.py
+++ b/authentik/enterprise/providers/google_workspace/clients/groups.py
@@ -97,8 +97,8 @@ class GoogleWorkspaceGroupClient(
             # Resource missing is handled by self.write, which will re-create the group
             raise
 
-    def write(self, obj: Group):
-        google_group, created = super().write(obj)
+    def _write(self, obj: Group):
+        google_group, created = super()._write(obj)
         self.create_sync_members(obj, google_group)
         return google_group, created
 

--- a/authentik/enterprise/providers/microsoft_entra/clients/groups.py
+++ b/authentik/enterprise/providers/microsoft_entra/clients/groups.py
@@ -110,8 +110,8 @@ class MicrosoftEntraGroupClient(
             # Resource missing is handled by self.write, which will re-create the group
             raise
 
-    def write(self, obj: Group):
-        microsoft_group, created = super().write(obj)
+    def _write(self, obj: Group):
+        microsoft_group, created = super()._write(obj)
         self.create_sync_members(obj, microsoft_group)
         return microsoft_group, created
 

--- a/authentik/lib/sync/outgoing/api.py
+++ b/authentik/lib/sync/outgoing/api.py
@@ -113,7 +113,7 @@ class OutgoingSyncProviderStatusMixin:
                 "override_dry_run": body.validated_data["override_dry_run"],
                 "pk": pk,
             },
-            retries=0,
+            retries=1,
             rel_obj=provider,
             uid=f"{provider.name}:{_object_type._meta.model_name}:{pk}:manual",
         )

--- a/authentik/lib/sync/outgoing/base.py
+++ b/authentik/lib/sync/outgoing/base.py
@@ -1,19 +1,28 @@
 """Basic outgoing sync Client"""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import timedelta
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
+import pglock
 from deepmerge import always_merger
-from django.db import DatabaseError
+from django.db import DatabaseError, connection
 from structlog.stdlib import get_logger
 
 from authentik.core.expression.exceptions import (
     PropertyMappingExpressionException,
 )
 from authentik.events.models import Event, EventAction
+from authentik.lib.config import advisory_lock_db_alias
 from authentik.lib.expression.exceptions import ControlFlowException
 from authentik.lib.sync.mapper import PropertyMappingManager
-from authentik.lib.sync.outgoing.exceptions import NotFoundSyncException, StopSync
+from authentik.lib.sync.outgoing.exceptions import (
+    NotFoundSyncException,
+    ObjectLockTimeout,
+    StopSync,
+)
 
 if TYPE_CHECKING:
     from django.db.models import Model
@@ -32,6 +41,8 @@ SAFE_METHODS = [
     "OPTIONS",
     "TRACE",
 ]
+
+OBJECT_LOCK_TIMEOUT = timedelta(seconds=30)
 
 
 class BaseOutgoingSyncClient[
@@ -61,9 +72,31 @@ class BaseOutgoingSyncClient[
         """Update object in remote destination"""
         raise NotImplementedError()
 
+    @contextmanager
+    def object_lock(self, obj: TModel) -> Iterator[None]:
+        """Serialize remote operations for one object and provider."""
+        lock_id = (
+            f"goauthentik.io/{connection.schema_name}/providers/outgoing-sync/"
+            f"{self.provider._meta.label_lower}/{self.provider.pk}/"
+            f"{obj._meta.label_lower}/{obj.pk}"
+        )
+        with pglock.advisory(
+            lock_id=lock_id,
+            timeout=OBJECT_LOCK_TIMEOUT,
+            side_effect=pglock.Return,
+            using=advisory_lock_db_alias(),
+        ) as lock_acquired:
+            if not lock_acquired:
+                raise ObjectLockTimeout(lock_id)
+            yield
+
     def write(self, obj: TModel) -> tuple[TConnection, bool]:
-        """Write object to destination. Uses self.create and self.update, but
-        can be overwritten for further logic"""
+        """Write an object to the destination while holding its object lock."""
+        with self.object_lock(obj):
+            return self._write(obj)
+
+    def _write(self, obj: TModel) -> tuple[TConnection, bool]:
+        """Write an object while the caller holds its object lock."""
         connection = self.connection_type.objects.filter(
             provider=self.provider, **{self.connection_type_query: obj}
         ).first()
@@ -83,6 +116,15 @@ class BaseOutgoingSyncClient[
             if connection:
                 connection.delete()
         return None, False
+
+    def sync_group_membership(self, obj: TModel, action: Direction, users_set: set[int]) -> None:
+        """Update group membership while holding the same lock used by writes."""
+        with self.object_lock(obj):
+            self.update_group(obj, action, users_set)
+
+    def update_group(self, obj: TModel, action: Direction, users_set: set[int]) -> None:
+        """Update group membership in the remote destination."""
+        raise NotImplementedError()
 
     def delete(self, identifier: str):
         """Delete object from destination"""

--- a/authentik/lib/sync/outgoing/exceptions.py
+++ b/authentik/lib/sync/outgoing/exceptions.py
@@ -36,6 +36,13 @@ class TransientSyncException(BaseSyncException):
     error_default = "Network error communicating with remote system"
 
 
+class ObjectLockTimeout(TransientSyncException):
+    """Timed out waiting to synchronize another change to the same object."""
+
+    error_prefix = "Object lock timeout"
+    error_default = "Timed out waiting to synchronize object"
+
+
 class NotFoundSyncException(BaseSyncException):
     """Exception when an object was not found in the remote system"""
 

--- a/authentik/lib/sync/outgoing/tasks.py
+++ b/authentik/lib/sync/outgoing/tasks.py
@@ -14,6 +14,7 @@ from authentik.lib.sync.outgoing.exceptions import (
     BadRequestSyncException,
     DryRunRejected,
     NotFoundSyncException,
+    ObjectLockTimeout,
     StopSync,
     TransientSyncException,
 )
@@ -217,6 +218,8 @@ class SyncTasks:
                     obj=sanitize_item(obj),
                     exception=exception_to_dict(exc),
                 )
+            except ObjectLockTimeout as exc:
+                raise Retry() from exc
             except TransientSyncException as exc:
                 self.logger.warning("failed to sync object", exc=exc, user=obj)
                 task.warning(
@@ -404,12 +407,14 @@ class SyncTasks:
 
         client = provider.client_for_model(Group)
         try:
-            operation = None
             if action == "post_add":
                 operation = Direction.add
-            if action == "post_remove":
+            elif action == "post_remove":
                 operation = Direction.remove
-            client.update_group(group, operation, pk_set)
+            else:
+                self.logger.warning("Unknown group membership action", action=action)
+                return
+            client.sync_group_membership(group, operation, pk_set)
         except TransientSyncException as exc:
             raise Retry() from exc
         except SkipObjectException:

--- a/authentik/providers/scim/tests/test_concurrency.py
+++ b/authentik/providers/scim/tests/test_concurrency.py
@@ -1,0 +1,100 @@
+"""SCIM outgoing synchronization concurrency tests."""
+
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
+from threading import Event, Lock
+from unittest.mock import patch
+
+from django.db import close_old_connections
+from django.test import TransactionTestCase
+
+from authentik.blueprints.tests import apply_blueprint
+from authentik.core.models import Group
+from authentik.lib.generators import generate_id
+from authentik.lib.sync.outgoing.base import Direction
+from authentik.lib.sync.outgoing.signals import sync_outgoing_inhibit_dispatch
+from authentik.providers.scim.clients.groups import SCIMGroupClient
+from authentik.providers.scim.models import SCIMMapping, SCIMProvider, SCIMProviderGroup
+
+
+class SCIMGroupConcurrencyTests(TransactionTestCase):
+    """Verify concurrent changes to one group are serialized."""
+
+    @apply_blueprint("system/providers-scim.yaml")
+    def setUp(self) -> None:
+        self.provider = SCIMProvider.objects.create(
+            name=generate_id(),
+            url="https://localhost",
+            token=generate_id(),
+        )
+        self.provider.property_mappings_group.set(
+            [SCIMMapping.objects.get(managed="goauthentik.io/providers/scim/group")]
+        )
+        with sync_outgoing_inhibit_dispatch():
+            self.group = Group.objects.create(name=generate_id())
+
+    def test_concurrent_create_is_serialized(self):
+        """Only one writer creates the remote object and local connection."""
+        create_started = Event()
+        release_create = Event()
+        second_started = Event()
+        second_finished = Event()
+        create_call_lock = Lock()
+        create_calls = 0
+
+        def create(client: SCIMGroupClient, group: Group) -> SCIMProviderGroup:
+            nonlocal create_calls
+            with create_call_lock:
+                create_calls += 1
+            create_started.set()
+            if not release_create.wait(5):
+                raise TimeoutError("Test did not release the first create")
+            return SCIMProviderGroup.objects.create(
+                provider=client.provider,
+                group=group,
+                scim_id=generate_id(),
+            )
+
+        def write_group(is_second: bool) -> bool:
+            close_old_connections()
+            try:
+                if is_second:
+                    second_started.set()
+                client = SCIMGroupClient(self.provider)
+                _, created = client.write(self.group)
+                if is_second:
+                    second_finished.set()
+                return created
+            finally:
+                close_old_connections()
+
+        with (
+            patch.object(SCIMGroupClient, "create", autospec=True, side_effect=create),
+            patch.object(SCIMGroupClient, "update", autospec=True),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            first = executor.submit(write_group, False)
+            self.assertTrue(create_started.wait(5))
+            second = executor.submit(write_group, True)
+            self.assertTrue(second_started.wait(5))
+            self.assertFalse(second_finished.wait(0.2))
+            release_create.set()
+            self.assertEqual([first.result(), second.result()], [True, False])
+
+        self.assertEqual(create_calls, 1)
+        self.assertEqual(
+            SCIMProviderGroup.objects.filter(provider=self.provider, group=self.group).count(),
+            1,
+        )
+
+    def test_membership_uses_object_lock(self):
+        """Membership changes use the same object lock as object writes."""
+        client = SCIMGroupClient(self.provider)
+        with (
+            patch.object(client, "object_lock", return_value=nullcontext()) as object_lock,
+            patch.object(client, "update_group") as update_group,
+        ):
+            client.sync_group_membership(self.group, Direction.add, {1})
+
+        object_lock.assert_called_once_with(self.group)
+        update_group.assert_called_once_with(self.group, Direction.add, {1})


### PR DESCRIPTION
### Summary
Prevent concurrent outgoing provisioning tasks from creating duplicate remote objects and duplicate local provisioned-object records.
Rapid consecutive changes, such as creating a group and immediately adding members, can schedule overlapping synchronization tasks. Both tasks could observe that no provider connection existed and independently create the same object remotely.

### Changes
- Add a tenant-, provider-, and object-scoped PostgreSQL advisory lock around outgoing writes.
- Hold the lock through remote creation/update, local connection persistence, and initial group membership synchronization.
- Use the same lock for subsequent membership changes.
- Retry tasks when the 30-second lock acquisition timeout is reached.
- Preserve Entra and Google Workspace post-write membership behavior inside the lock.
- Reject unknown membership task actions.
- Add a concurrent SCIM group regression test that verifies:
- Only one create operation occurs.
- The second writer waits for the first.
- Both writers converge on one local connection.
 
### Scope
The locking is implemented in the shared outgoing synchronization client, so it applies to SCIM, Microsoft Entra, and Google Workspace users and groups.
This change does not modify or clean up existing duplicate records.

### Testing
- New SCIM concurrency tests: 2 passed
- SCIM, Microsoft Entra, and Google Workspace suites: 101 passed
- Black and Ruff checks passed


---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [ ] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
