### PR TITLE
website: use printf for password hashing examples

### DIFF
--- a/website/docs/customize/blueprints/v1/models.mdx
+++ b/website/docs/customize/blueprints/v1/models.mdx
@@ -58,7 +58,7 @@ docker compose run --rm server hash_password
 For automation, pass the password in the `PASSWORD` environment variable and pipe it through standard input to prevent exposing the password in your shell history:
 
 ```bash
-echo "$PASSWORD" | docker compose run --rm server hash_password
+printf '%s' "$PASSWORD" | docker compose run --rm server hash_password
 ```
 
 For example:

--- a/website/docs/install-config/automated-install.mdx
+++ b/website/docs/install-config/automated-install.mdx
@@ -24,7 +24,7 @@ docker compose run --rm server hash_password
 For automation, pass the password in the `PASSWORD` environment variable and pipe it through standard input to prevent exposing the password in your shell history:
 
 ```bash
-echo "$PASSWORD" | docker compose run --rm server hash_password
+printf '%s' "$PASSWORD" | docker compose run --rm server hash_password
 ```
 
 Alternatively, redirect a file that contains the password into the command:

--- a/website/docs/releases/2026/v2026.8.mdx
+++ b/website/docs/releases/2026/v2026.8.mdx
@@ -26,7 +26,7 @@ docker compose run --rm server hash_password
 For automation, pipe the password through standard input:
 
 ```bash
-echo "$PASSWORD" | docker compose run --rm server hash_password
+printf '%s' "$PASSWORD" | docker compose run --rm server hash_password
 ```
 
 ### "Prevent duplicate device" in WebAuthn setup stage removed


### PR DESCRIPTION
Updates all automated password piping examples to use printf instead of echo, preserving password contents when passed to hash_password.

Closes: #25653

Validated with make docs.