### PR TITLE
website: attempt to silence noisy netlify comments

### DIFF
--- a/web/netlify.toml
+++ b/web/netlify.toml
@@ -1,0 +1,5 @@
+[build]
+  base    = "web"
+  command = "npm run build-locales && npm run storybook:build"
+  publish = "storybook-static/"
+  ignore  = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- web package.json pnpm-lock.yaml"

--- a/website/docs/netlify.toml
+++ b/website/docs/netlify.toml
@@ -12,6 +12,7 @@
   package = "docs"
   command = "pnpm --dir .. install --frozen-lockfile && pnpm install --frozen-lockfile && pnpm run build"
   publish = "docs/build"
+  ignore  = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- website/docs website/docusaurus-theme website/package.json website/pnpm-lock.yaml pnpm-lock.yaml"
 
 [dev]
   command    = "pnpm start"

--- a/website/integrations/netlify.toml
+++ b/website/integrations/netlify.toml
@@ -12,6 +12,7 @@
   package = "integrations"
   command = "pnpm --dir .. install --frozen-lockfile && pnpm install --frozen-lockfile && pnpm run build:integrations"
   publish = "integrations/build"
+  ignore  = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- website/integrations website/docusaurus-theme website/package.json website/pnpm-lock.yaml pnpm-lock.yaml"
 
 [dev]
   command    = "pnpm start"


### PR DESCRIPTION
Netlify likes to comment on PRs that don't change any docs/integrations, which is annoying. There doesn't seem to be a setting to prevent this, so this might do?

claude etc etc