### PR TITLE
providers/oauth2: only expose URL-based avatars as picture claim

### DIFF
--- a/authentik/providers/oauth2/tests/test_userinfo.py
+++ b/authentik/providers/oauth2/tests/test_userinfo.py
@@ -68,7 +68,8 @@ class TestUserinfo(OAuthTestCase):
                 "nickname": self.user.name,
                 "groups": [group.name for group in self.user.groups.all()],
                 "sub": "bar",
-                "picture": self.user.avatar,
+                # The stock profile mapping only exposes URL-based avatars; the
+                # test user falls back to a generated inline data-URI avatar.
             },
         )
         self.assertEqual(res.status_code, 200)
@@ -91,7 +92,8 @@ class TestUserinfo(OAuthTestCase):
                 "nickname": self.user.name,
                 "groups": [group.name for group in self.user.groups.all()],
                 "sub": "bar",
-                "picture": self.user.avatar,
+                # The stock profile mapping only exposes URL-based avatars; the
+                # test user falls back to a generated inline data-URI avatar.
             },
         )
         self.assertEqual(res.status_code, 200)

--- a/blueprints/system/providers-oauth2.yaml
+++ b/blueprints/system/providers-oauth2.yaml
@@ -34,6 +34,7 @@ entries:
       scope_name: profile
       description: "General Profile Information"
       expression: |
+        avatar = request.user.avatar
         return delete_none_values({
             "name": request.user.name,
             "given_name": ak_obj_attr(request.user, "given_name", "name"),
@@ -41,7 +42,10 @@ entries:
             "preferred_username": request.user.username,
             "nickname": request.user.username,
             "groups": [group.name for group in request.user.groups.all()],
-            "picture": request.user.avatar,
+            # Only expose URL-based avatars: generated avatars are inline base64
+            # SVG data URIs, which would bloat the ID/access token for every
+            # user without a real avatar URL (OIDC expects a URL here).
+            "picture": avatar if avatar and not avatar.startswith("data:") else None,
         })
   - identifiers:
       managed: goauthentik.io/providers/oauth2/scope-entitlements


### PR DESCRIPTION
Fixes #25978

## Problem

The stock `profile` scope mapping (`goauthentik.io/providers/oauth2/scope-profile`) emits the user's avatar as the `picture` claim unconditionally. With the default tenant avatar settings (`gravatar,initials`), any user whose email has no Gravatar falls through to `avatar_mode_generated`, which returns the avatar **inline as a base64 SVG data URI**. Every ID and access token for such users carries hundreds of bytes of inline SVG, and there is currently no way to exclude the claim from tokens while keeping the default mapping.

## Fix

The stock mapping now only emits `picture` when the avatar is an actual http(s) URL:

- Gravatar and attribute-based URL avatars keep working unchanged.
- Generated (initials/SVG) avatars, which are data URIs, no longer bloat tokens. This also matches the OIDC Core spec, which defines `picture` as "URL of the End-User's profile picture" (SHOULD be HTTPS).
- Admins who want the inline data URIs as `picture` can clone the mapping and customize it; the stock mapping stays lean and spec-compliant.

## Testing

- Updated `test_userinfo.py`: the two userinfo tests asserted `picture: self.user.avatar` (a data URI in the test environment); they now assert the claim is absent, with a comment explaining why.
- Ran in Docker (python 3.14, postgres, redis, repo-pinned deps via `uv sync --frozen`): `authentik.providers.oauth2.tests.test_userinfo.py` 2/2 pass; `test_token_cc_standard.py` + `test_token_exchange.py` (the other tests exercising profile-scope claims) 46/46 pass; `ruff check` and `ruff format --check` clean on the changed file.