### PR TITLE
blueprints: export with references

### DIFF
--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -7,7 +7,7 @@ from django.test import TransactionTestCase
 from yaml import load
 
 from authentik.blueprints.tests import apply_blueprint
-from authentik.blueprints.v1.common import BlueprintLoader
+from authentik.blueprints.v1.common import BlueprintLoader, KeyOf
 from authentik.blueprints.v1.exporter import FlowExporter
 from authentik.blueprints.v1.importer import Importer, transaction_rollback
 from authentik.core.models import Group
@@ -327,6 +327,64 @@ class TestBlueprintsV1(TransactionTestCase):
         self.assertTrue(importer.validate()[0])
         self.assertTrue(importer.apply())
         self.assertTrue(UserLoginStage.objects.filter(name=stage_name).exists())
+        self.assertTrue(Flow.objects.filter(slug=flow_slug).exists())
+
+    def test_export_uses_keyof_references(self):
+        """Test that exporting a flow rewrites references between exported objects
+        as !KeyOf tags instead of raw primary keys"""
+        flow_slug = generate_id()
+        stage_name = generate_id()
+        with transaction_rollback():
+            flow_policy = ExpressionPolicy.objects.create(
+                name=generate_id(),
+                expression="return True",
+            )
+            flow = Flow.objects.create(
+                slug=flow_slug,
+                designation=FlowDesignation.AUTHENTICATION,
+                name=generate_id(),
+                title=generate_id(),
+            )
+            PolicyBinding.objects.create(policy=flow_policy, target=flow, order=0)
+
+            user_login = UserLoginStage.objects.create(name=stage_name)
+            fsb = FlowStageBinding.objects.create(target=flow, stage=user_login, order=0)
+            PolicyBinding.objects.create(policy=flow_policy, target=fsb, order=0)
+
+            exporter = FlowExporter(flow)
+            export = exporter.export()
+            export_yaml = exporter.export_to_string()
+
+        entries_by_model = {}
+        for entry in export.entries:
+            entries_by_model.setdefault(entry.model, []).append(entry)
+
+        flow_entry = entries_by_model["authentik_flows.flow"][0]
+        stage_entry = entries_by_model["authentik_stages_user_login.userloginstage"][0]
+        stage_binding_entry = entries_by_model["authentik_flows.flowstagebinding"][0]
+        policy_entry = entries_by_model["authentik_policies_expression.expressionpolicy"][0]
+        policy_binding_entries = entries_by_model["authentik_policies.policybinding"]
+
+        self.assertIsNotNone(flow_entry.id)
+        self.assertIsNotNone(stage_entry.id)
+
+        self.assertIsInstance(stage_binding_entry.identifiers["target"], KeyOf)
+        self.assertEqual(stage_binding_entry.identifiers["target"].id_from, flow_entry.id)
+        self.assertIsInstance(stage_binding_entry.identifiers["stage"], KeyOf)
+        self.assertEqual(stage_binding_entry.identifiers["stage"].id_from, stage_entry.id)
+
+        binding_targets = {pb.identifiers["target"].id_from for pb in policy_binding_entries}
+        self.assertIn(flow_entry.id, binding_targets)
+        self.assertIn(stage_binding_entry.id, binding_targets)
+        for policy_binding_entry in policy_binding_entries:
+            self.assertIsInstance(policy_binding_entry.identifiers["policy"], KeyOf)
+            self.assertEqual(policy_binding_entry.identifiers["policy"].id_from, policy_entry.id)
+
+        self.assertIn("!KeyOf", export_yaml)
+
+        importer = Importer.from_string(export_yaml)
+        self.assertTrue(importer.validate()[0])
+        self.assertTrue(importer.apply())
         self.assertTrue(Flow.objects.filter(slug=flow_slug).exists())
 
     def test_export_validate_import_prompt(self):

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -4,6 +4,7 @@ from os import chmod, environ, unlink, write
 from tempfile import mkstemp
 
 from django.test import TransactionTestCase
