### PR TITLE
web/locale: add missing Czech translation for identification stage subtitle

### DIFF
--- a/web/xliff/cs-CZ.xlf
+++ b/web/xliff/cs-CZ.xlf
@@ -9548,6 +9548,7 @@ Vazby na skupiny/uživatele jsou kontrolovány vůči uživateli události.</tar
 </trans-unit>
 <trans-unit id="sf910cca0f06bbc31">
   <source>Enter the email address or username associated with your account.</source>
+  <target>Zadejte emailovou adresu nebo uživatelské jméno spojené s vaším účtem.</target>
 </trans-unit>
 <trans-unit id="s6e858c4c4c3b6b76">
   <source>You're about to be redirected to the following URL.</source>


### PR DESCRIPTION
## Details

### What does this PR change?

Adds the missing Czech `<target>` for one string in `web/xliff/cs-CZ.xlf`: "Enter the email address or username associated with your account."

### Why is this change needed?

This string has no Czech translation at all, so it silently falls back to English regardless of the active locale, on both the login and password-recovery screens.

### How was this tested?

- Validated the file is still well-formed XML after the edit.
- Checked how similar strings are already phrased elsewhere in `cs-CZ.xlf` to keep wording and terminology consistent with the rest of the catalog.
- Wording reviewed by a native Czech speaker before submitting.

### Linked issues

None - found while investigating #20632, not itself tracked by an issue.

---

### AI disclosure

Investigated with Claude Code (Anthropic), including finding the missing translation and drafting the wording. I reviewed the phrasing myself as a native Czech speaker and corrected it before submitting.

---

## Checklist

- [x] The project has been linted, built, and tested (`make all`)
- [x] The documentation has been updated and formatted (`make docs`) - N/A, translation-only change
- [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
