### PR TITLE
web/flows: fix hardcoded locale in identification stage's OR_LIST_FORMATTERS

### DIFF
--- a/web/src/flow/stages/identification/IdentificationStage.ts
+++ b/web/src/flow/stages/identification/IdentificationStage.ts
@@ -17,8 +17,8 @@ import WebauthnController from "#flow/stages/identification/controllers/Webauthn
 import Styles from "#flow/stages/identification/styles.css";
 import {
     compareLoginSource,
+    createOrListFormatter,
     formatUIFieldLabel,
-    OR_LIST_FORMATTERS,
 } from "#flow/stages/identification/utils";
 
 import AKFieldset from "#styles/authentik/components/Fieldset/fieldset.css";
@@ -350,7 +350,9 @@ export class IdentificationStage extends BaseStage<
         const offerRecovery = flowDesignation === FlowDesignationEnum.Recovery;
         const type = fields.length === 1 && fields[0] === UserFieldsEnum.Email ? "email" : "text";
 
-        const label = OR_LIST_FORMATTERS.format(fields.map((field) => formatUIFieldLabel(field)));
+        const label = createOrListFormatter(this.activeLanguageTag).format(
+            fields.map((field) => formatUIFieldLabel(field)),
+        );
 
         // prettier-ignore
         return html`${offerRecovery ? this.renderRecoveryMessage() : nothing}

--- a/web/src/flow/stages/identification/utils.ts
+++ b/web/src/flow/stages/identification/utils.ts
@@ -6,10 +6,15 @@ import { match } from "ts-pattern";
 
 import { msg, str } from "@lit/localize";
 
-export const OR_LIST_FORMATTERS: Intl.ListFormat = new Intl.ListFormat("default", {
-    style: "short",
-    type: "disjunction",
-});
+/**
+ * Builds an `Intl.ListFormat` for the given locale — call fresh per render, don't cache.
+ */
+export function createOrListFormatter(locale: string): Intl.ListFormat {
+    return new Intl.ListFormat(locale, {
+        style: "short",
+        type: "disjunction",
+    });
+}
 
 export const UIFieldLabels: Record<UserFieldsEnum, MessageFormatter<string>> = {
     [UserFieldsEnum.Username]: () => msg("Username"),

--- a/web/src/flow/stages/identification/utils.unit.test.ts
+++ b/web/src/flow/stages/identification/utils.unit.test.ts
@@ -1,0 +1,24 @@
+import { createOrListFormatter } from "#flow/stages/identification/utils";
+
+import { describe, expect, it } from "vitest";
+
+describe("createOrListFormatter", () => {
+    it("localizes the disjunction word for the given locale", () => {
+        expect(createOrListFormatter("en-US").format(["Email", "Username"])).toBe(
+            "Email or Username",
+        );
+        expect(createOrListFormatter("cs-CZ").format(["E-mail", "Uživatelské jméno"])).toBe(
+            "E-mail nebo Uživatelské jméno",
+        );
+        expect(createOrListFormatter("de-DE").format(["E-Mail", "Anmeldename"])).toBe(
+            "E-Mail oder Anmeldename",
+        );
+    });
+
+    it("does not fall back to the runtime's own default locale", () => {
+        // Guards against reintroducing the hardcoded "default" locale.
+        const formatted = createOrListFormatter("cs-CZ").format(["E-mail", "Uživatelské jméno"]);
+
+        expect(formatted).not.toContain(" or ");
+    });
+});


### PR DESCRIPTION
## Details

### What does this PR change?

Moves the "or" list formatter in the identification stage from a module-level constant to a function built at render time with the stage's active locale.

### Why is this change needed?

`OR_LIST_FORMATTERS` was built once with `Intl.ListFormat("default", ...)`. That resolves to the browser's own locale, not authentik's active locale. Field labels like "Email" and "Username" translate correctly through `msg()`, but the "or" joining them stays in the browser's language no matter what locale is active.

Verified directly in Node: `Intl.ListFormat("default", ...)` follows `LANG`/`LC_ALL`, not anything authentik sets.

```
LANG=en_US.UTF-8 -> "Email or Username"
LANG=cs_CZ.UTF-8 -> "Email nebo Username"
```

### How was this tested?

- Added `utils.unit.test.ts`: covers en-US, cs-CZ, de-DE, plus a regression check against the old "default" locale bug.
- Ran `tsc --noEmit`, `eslint`, `prettier --check`, and `vitest run` on the changed files - all pass.

### Linked issues

Closes #20632

---

### AI disclosure

Root cause investigation, fix, and test were done with Claude Code (Anthropic). I reviewed the diagnosis, reproduced the locale bug myself in Node before accepting it, and verified the fix.

---

## Checklist

- [x] The project has been linted, built, and tested (`make all`)
- [x] The documentation has been updated and formatted (`make docs`) - no docs needed, this restores existing intended behavior, not a new/changed feature
- [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
