### PR TITLE
packages/ak-common/config: fix list values from env variables parsing (#7836)

### DIFF
--- a/packages/ak-common/src/config/mod.rs
+++ b/packages/ak-common/src/config/mod.rs
@@ -525,19 +525,18 @@ mod tests {
         assert!(!config.debug);
     }
 
-    // See https://github.com/rust-cli/config-rs/issues/443
-    // #[test]
-    // fn env_list_empty() {
-    //     #[expect(unsafe_code, reason = "testing")]
-    //     // SAFETY: testing
-    //     unsafe {
-    //         env::set_var("AUTHENTIK_LISTEN__HTTP", "");
-    //     }
-    //
-    //     let (config, _) = super::Config::load(&[], None).expect("failed to load config");
-    //
-    //     assert_eq!(config.listen.http, []);
-    // }
+    #[test]
+    fn env_list_empty() {
+        #[expect(unsafe_code, reason = "testing")]
+        // SAFETY: testing
+        unsafe {
+            env::set_var("AUTHENTIK_LISTEN__HTTP", "");
+        }
+
+        let (config, _) = super::Config::load(&[], None).expect("failed to load config");
+
+        assert_eq!(config.listen.http, []);
+    }
 
     #[test]
     fn env_list_one_element() {

--- a/packages/ak-common/src/config/schema.rs
+++ b/packages/ak-common/src/config/schema.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, net::SocketAddr, num::NonZeroUsize, path::PathBuf};
+use std::{
+    collections::HashMap, fmt::Display, net::SocketAddr, num::NonZeroUsize,
+    path::PathBuf, str::FromStr,
+};
 
 use ipnet::IpNet;
 use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
@@ -10,6 +13,22 @@ pub(super) const KEYS_TO_PARSE_AS_LIST: [&str; 5] = [
     "listen.trusted_proxy_cidrs",
     "log.http_headers",
 ];
+
+/// Deserialize a list, ignoring empty entries.
+///
+/// The environment source splits values on `,`, so an empty variable
+/// yields a single empty entry rather than an empty list.
+fn deserialize_list<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr<Err: Display>,
+{
+    Vec::<String>::deserialize(deserializer)?
+        .iter()
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| entry.parse().map_err(D::Error::custom))
+        .collect()
+}
 
 fn deserialize_optional_u64<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
 where
@@ -182,15 +201,20 @@ pub struct PostgreSQLConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ListenConfig {
+    #[serde(deserialize_with = "deserialize_list")]
     pub http: Vec<SocketAddr>,
+    #[serde(deserialize_with = "deserialize_list")]
     pub https: Vec<SocketAddr>,
+    #[serde(deserialize_with = "deserialize_list")]
     pub metrics: Vec<SocketAddr>,
     pub debug_tokio: Option<SocketAddr>,
+    #[serde(deserialize_with = "deserialize_list")]
     pub trusted_proxy_cidrs: Vec<IpNet>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogConfig {
+    #[serde(deserialize_with = "deserialize_list")]
     pub http_headers: Vec<String>,
     pub rust_log: HashMap<String, String>,
 }

--- a/website/docs/install-config/configuration/configuration.mdx
+++ b/website/docs/install-config/configuration/configuration.mdx
@@ -399,6 +399,8 @@ List of comma-separated `address:port` values for HTTPS.
 
 Applies to the Server and Proxy outposts.
 
+Set to an empty value to disable the HTTPS listener.
+
 Defaults to `[::]:9443`.
 
 ##### `AUTHENTIK_LISTEN__LDAP`


### PR DESCRIPTION
## Details

Fixed the issue stated in [#7836](https://github.com/goauthentik/authentik/issues/7836#issuecomment-5382201554) by dropping empty list values when parsing a comma-separated list from an environment variable.

### What does this PR change?

Empty values are dropped from the list before attempting to parse each value.

### Why is this change needed?

Fixes a regression in 2026.8 where the HTTPS listener can no longer be disabled by setting the env variable to the empty value. This worked find in 2026.5.6

### How was this tested?

Uncommented an already existing test case in ak-common/config.

### Linked issues

closes #7836 

---

## Checklist

-   [ ] The project has been linted, built, and tested (`make all`)
-   [ ] The documentation has been updated and formatted (`make docs`)
-   [ ] I have read the [AI usage policy](https://github.com/goauthentik/authentik/blob/main/AI_POLICY.md).