+from django.utils.text import slugify
 from yaml import load
 
 from authentik.blueprints.tests import apply_blueprint
@@ -367,6 +368,10 @@ class TestBlueprintsV1(TransactionTestCase):
 
         self.assertIsNotNone(flow_entry.id)
         self.assertIsNotNone(stage_entry.id)
+        # ids are derived from a readable, unique, non-UUID field (slug/name) when available,
+        # rather than an opaque counter
+        self.assertEqual(flow_entry.id, f"flow-{slugify(flow_slug)}")
+        self.assertEqual(stage_entry.id, f"userloginstage-{slugify(stage_name)}")
 
         self.assertIsInstance(stage_binding_entry.identifiers["target"], KeyOf)
         self.assertEqual(stage_binding_entry.identifiers["target"].id_from, flow_entry.id)

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -1,15 +1,17 @@
 """Test blueprints v1"""
 
 from os import chmod, environ, unlink, write
+from pathlib import Path
 from tempfile import mkstemp
 
 from django.test import TransactionTestCase
 from django.utils.text import slugify
 from yaml import load
 
+from authentik.blueprints.models import BlueprintInstance
 from authentik.blueprints.tests import apply_blueprint
 from authentik.blueprints.v1.common import BlueprintLoader, KeyOf
-from authentik.blueprints.v1.exporter import FlowExporter
+from authentik.blueprints.v1.exporter import Exporter, FlowExporter
 from authentik.blueprints.v1.importer import Importer, transaction_rollback
 from authentik.core.models import Group
 from authentik.flows.models import Flow, FlowDesignation, FlowStageBinding
@@ -400,6 +402,22 @@ class TestBlueprintsV1(TransactionTestCase):
         self.assertTrue(importer.validate()[0])
         self.assertTrue(importer.apply())
         self.assertTrue(Flow.objects.filter(slug=flow_slug).exists())
+
+    def test_export_default_blueprints_no_static_identifiers(self):
+        """Test that exporting a full instance after applying all default blueprints
+        never falls back to an opaque, non-portable `pk` identifier, e.g. for models
+        such as FlowStageBinding that have no unique text field of their own"""
+        for blueprint_file in sorted(Path("blueprints/default").glob("*.yaml")):
+            rel_path = str(blueprint_file.relative_to("blueprints"))
+            importer = Importer.from_string(BlueprintInstance(path=rel_path).retrieve())
+            self.assertTrue(importer.validate()[0])
+            self.assertTrue(importer.apply())
+
+        export = Exporter().export()
+        for entry in export.entries:
+            self.assertNotIn(
+                "pk", entry.identifiers, f"{entry.model} entry has a static pk identifier"
+            )
 
     def test_export_validate_import_prompt(self):
         """Test export and validate it"""

