### PR TITLE
providers/oauth: handle token exchange when no signing key is set

### DIFF
--- a/authentik/providers/oauth2/tests/test_token_exchange.py
+++ b/authentik/providers/oauth2/tests/test_token_exchange.py
@@ -63,6 +63,7 @@ class TestTokenExchange(OAuthTestCase):
             name=generate_id(),
             authorization_flow=create_test_flow(),
             signing_key=self.other_cert,
+            grant_types=[],
         )
         self.other_provider.property_mappings.set(ScopeMapping.objects.all())
         self.other_app = Application.objects.create(
@@ -70,7 +71,7 @@ class TestTokenExchange(OAuthTestCase):
         )
 
         # The provider performing the exchange
-        self.provider: OAuth2Provider = OAuth2Provider.objects.create(
+        self.provider = OAuth2Provider.objects.create(
             name=generate_id(),
             authorization_flow=create_test_flow(),
             redirect_uris=[RedirectURI(RedirectURIMatchingMode.STRICT, "http://testserver")],
@@ -89,6 +90,7 @@ class TestTokenExchange(OAuthTestCase):
             name=generate_id(),
             authorization_flow=create_test_flow(),
             signing_key=self.target_cert,
+            grant_types=[],
         )
         self.target_provider.jwt_federation_providers.add(self.provider)
         self.target_provider.property_mappings.set(ScopeMapping.objects.all())
@@ -495,6 +497,7 @@ class TestTokenExchange(OAuthTestCase):
         hs256_provider = OAuth2Provider.objects.create(
             name=generate_id(),
             authorization_flow=create_test_flow(),
+            grant_types=[],
         )
         self.provider.jwt_federation_providers.add(hs256_provider)
         subject_token = self.create_subject_token(self.user, provider=hs256_provider)

--- a/authentik/providers/oauth2/tests/test_token_exchange.py
+++ b/authentik/providers/oauth2/tests/test_token_exchange.py
@@ -490,6 +490,24 @@ class TestTokenExchange(OAuthTestCase):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_successful_hs256_subject_token(self):
+        """test successful exchange of a subject token signed with the client secret"""
+        hs256_provider = OAuth2Provider.objects.create(
+            name=generate_id(),
+            authorization_flow=create_test_flow(),
+        )
+        self.provider.jwt_federation_providers.add(hs256_provider)
+        subject_token = self.create_subject_token(self.user, provider=hs256_provider)
+
+        response = self._exchange(subject_token=subject_token)
+        self.assertEqual(response.status_code, 200, response.content)
+        body = loads(response.content.decode())
+        self.assertEqual(body["token_type"], TOKEN_TYPE)
+        self.assertEqual(body["issued_token_type"], TOKEN_TYPE_URI_ACCESS_TOKEN)
+
+        jwt = self._decode_for(self.provider, body["access_token"])
+        self.assertEqual(jwt["preferred_username"], self.user.username)
+
     def test_successful(self):
         """test successful exchange, preserving the subject's identity"""
         response = self.client.post(

--- a/authentik/providers/oauth2/token/base_fed.py
+++ b/authentik/providers/oauth2/token/base_fed.py
@@ -121,9 +121,10 @@ class FederatedTokenRequest(TokenRequest):
         if federated_token:
             _key, _alg = federated_token.provider.jwt_key
             try:
+                verification_key = _key if isinstance(_key, str) else _key.public_key()
                 token = decode(
                     assertion,
-                    _key.public_key(),
+                    verification_key,
                     algorithms=[_alg],
                     options={
                         "verify_aud": False,


### PR DESCRIPTION
## Details

### What does this PR change?

Fixes provider-federated JWT verification for OAuth2 providers without a configured signing key. These providers use HS256 with their client secret, but verification incorrectly attempted to call `.public_key()` on the secret.

### Why is this change needed?

### How was this tested?

### Linked issues

---

## Checklist

-   [x] The project has been linted, built, and tested (`make all`)
-   [x] The documentation has been updated and formatted (`make docs`)
-   [x] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).
