### PR TITLE
website/docs: add warnings about property mapping handling for sync providers

### DIFF
--- a/website/docs/add-secure-apps/providers/entra/index.mdx
+++ b/website/docs/add-secure-apps/providers/entra/index.mdx
@@ -38,7 +38,7 @@ Additionally, any users or groups present in authentik but absent in Entra ID wi
 
 ## Error handling
 
-When a property mapping has an invalid expression, it will cause a sync to stop to prevent excessive error messages.
+Property mappings are evaluated in name order. If a property mapping fails to evaluate, authentik stops the synchronization and does not evaluate the remaining mappings.
 
 To handle network interruptions, authentik detects transient request failures and retries sync tasks.
 

--- a/website/docs/add-secure-apps/providers/gws/index.mdx
+++ b/website/docs/add-secure-apps/providers/gws/index.mdx
@@ -36,7 +36,7 @@ Additionally, any users or groups present in authentik but absent in Google Work
 
 ## Error handling
 
-When a property mapping has an invalid expression, it will cause a sync to stop to prevent excessive error messages.
+Property mappings are evaluated in name order. If a property mapping fails to evaluate, authentik stops the synchronization and does not evaluate the remaining mappings.
 
 To handle network interruptions, authentik detects transient request failures and retries sync tasks.
 

--- a/website/docs/add-secure-apps/providers/property-mappings/index.mdx
+++ b/website/docs/add-secure-apps/providers/property-mappings/index.mdx
@@ -91,6 +91,10 @@ See [Scope mappings](../oauth2/index.mdx#scope-mappings) for scope authorization
 
 Synchronization providers use property mappings to build the user and group data that they send to integrated services. The mapping must return data in the format that the integrated service expects.
 
+:::warning Property mapping errors
+Synchronization providers evaluate property mappings in name order. If a property mapping fails to evaluate, authentik stops the synchronization and does not evaluate the remaining mappings. Other provider types generally record the error and continue with the next property mapping.
+:::
+
 Refer to the provider documentation for supported fields and examples:
 
 - [SCIM](../scim/index.mdx#attribute-mapping)

--- a/website/docs/add-secure-apps/providers/scim/index.mdx
+++ b/website/docs/add-secure-apps/providers/scim/index.mdx
@@ -59,6 +59,10 @@ Attribute mapping from authentik to SCIM users is done through property mappings
 
 All selected mappings are applied in the order of their name, and are deeply merged onto the final user data. The final data is then validated against the SCIM schema, and if the data is not valid, the sync is stopped.
 
+:::warning Property mapping errors
+Property mappings are evaluated in name order. If a property mapping fails to evaluate, authentik stops the synchronization and does not evaluate the remaining mappings.
+:::
+
 ### Custom attributes and schemas
 
 To send attributes in a custom SCIM schema extension, [create or edit a SCIM provider property mapping](../property-mappings/#create-a-custom-provider-property-mapping), then add it to the SCIM provider's **User Property Mappings**.


### PR DESCRIPTION
## Details

@BeryJu 

### What does this PR change?

### Why is this change needed?

### How was this tested?

### Linked issues


---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