--- a/authentik/blueprints/tests/test_v1.py
+++ b/authentik/blueprints/tests/test_v1.py
@@ -335,9 +335,10 @@ class TestBlueprintsV1(TransactionTestCase):
         as !KeyOf tags instead of raw primary keys"""
         flow_slug = generate_id()
         stage_name = generate_id()
+        policy_name = generate_id()
         with transaction_rollback():
             flow_policy = ExpressionPolicy.objects.create(
-                name=generate_id(),
+                name=policy_name,
                 expression="return True",
             )
             flow = Flow.objects.create(
@@ -372,6 +373,14 @@ class TestBlueprintsV1(TransactionTestCase):
         # rather than an opaque counter
         self.assertEqual(flow_entry.id, f"flow-{slugify(flow_slug)}")
         self.assertEqual(stage_entry.id, f"userloginstage-{slugify(stage_name)}")
+
+        # Policy is exported without any explicit extra identifiers, but its unique,
+        # non-UUID `name` field is still picked up automatically as a stable identifier
+        self.assertEqual(policy_entry.identifiers.get("name"), policy_name)
+        # The primary key is instance-local and not portable, so it must not be used as
+        # an identifier whenever a stable identifier could be found instead
+        for entry in (flow_entry, stage_entry, policy_entry):
+            self.assertNotIn("pk", entry.identifiers)
 
         self.assertIsInstance(stage_binding_entry.identifiers["target"], KeyOf)
         self.assertEqual(stage_binding_entry.identifiers["target"].id_from, flow_entry.id)

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -15,7 +15,8 @@ from uuid import UUID
 
 from deepmerge import always_merger
 from django.apps import apps
-from django.db.models import Model, Q
+from django.db.models import CharField, Model, Q, TextField
+from django.utils.text import slugify
 from rest_framework.exceptions import ValidationError
 from rest_framework.fields import Field
 from rest_framework.relations import ManyRelatedField, PrimaryKeyRelatedField
@@ -85,6 +86,28 @@ def resolve_references(
     return attrs
 
 
+def _readable_key(obj: Model) -> str | None:
+    """Find a unique, human-readable text field on `obj` (not a UUID) to make
+    a !KeyOf id easier to read than a bare counter, e.g. a slug or name."""
+    for model_field in obj._meta.fields:
+        if not isinstance(model_field, CharField | TextField):
+            continue
+        if not model_field.unique:
+            continue
+        value = getattr(obj, model_field.attname, None)
+        if not value or not isinstance(value, str):
+            continue
+        try:
+            UUID(value)
+            continue
+        except ValueError:
+            pass
+        slug = slugify(value)
+        if slug:
+            return slug
+    return None
+
+
 class ReferenceIndex:
     """Tracks exported model instances so relations between them can be
     rewritten as !KeyOf references instead of raw primary keys."""
@@ -92,11 +115,16 @@ class ReferenceIndex:
     def __init__(self):
         self._entries: dict[Any, tuple[type[Model], str]] = {}
         self._used: set[str] = set()
+        self._seen_ids: set[str] = set()
         self._counter = count(1)
 
     def register(self, obj: Model) -> str:
         """Register an exported model instance, returning the id assigned to it"""
-        entry_id = f"{obj._meta.model_name}-{next(self._counter)}"
+        readable_key = _readable_key(obj)
+        entry_id = f"{obj._meta.model_name}-{readable_key or next(self._counter)}"
+        if entry_id in self._seen_ids:
+            entry_id = f"{entry_id}-{next(self._counter)}"
+        self._seen_ids.add(entry_id)
         self._entries[obj.pk] = (type(obj), entry_id)
         return entry_id
 

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -6,6 +6,7 @@ from copy import copy
 from dataclasses import asdict, dataclass, field, is_dataclass
 from enum import Enum
 from functools import reduce
+from itertools import count
 from json import JSONDecodeError, loads
 from operator import ixor
 from os import getenv
@@ -17,6 +18,7 @@ from django.apps import apps
 from django.db.models import Model, Q
 from rest_framework.exceptions import ValidationError
 from rest_framework.fields import Field
+from rest_framework.relations import ManyRelatedField, PrimaryKeyRelatedField
 from rest_framework.serializers import Serializer
 from structlog.stdlib import get_logger
 from yaml import SafeDumper, SafeLoader, ScalarNode, SequenceNode
@@ -32,7 +34,7 @@ class UNSET:
     """Used to test whether a key has not been set."""
 
 
-def get_attrs(obj: SerializerModel) -> dict[str, Any]:
+def get_attrs(obj: SerializerModel) -> tuple[dict[str, Any], dict[str, Field]]:
     """Get object's attributes via their serializer, and convert it to a normal dict"""
     serializer: Serializer = obj.serializer(obj)
     data = dict(serializer.data)
@@ -45,7 +47,78 @@ def get_attrs(obj: SerializerModel) -> dict[str, Any]:
             data.pop(field_name, None)
         if field_name.endswith("_set"):
             data.pop(field_name, None)
-    return data
+    return data, serializer.fields
+
+
+def _relation_target_model(ser_field: Field) -> type[Model] | None:
+    """Get the model a relational serializer field points to, if any"""
+    if isinstance(ser_field, ManyRelatedField):
+        ser_field = ser_field.child_relation
+    if isinstance(ser_field, PrimaryKeyRelatedField) and ser_field.queryset is not None:
+        return ser_field.queryset.model
+    return None
+
+
+def resolve_references(
+    attrs: dict[str, Any], fields: dict[str, Field], reference_index: ReferenceIndex
+) -> dict[str, Any]:
+    """Replace any attrs value that references another exported object with a `KeyOf` tag"""
+    for name, _field in fields.items():
+        if name not in attrs or attrs[name] is None:
+            continue
+        target_model = _relation_target_model(_field)
+        if target_model is None:
+            continue
+        if isinstance(_field, ManyRelatedField):
+            attrs[name] = [
+                (
+                    KeyOf(id_from=entry_id)
+                    if (entry_id := reference_index.lookup(value, target_model))
+                    else value
+                )
+                for value in attrs[name]
+            ]
+        else:
+            entry_id = reference_index.lookup(attrs[name], target_model)
+            if entry_id:
+                attrs[name] = KeyOf(id_from=entry_id)
+    return attrs
+
+
+class ReferenceIndex:
+    """Tracks exported model instances so relations between them can be
+    rewritten as !KeyOf references instead of raw primary keys."""
+
+    def __init__(self):
+        self._entries: dict[Any, tuple[type[Model], str]] = {}
+        self._used: set[str] = set()
+        self._counter = count(1)
+
+    def register(self, obj: Model) -> str:
+        """Register an exported model instance, returning the id assigned to it"""
+        entry_id = f"{obj._meta.model_name}-{next(self._counter)}"
+        self._entries[obj.pk] = (type(obj), entry_id)
+        return entry_id
+
+    def id_for(self, obj: Model) -> str | None:
+        """Get the id assigned to a previously registered model instance, if any"""
+        entry = self._entries.get(obj.pk)
+        return entry[1] if entry else None
+
+    def lookup(self, value: Any, target_model: type[Model]) -> str | None:
+        """Look up the id of a registered model instance by its primary key,
+        provided it is an instance of `target_model`"""
+        entry = self._entries.get(value)
+        if entry and issubclass(entry[0], target_model):
+            self._used.add(entry[1])
+            return entry[1]
+        return None
+
+    def clear_unused_ids(self, entries: Iterable[BlueprintEntry], objects: Iterable[Model]) -> None:
+        """Strip the id from any entry that is never referenced by a !KeyOf tag"""
+        for entry, obj in zip(entries, objects, strict=True):
+            if self.id_for(obj) not in self._used:
+                entry.id = None
 
 
 @dataclass
@@ -92,20 +165,29 @@ class BlueprintEntry:
         self.__tag_contexts: list[YAMLTagContext] = []
 
     @staticmethod
-    def from_model(model: SerializerModel, *extra_identifier_names: str) -> BlueprintEntry:
+    def from_model(
+        model: SerializerModel,
+        *extra_identifier_names: str,
+        reference_index: ReferenceIndex | None = None,
+    ) -> BlueprintEntry:
         """Convert a SerializerModel instance to a blueprint Entry"""
         identifiers = {
             "pk": model.pk,
         }
-        all_attrs = get_attrs(model)
+        all_attrs, fields = get_attrs(model)
+        if reference_index is not None:
+            all_attrs = resolve_references(all_attrs, fields, reference_index)
 
         for extra_identifier_name in extra_identifier_names:
             identifiers[extra_identifier_name] = all_attrs.pop(extra_identifier_name, None)
-        return BlueprintEntry(
+        entry = BlueprintEntry(
             identifiers=identifiers,
             model=f"{model._meta.app_label}.{model._meta.model_name}",
             attrs=all_attrs,
         )
+        if reference_index is not None:
+            entry.id = reference_index.id_for(model)
+        return entry
 
     def get_tag_context(
         self,
@@ -232,9 +314,14 @@ class KeyOf(YAMLTag):
 
     id_from: str
 
-    def __init__(self, loader: BlueprintLoader, node: ScalarNode) -> None:
+    def __init__(
+        self,
+        loader: BlueprintLoader | None = None,
+        node: ScalarNode | None = None,
+        id_from: str | None = None,
+    ) -> None:
         super().__init__()
-        self.id_from = node.value
+        self.id_from = node.value if node is not None else id_from
 
     def resolve(self, entry: BlueprintEntry, blueprint: Blueprint) -> Any:
         for _entry in blueprint.iter_entries():
@@ -732,6 +819,9 @@ class BlueprintDumper(SafeDumper):
         self.add_representer(Enum, lambda self, data: self.represent_str(data.value))
         self.add_representer(
             BlueprintEntryDesiredState, lambda self, data: self.represent_str(data.value)
+        )
+        self.add_representer(
+            KeyOf, lambda self, data: self.represent_scalar("!KeyOf", data.id_from)
         )
         self.add_representer(None, lambda self, data: self.represent_str(str(data)))
 

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -15,7 +15,7 @@ from uuid import UUID
 
 from deepmerge import always_merger
 from django.apps import apps
-from django.db.models import CharField, Model, Q, TextField
+from django.db.models import CharField, Model, Q, TextField, UniqueConstraint
 from django.utils.text import slugify
 from rest_framework.exceptions import ValidationError
 from rest_framework.fields import Field
@@ -123,6 +123,37 @@ def _readable_key(obj: Model) -> str | None:
     return None
 
 
+def _unique_together_groups(model_class: type[Model]) -> Iterable[tuple[str, ...]]:
+    """Field-name groups declared unique together on a model, via either the legacy
+    Meta.unique_together or a plain (unconditional) Meta.constraints UniqueConstraint"""
+    yield from model_class._meta.unique_together
+    for constraint in model_class._meta.constraints:
+        if not isinstance(constraint, UniqueConstraint):
+            continue
+        if not constraint.condition and constraint.fields:
+            yield constraint.fields
+
+
+def _composite_identifier_fields(
+    model_class: type[Model], all_attrs: dict[str, Any], fields: dict[str, Field]
+) -> list[str]:
+    """When no single field can serve as a stable identifier, fall back to a composite
+    of fields that together identify the instance: a declared unique-together group if
+    one is fully known, otherwise every populated relation to another exported object
+    (e.g. a binding's target and policy), mirroring how such join objects are naturally
+    keyed. Portable across instances, as relations are resolved to !KeyOf tags."""
+    for group in _unique_together_groups(model_class):
+        if all(name in all_attrs and all_attrs[name] is not None for name in group):
+            return list(group)
+    return [
+        name
+        for name, ser_field in fields.items()
+        if name in all_attrs
+        and all_attrs[name] is not None
+        and _relation_target_model(ser_field) is not None
+    ]
+
+
 class ReferenceIndex:
     """Tracks exported model instances so relations between them can be
     rewritten as !KeyOf references instead of raw primary keys."""
@@ -210,7 +241,6 @@ class BlueprintEntry:
     @staticmethod
     def from_model(
         model: SerializerModel,
-        *extra_identifier_names: str,
         reference_index: ReferenceIndex | None = None,
     ) -> BlueprintEntry:
         """Convert a SerializerModel instance to a blueprint Entry"""
@@ -218,12 +248,14 @@ class BlueprintEntry:
         if reference_index is not None:
             all_attrs = resolve_references(all_attrs, fields, reference_index)
 
-        identifier_names = list(extra_identifier_names)
-        for field_name in _stable_identifier_fields(type(model)):
-            if field_name in identifier_names or field_name not in all_attrs:
-                continue
-            if _is_stable_value(all_attrs[field_name]):
-                identifier_names.append(field_name)
+        identifier_names = [
+            field_name
+            for field_name in _stable_identifier_fields(type(model))
+            if field_name in all_attrs and _is_stable_value(all_attrs[field_name])
+        ]
+
+        if not identifier_names:
+            identifier_names = _composite_identifier_fields(type(model), all_attrs, fields)
 
         identifiers = {}
         for identifier_name in identifier_names:

--- a/authentik/blueprints/v1/common.py
+++ b/authentik/blueprints/v1/common.py
@@ -86,22 +86,37 @@ def resolve_references(
     return attrs
 
 
+def _stable_identifier_fields(model_class: type[Model]) -> list[str]:
+    """List the names of unique, non-relational text fields on a model (other than its
+    primary key) that could serve as stable identifiers, portable across authentik instances"""
+    return [
+        model_field.attname
+        for model_field in model_class._meta.fields
+        if not model_field.primary_key
+        and isinstance(model_field, CharField | TextField)
+        and model_field.unique
+    ]
+
+
+def _is_stable_value(value: Any) -> bool:
+    """A value is considered stable (portable across instances) if it's a non-empty
+    string that isn't a UUID, which is almost always instance-local (e.g. a random default)"""
+    if not value or not isinstance(value, str):
+        return False
+    try:
+        UUID(value)
+        return False
+    except ValueError:
+        return True
+
+
 def _readable_key(obj: Model) -> str | None:
     """Find a unique, human-readable text field on `obj` (not a UUID) to make
     a !KeyOf id easier to read than a bare counter, e.g. a slug or name."""
-    for model_field in obj._meta.fields:
-        if not isinstance(model_field, CharField | TextField):
+    for field_name in _stable_identifier_fields(type(obj)):
+        value = getattr(obj, field_name, None)
+        if not _is_stable_value(value):
             continue
-        if not model_field.unique:
-            continue
-        value = getattr(obj, model_field.attname, None)
-        if not value or not isinstance(value, str):
-            continue
-        try:
-            UUID(value)
-            continue
-        except ValueError:
-            pass
         slug = slugify(value)
         if slug:
             return slug
@@ -199,15 +214,24 @@ class BlueprintEntry:
         reference_index: ReferenceIndex | None = None,
     ) -> BlueprintEntry:
         """Convert a SerializerModel instance to a blueprint Entry"""
-        identifiers = {
-            "pk": model.pk,
-        }
         all_attrs, fields = get_attrs(model)
         if reference_index is not None:
             all_attrs = resolve_references(all_attrs, fields, reference_index)
 
-        for extra_identifier_name in extra_identifier_names:
-            identifiers[extra_identifier_name] = all_attrs.pop(extra_identifier_name, None)
+        identifier_names = list(extra_identifier_names)
+        for field_name in _stable_identifier_fields(type(model)):
+            if field_name in identifier_names or field_name not in all_attrs:
+                continue
+            if _is_stable_value(all_attrs[field_name]):
+                identifier_names.append(field_name)
+
+        identifiers = {}
+        for identifier_name in identifier_names:
+            identifiers[identifier_name] = all_attrs.pop(identifier_name, None)
+        # Only fall back to the (instance-local, non-portable) primary key when no other
+        # stable identifier could be found
+        if not identifiers:
+            identifiers["pk"] = model.pk
         entry = BlueprintEntry(
             identifiers=identifiers,
             model=f"{model._meta.app_label}.{model._meta.model_name}",

--- a/authentik/blueprints/v1/exporter.py
+++ b/authentik/blueprints/v1/exporter.py
@@ -1,6 +1,7 @@
 """Blueprint exporter"""
 
 from collections.abc import Iterable
+from typing import Any
 from uuid import UUID
 
 from django.apps import apps
@@ -15,13 +16,14 @@ from authentik.blueprints.v1.common import (
     BlueprintDumper,
     BlueprintEntry,
     BlueprintMetadata,
+    ReferenceIndex,
 )
 from authentik.blueprints.v1.importer import is_model_allowed
 from authentik.blueprints.v1.labels import LABEL_AUTHENTIK_GENERATED
 from authentik.events.models import Event
 from authentik.flows.models import Flow, FlowStageBinding, Stage
 from authentik.policies.models import Policy, PolicyBinding
-from authentik.stages.prompt.models import PromptStage
+from authentik.stages.prompt.models import Prompt, PromptStage
 
 
 class Exporter:
@@ -36,13 +38,21 @@ class Exporter:
 
     def get_entries(self) -> Iterable[BlueprintEntry]:
         """Get blueprint entries"""
+        reference_index = ReferenceIndex()
+        instances: list[Model] = []
         for model in apps.get_models():
             if not is_model_allowed(model):
                 continue
             if model in self.excluded_models:
                 continue
             for obj in self.get_model_instances(model):
-                yield BlueprintEntry.from_model(obj)
+                instances.append(obj)
+                reference_index.register(obj)
+        entries = [
+            BlueprintEntry.from_model(obj, reference_index=reference_index) for obj in instances
+        ]
+        reference_index.clear_unused_ids(entries, instances)
+        return entries
 
     def get_model_instances(self, model: type[Model]) -> QuerySet:
         """Return a queryset for `model`. Can be used to filter some
@@ -96,54 +106,78 @@ class FlowExporter(Exporter):
             "pbm_uuid", flat=True
         )
 
-    def walk_stages(self) -> Iterable[BlueprintEntry]:
-        """Convert all stages attached to self.flow into BlueprintEntry objects"""
-        stages = Stage.objects.filter(flow=self.flow).select_related().select_subclasses()
-        for stage in stages:
-            if isinstance(stage, PromptStage):
-                pass
-            yield BlueprintEntry.from_model(stage, "name")
+    def _stages(self) -> Iterable[Stage]:
+        """Get all stages attached to self.flow"""
+        return Stage.objects.filter(flow=self.flow).select_related().select_subclasses()
 
-    def walk_stage_bindings(self) -> Iterable[BlueprintEntry]:
-        """Convert all bindings attached to self.flow into BlueprintEntry objects"""
-        bindings = FlowStageBinding.objects.filter(target=self.flow).select_related()
-        for binding in bindings:
-            yield BlueprintEntry.from_model(binding, "target", "stage", "order")
+    def _stage_bindings(self) -> Iterable[FlowStageBinding]:
+        """Get all bindings attached to self.flow"""
+        return FlowStageBinding.objects.filter(target=self.flow).select_related()
 
-    def walk_policies(self) -> Iterable[BlueprintEntry]:
-        """Walk over all policies. This is done at the beginning of the export for stages that have
+    def _policies(self) -> Iterable[Policy]:
+        """Get all policies. This is done at the beginning of the export for stages that have
         a direct foreign key to a policy."""
         # Special case for PromptStage as that has a direct M2M to policy, we have to ensure
         # all policies referenced in there we also include here
         prompt_stages = PromptStage.objects.filter(flow=self.flow).values_list("pk", flat=True)
         query = Q(bindings__in=self.pbm_uuids) | Q(promptstage__in=prompt_stages)
-        policies = Policy.objects.filter(query).select_related()
-        for policy in policies:
-            yield BlueprintEntry.from_model(policy)
+        return Policy.objects.filter(query).select_related()
 
-    def walk_policy_bindings(self) -> Iterable[BlueprintEntry]:
-        """Walk over all policybindings relative to us. This is run at the end of the export, as
+    def _policy_bindings(self) -> Iterable[PolicyBinding]:
+        """Get all policybindings relative to us. This is run at the end of the export, as
         we are sure all objects exist now."""
-        bindings = PolicyBinding.objects.filter(target__in=self.pbm_uuids).select_related()
-        for binding in bindings:
-            yield BlueprintEntry.from_model(binding, "policy", "target", "order")
+        return PolicyBinding.objects.filter(target__in=self.pbm_uuids).select_related()
 
-    def walk_stage_prompts(self) -> Iterable[BlueprintEntry]:
-        """Walk over all prompts associated with any PromptStages"""
+    def _stage_prompts(self) -> Iterable[Prompt]:
+        """Get all prompts associated with any PromptStages, deduplicated as multiple stages
+        may share the same prompt"""
         prompt_stages = PromptStage.objects.filter(flow=self.flow)
+        prompts: dict[Any, Prompt] = {}
         for stage in prompt_stages:
             for prompt in stage.fields.all():
-                yield BlueprintEntry.from_model(prompt)
+                prompts[prompt.pk] = prompt
+        return prompts.values()
 
     def get_entries(self) -> Iterable[BlueprintEntry]:
-        entries = []
-        entries.append(BlueprintEntry.from_model(self.flow, "slug"))
-        if self.with_stage_prompts:
-            entries.extend(self.walk_stage_prompts())
-        if self.with_policies:
-            entries.extend(self.walk_policies())
-        entries.extend(self.walk_stages())
-        entries.extend(self.walk_stage_bindings())
-        if self.with_policies:
-            entries.extend(self.walk_policy_bindings())
+        reference_index = ReferenceIndex()
+        reference_index.register(self.flow)
+
+        prompts = list(self._stage_prompts()) if self.with_stage_prompts else []
+        policies = list(self._policies()) if self.with_policies else []
+        stages = list(self._stages())
+        stage_bindings = list(self._stage_bindings())
+        policy_bindings = list(self._policy_bindings()) if self.with_policies else []
+
+        for obj in (*prompts, *policies, *stages, *stage_bindings, *policy_bindings):
+            reference_index.register(obj)
+
+        objects = [self.flow, *prompts, *policies, *stages, *stage_bindings, *policy_bindings]
+        entries = [
+            BlueprintEntry.from_model(self.flow, "slug", reference_index=reference_index),
+            *(
+                BlueprintEntry.from_model(prompt, reference_index=reference_index)
+                for prompt in prompts
+            ),
+            *(
+                BlueprintEntry.from_model(policy, reference_index=reference_index)
+                for policy in policies
+            ),
+            *(
+                BlueprintEntry.from_model(stage, "name", reference_index=reference_index)
+                for stage in stages
+            ),
+            *(
+                BlueprintEntry.from_model(
+                    binding, "target", "stage", "order", reference_index=reference_index
+                )
+                for binding in stage_bindings
+            ),
+            *(
+                BlueprintEntry.from_model(
+                    binding, "policy", "target", "order", reference_index=reference_index
+                )
+                for binding in policy_bindings
+            ),
+        ]
+        reference_index.clear_unused_ids(entries, objects)
         return entries

--- a/authentik/blueprints/v1/exporter.py
+++ b/authentik/blueprints/v1/exporter.py
@@ -153,7 +153,7 @@ class FlowExporter(Exporter):
 
         objects = [self.flow, *prompts, *policies, *stages, *stage_bindings, *policy_bindings]
         entries = [
-            BlueprintEntry.from_model(self.flow, "slug", reference_index=reference_index),
+            BlueprintEntry.from_model(self.flow, reference_index=reference_index),
             *(
                 BlueprintEntry.from_model(prompt, reference_index=reference_index)
                 for prompt in prompts
@@ -163,19 +163,15 @@ class FlowExporter(Exporter):
                 for policy in policies
             ),
             *(
-                BlueprintEntry.from_model(stage, "name", reference_index=reference_index)
+                BlueprintEntry.from_model(stage, reference_index=reference_index)
                 for stage in stages
             ),
             *(
-                BlueprintEntry.from_model(
-                    binding, "target", "stage", "order", reference_index=reference_index
-                )
+                BlueprintEntry.from_model(binding, reference_index=reference_index)
                 for binding in stage_bindings
             ),
             *(
-                BlueprintEntry.from_model(
-                    binding, "policy", "target", "order", reference_index=reference_index
-                )
+                BlueprintEntry.from_model(binding, reference_index=reference_index)
                 for binding in policy_bindings
             ),
         ]


### PR DESCRIPTION
fixes the long standing issue that exported blueprints are not re-importable in a different authentik instance due to common objects having a different PK and the exported blueprint hardcoding a pk

claude etc